### PR TITLE
Removed all test class doc comments because of their lack of useful i…

### DIFF
--- a/src/Api/tests/ApplicationTest.php
+++ b/src/Api/tests/ApplicationTest.php
@@ -21,9 +21,6 @@ use Aphiria\Net\Http\IHttpResponseMessage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the application
- */
 class ApplicationTest extends TestCase
 {
     private Application $app;

--- a/src/Api/tests/Controllers/ControllerParameterResolverTest.php
+++ b/src/Api/tests/Controllers/ControllerParameterResolverTest.php
@@ -31,9 +31,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionParameter;
 
-/**
- * Tests the controller parameter resolver
- */
 class ControllerParameterResolverTest extends TestCase
 {
     private ControllerParameterResolver $resolver;

--- a/src/Api/tests/Controllers/ControllerRequestHandlerTest.php
+++ b/src/Api/tests/Controllers/ControllerRequestHandlerTest.php
@@ -22,9 +22,6 @@ use Aphiria\Net\Http\IHttpResponseMessage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the controller request handler
- */
 class ControllerRequestHandlerTest extends TestCase
 {
     /** @var IServiceResolver|MockObject */

--- a/src/Api/tests/Controllers/ControllerTest.php
+++ b/src/Api/tests/Controllers/ControllerTest.php
@@ -32,9 +32,6 @@ use LogicException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the controller
- */
 class ControllerTest extends TestCase
 {
     private Controller $controller;

--- a/src/Api/tests/Controllers/RouteActionInvokerTest.php
+++ b/src/Api/tests/Controllers/RouteActionInvokerTest.php
@@ -39,9 +39,6 @@ use ReflectionFunctionAbstract;
 use ReflectionParameter;
 use RuntimeException;
 
-/**
- * Tests the route action invoker
- */
 class RouteActionInvokerTest extends TestCase
 {
     /** @var IRequestBodyValidator|MockObject */

--- a/src/Api/tests/Errors/ProblemDetailsResponseMutatorTest.php
+++ b/src/Api/tests/Errors/ProblemDetailsResponseMutatorTest.php
@@ -18,9 +18,6 @@ use Aphiria\Net\Http\IHttpResponseMessage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the problem details response mutator
- */
 class ProblemDetailsResponseMutatorTest extends TestCase
 {
     private ProblemDetailsResponseMutator $mutator;

--- a/src/Api/tests/Errors/ProblemDetailsTest.php
+++ b/src/Api/tests/Errors/ProblemDetailsTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Api\Tests\Errors;
 use Aphiria\Api\Errors\ProblemDetails;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the problem details
- */
 class ProblemDetailsTest extends TestCase
 {
     public function testConstructorSetsProperties(): void

--- a/src/Api/tests/RouterTest.php
+++ b/src/Api/tests/RouterTest.php
@@ -38,9 +38,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the router kernel
- */
 class RouterTest extends TestCase
 {
     private Router $router;

--- a/src/Api/tests/Validation/RequestBodyValidatorTest.php
+++ b/src/Api/tests/Validation/RequestBodyValidatorTest.php
@@ -24,9 +24,6 @@ use Aphiria\Validation\ValidationException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the request body validator
- */
 class RequestBodyValidatorTest extends TestCase
 {
     /** @var IHttpRequestMessage|MockObject */

--- a/src/Api/tests/Validation/ValidationProblemDetailsTest.php
+++ b/src/Api/tests/Validation/ValidationProblemDetailsTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Api\Tests\Validation;
 use Aphiria\Api\Validation\ValidationProblemDetails;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the validation problem details
- */
 class ValidationProblemDetailsTest extends TestCase
 {
     public function testConstructorSetsAllTheProperties(): void

--- a/src/Application/tests/BootstrapperCollectionTest.php
+++ b/src/Application/tests/BootstrapperCollectionTest.php
@@ -16,9 +16,6 @@ use Aphiria\Application\BootstrapperCollection;
 use Aphiria\Application\IBootstrapper;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the bootstrapper collection
- */
 class BootstrapperCollectionTest extends TestCase
 {
     private BootstrapperCollection $bootstrappers;

--- a/src/Application/tests/Builders/ApplicationBuilderTest.php
+++ b/src/Application/tests/Builders/ApplicationBuilderTest.php
@@ -19,9 +19,6 @@ use Aphiria\Application\IModule;
 use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the application builder
- */
 class ApplicationBuilderTest extends TestCase
 {
     private ApplicationBuilder $appBuilder;

--- a/src/Collections/tests/ArrayListTest.php
+++ b/src/Collections/tests/ArrayListTest.php
@@ -16,9 +16,6 @@ use Aphiria\Collections\ArrayList;
 use OutOfRangeException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the array list
- */
 class ArrayListTest extends TestCase
 {
     private ArrayList $arrayList;

--- a/src/Collections/tests/HashSetTest.php
+++ b/src/Collections/tests/HashSetTest.php
@@ -13,12 +13,9 @@ declare(strict_types=1);
 namespace Aphiria\Collections\Tests;
 
 use Aphiria\Collections\HashSet;
-use Aphiria\Collections\Tests\Mocks\MockObject;
+use Aphiria\Collections\Tests\Mocks\FakeObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests a hash set
- */
 class HashSetTest extends TestCase
 {
     private HashSet $set;
@@ -57,7 +54,7 @@ class HashSetTest extends TestCase
 
     public function testAddingValue(): void
     {
-        $object = new MockObject();
+        $object = new FakeObject();
         $this->set->add($object);
         $this->assertEquals([$object], $this->set->toArray());
     }
@@ -67,7 +64,7 @@ class HashSetTest extends TestCase
         $this->assertFalse($this->set->containsValue('foo'));
         $this->set->add('foo');
         $this->assertTrue($this->set->containsValue('foo'));
-        $object = new MockObject();
+        $object = new FakeObject();
         $this->assertFalse($this->set->containsValue($object));
         $this->set->add($object);
         $this->assertTrue($this->set->containsValue($object));
@@ -75,15 +72,15 @@ class HashSetTest extends TestCase
 
     public function testClearingSetRemovesAllValues(): void
     {
-        $this->set->add(new MockObject());
+        $this->set->add(new FakeObject());
         $this->set->clear();
         $this->assertEquals([], $this->set->toArray());
     }
 
     public function testCountReturnsNumberOfUniqueValuesInSet(): void
     {
-        $object1 = new MockObject();
-        $object2 = new MockObject();
+        $object1 = new FakeObject();
+        $object2 = new FakeObject();
         $this->assertEquals(0, $this->set->count());
         $this->set->add($object1);
         $this->assertEquals(1, $this->set->count());
@@ -95,7 +92,7 @@ class HashSetTest extends TestCase
 
     public function testEqualButNotSameObjectsAreNotIntersected(): void
     {
-        $object1 = new MockObject();
+        $object1 = new FakeObject();
         $object2 = clone $object1;
         $this->set->add($object1);
         $this->set->intersect([$object2]);
@@ -104,8 +101,8 @@ class HashSetTest extends TestCase
 
     public function testIntersectingIntersectsValuesOfSetAndArray(): void
     {
-        $object1 = new MockObject();
-        $object2 = new MockObject();
+        $object1 = new FakeObject();
+        $object2 = new FakeObject();
         $this->set->add($object1);
         $this->set->add($object2);
         $this->set->intersect([$object2]);
@@ -118,8 +115,8 @@ class HashSetTest extends TestCase
     public function testIteratingOverValuesReturnsValuesNotHashKeys(): void
     {
         $expectedValues = [
-            new MockObject(),
-            new MockObject()
+            new FakeObject(),
+            new FakeObject()
         ];
         $this->set->addRange($expectedValues);
         $actualValues = [];
@@ -135,7 +132,7 @@ class HashSetTest extends TestCase
 
     public function testRemovingValue(): void
     {
-        $object = new MockObject();
+        $object = new FakeObject();
         $this->set->add($object);
         $this->set->removeValue($object);
         $this->assertEquals([], $this->set->toArray());
@@ -152,7 +149,7 @@ class HashSetTest extends TestCase
 
     public function testUnionUnionsValuesOfSetAndArray(): void
     {
-        $object = new MockObject();
+        $object = new FakeObject();
         $this->set->add($object);
         $this->set->union(['bar', 'baz']);
         $this->assertEquals([$object, 'bar', 'baz'], $this->set->toArray());

--- a/src/Collections/tests/HashTableTest.php
+++ b/src/Collections/tests/HashTableTest.php
@@ -14,14 +14,11 @@ namespace Aphiria\Collections\Tests;
 
 use Aphiria\Collections\HashTable;
 use Aphiria\Collections\KeyValuePair;
-use Aphiria\Collections\Tests\Mocks\MockObject;
+use Aphiria\Collections\Tests\Mocks\FakeObject;
 use InvalidArgumentException;
 use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the hash table
- */
 class HashTableTest extends TestCase
 {
     private HashTable $hashTable;
@@ -108,8 +105,8 @@ class HashTableTest extends TestCase
      */
     public function testGettingKeysReturnsOriginalKeysNotHashKeys(): void
     {
-        $key1 = new MockObject();
-        $key2 = new MockObject();
+        $key1 = new FakeObject();
+        $key2 = new FakeObject();
         $this->hashTable->add($key1, 'foo');
         $this->hashTable->add($key2, 'bar');
         $this->assertEquals([$key1, $key2], $this->hashTable->getKeys());

--- a/src/Collections/tests/ImmutableArrayListTest.php
+++ b/src/Collections/tests/ImmutableArrayListTest.php
@@ -17,9 +17,6 @@ use OutOfRangeException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the immutable array list
- */
 class ImmutableArrayListTest extends TestCase
 {
     public function testCheckingOffsetExists(): void

--- a/src/Collections/tests/ImmutableHashSetTest.php
+++ b/src/Collections/tests/ImmutableHashSetTest.php
@@ -13,12 +13,9 @@ declare(strict_types=1);
 namespace Aphiria\Collections\Tests;
 
 use Aphiria\Collections\ImmutableHashSet;
-use Aphiria\Collections\Tests\Mocks\MockObject;
+use Aphiria\Collections\Tests\Mocks\FakeObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests an immutable hash set
- */
 class ImmutableHashSetTest extends TestCase
 {
     public function testAddingArrayValueIsAcceptable(): void
@@ -49,7 +46,7 @@ class ImmutableHashSetTest extends TestCase
 
     public function testAddingValue(): void
     {
-        $object = new MockObject();
+        $object = new FakeObject();
         $set = new ImmutableHashSet([$object]);
         $this->assertEquals([$object], $set->toArray());
     }
@@ -60,15 +57,15 @@ class ImmutableHashSetTest extends TestCase
         $this->assertFalse($setWithNoValues->containsValue('foo'));
         $setWithStringValue = new ImmutableHashSet(['foo']);
         $this->assertTrue($setWithStringValue->containsValue('foo'));
-        $object = new MockObject();
+        $object = new FakeObject();
         $setWithObjectValue = new ImmutableHashSet([$object]);
         $this->assertTrue($setWithObjectValue->containsValue($object));
     }
 
     public function testCountReturnsNumberOfUniqueValuesInSet(): void
     {
-        $object1 = new MockObject();
-        $object2 = new MockObject();
+        $object1 = new FakeObject();
+        $object2 = new FakeObject();
         $this->assertEquals(0, (new ImmutableHashSet([]))->count());
         $setWithOneValue = new ImmutableHashSet([$object1]);
         $this->assertEquals(1, $setWithOneValue->count());
@@ -84,8 +81,8 @@ class ImmutableHashSetTest extends TestCase
     public function testIteratingOverValuesReturnsValuesNotHashKeys(): void
     {
         $expectedValues = [
-            new MockObject(),
-            new MockObject()
+            new FakeObject(),
+            new FakeObject()
         ];
         $set = new ImmutableHashSet($expectedValues);
         $actualValues = [];

--- a/src/Collections/tests/ImmutableHashTableTest.php
+++ b/src/Collections/tests/ImmutableHashTableTest.php
@@ -14,15 +14,12 @@ namespace Aphiria\Collections\Tests;
 
 use Aphiria\Collections\ImmutableHashTable;
 use Aphiria\Collections\KeyValuePair;
-use Aphiria\Collections\Tests\Mocks\MockObject;
+use Aphiria\Collections\Tests\Mocks\FakeObject;
 use InvalidArgumentException;
 use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the immutable hash table
- */
 class ImmutableHashTableTest extends TestCase
 {
     public function testContainsKey(): void
@@ -66,8 +63,8 @@ class ImmutableHashTableTest extends TestCase
 
     public function testGettingKeysReturnsOriginalKeysNotHashKeys(): void
     {
-        $kvp1 = new KeyValuePair(new MockObject(), 'foo');
-        $kvp2 = new KeyValuePair(new MockObject(), 'bar');
+        $kvp1 = new KeyValuePair(new FakeObject(), 'foo');
+        $kvp2 = new KeyValuePair(new FakeObject(), 'bar');
         $hashTable = new ImmutableHashTable([$kvp1, $kvp2]);
         $this->assertEquals([$kvp1->getKey(), $kvp2->getKey()], $hashTable->getKeys());
     }

--- a/src/Collections/tests/KeyHasherTest.php
+++ b/src/Collections/tests/KeyHasherTest.php
@@ -17,9 +17,6 @@ use Aphiria\Collections\Tests\Mocks\SerializableObject;
 use Aphiria\Collections\Tests\Mocks\UnserializableObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the key hasher
- */
 class KeyHasherTest extends TestCase
 {
     private KeyHasher $keyHasher;

--- a/src/Collections/tests/KeyValuePairTest.php
+++ b/src/Collections/tests/KeyValuePairTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Collections\Tests;
 use Aphiria\Collections\KeyValuePair;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the key-value pair
- */
 class KeyValuePairTest extends TestCase
 {
     public function testGettingKey(): void

--- a/src/Collections/tests/Mocks/FakeObject.php
+++ b/src/Collections/tests/Mocks/FakeObject.php
@@ -15,7 +15,7 @@ namespace Aphiria\Collections\Tests\Mocks;
 /**
  * Mocks an object
  */
-class MockObject
+class FakeObject
 {
     // Don't do anything
 }

--- a/src/Collections/tests/QueueTest.php
+++ b/src/Collections/tests/QueueTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Collections\Tests;
 use Aphiria\Collections\Queue;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the queue
- */
 class QueueTest extends TestCase
 {
     private Queue $queue;

--- a/src/Collections/tests/StackTest.php
+++ b/src/Collections/tests/StackTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Collections\Tests;
 use Aphiria\Collections\Stack;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the stack
- */
 class StackTest extends TestCase
 {
     private Stack $stack;

--- a/src/Configuration/tests/GlobalConfigurationBuilderTest.php
+++ b/src/Configuration/tests/GlobalConfigurationBuilderTest.php
@@ -18,9 +18,6 @@ use Aphiria\Configuration\HashTableConfiguration;
 use Aphiria\Configuration\InvalidConfigurationFileException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the global configuration builder
- */
 class GlobalConfigurationBuilderTest extends TestCase
 {
     private GlobalConfigurationBuilder $builder;

--- a/src/Configuration/tests/GlobalConfigurationTest.php
+++ b/src/Configuration/tests/GlobalConfigurationTest.php
@@ -18,9 +18,6 @@ use Aphiria\Configuration\MissingConfigurationValueException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the global configuration
- */
 class GlobalConfigurationTest extends TestCase
 {
     protected function setUp(): void

--- a/src/Configuration/tests/HashTableConfigurationTest.php
+++ b/src/Configuration/tests/HashTableConfigurationTest.php
@@ -16,9 +16,6 @@ use Aphiria\Configuration\HashTableConfiguration;
 use Aphiria\Configuration\MissingConfigurationValueException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the hash table configuration
- */
 class HashTableConfigurationTest extends TestCase
 {
     public function testGetArrayForNestedValueReturnsArray(): void

--- a/src/Configuration/tests/JsonConfigurationFileReaderTest.php
+++ b/src/Configuration/tests/JsonConfigurationFileReaderTest.php
@@ -16,9 +16,6 @@ use Aphiria\Configuration\InvalidConfigurationFileException;
 use Aphiria\Configuration\JsonConfigurationFileReader;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the JSON file configuration reader
- */
 class JsonConfigurationFileReaderTest extends TestCase
 {
     private JsonConfigurationFileReader $reader;

--- a/src/Configuration/tests/PhpConfigurationFileReaderTest.php
+++ b/src/Configuration/tests/PhpConfigurationFileReaderTest.php
@@ -16,9 +16,6 @@ use Aphiria\Configuration\InvalidConfigurationFileException;
 use Aphiria\Configuration\PhpConfigurationFileReader;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the PHP file configuration reader
- */
 class PhpConfigurationFileReaderTest extends TestCase
 {
     private PhpConfigurationFileReader $reader;

--- a/src/Console/tests/ApplicationTest.php
+++ b/src/Console/tests/ApplicationTest.php
@@ -26,9 +26,6 @@ use Aphiria\Console\StatusCodes;
 use Aphiria\Console\Tests\Output\Mocks\Output;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the console application
- */
 class ApplicationTest extends TestCase
 {
     private CommandRegistry $commands;

--- a/src/Console/tests/Commands/Annotations/AnnotationCommandRegistrantTest.php
+++ b/src/Console/tests/Commands/Annotations/AnnotationCommandRegistrantTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Aphiria\Console\Tests\Commands\Annotations;
 
-use Aphiria\Collections\Tests\Mocks\MockObject;
+use Aphiria\Collections\Tests\Mocks\FakeObject;
 use Aphiria\Console\Commands\Annotations\AnnotationCommandRegistrant;
 use Aphiria\Console\Commands\Annotations\Argument;
 use Aphiria\Console\Commands\Annotations\Command;
@@ -28,16 +28,13 @@ use Aphiria\Reflection\ITypeFinder;
 use Doctrine\Common\Annotations\Annotation\Required;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the reflection command annotation registrant
- */
 class AnnotationCommandRegistrantTest extends TestCase
 {
     private AnnotationCommandRegistrant $registrant;
     private CommandRegistry $commands;
-    /** @var IServiceResolver|MockObject */
+    /** @var IServiceResolver|FakeObject */
     private IServiceResolver $commandHandlerResolver;
-    /** @var ITypeFinder|MockObject */
+    /** @var ITypeFinder|FakeObject */
     private ITypeFinder $typeFinder;
 
     protected function setUp(): void

--- a/src/Console/tests/Commands/Annotations/ArgumentTest.php
+++ b/src/Console/tests/Commands/Annotations/ArgumentTest.php
@@ -17,9 +17,6 @@ use Aphiria\Console\Input\ArgumentTypes;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the argument annotation
- */
 class ArgumentTest extends TestCase
 {
     public function testDefaultValuesOfArgumentPropertiesAreSet(): void

--- a/src/Console/tests/Commands/Annotations/CommandTest.php
+++ b/src/Console/tests/Commands/Annotations/CommandTest.php
@@ -20,9 +20,6 @@ use Aphiria\Console\Input\OptionTypes;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the command annotation
- */
 class CommandTest extends TestCase
 {
     public function testDefaultValuesOfCommandPropertiesAreSet(): void

--- a/src/Console/tests/Commands/Annotations/OptionTest.php
+++ b/src/Console/tests/Commands/Annotations/OptionTest.php
@@ -17,9 +17,6 @@ use Aphiria\Console\Input\OptionTypes;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the option annotation
- */
 class OptionTest extends TestCase
 {
     public function testDefaultValuesOfOptionPropertiesAreSet(): void

--- a/src/Console/tests/Commands/Caching/FileCommandRegistryCacheTest.php
+++ b/src/Console/tests/Commands/Caching/FileCommandRegistryCacheTest.php
@@ -18,9 +18,6 @@ use Aphiria\Console\Commands\CommandRegistry;
 use Aphiria\Console\Tests\Commands\Mocks\MockCommandHandler;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the file command registry
- */
 class FileCommandRegistryCacheTest extends TestCase
 {
     /** @var string The path to the command cache */

--- a/src/Console/tests/Commands/ClosureCommandHandlerTest.php
+++ b/src/Console/tests/Commands/ClosureCommandHandlerTest.php
@@ -18,9 +18,6 @@ use Aphiria\Console\Output\IOutput;
 use Aphiria\Console\StatusCodes;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the closure command handler
- */
 class ClosureCommandHandlerTest extends TestCase
 {
     public function testHandlingInvokesClosure(): void

--- a/src/Console/tests/Commands/ClosureCommandRegistrantTest.php
+++ b/src/Console/tests/Commands/ClosureCommandRegistrantTest.php
@@ -19,9 +19,6 @@ use Aphiria\Console\Commands\CommandRegistry;
 use Aphiria\Console\Commands\ICommandHandler;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the closure command registrant
- */
 class ClosureCommandRegistrantTest extends TestCase
 {
     public function testRegisteringCommandsRegistersCommandsFromClosures(): void

--- a/src/Console/tests/Commands/CommandBindingTest.php
+++ b/src/Console/tests/Commands/CommandBindingTest.php
@@ -22,9 +22,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-/**
- * Tests the command binding
- */
 class CommandBindingTest extends TestCase
 {
     public function testPropertiesAreSetInConstructorWhenUsingCommandHandlerInterface(): void

--- a/src/Console/tests/Commands/CommandRegistrantCollectionTest.php
+++ b/src/Console/tests/Commands/CommandRegistrantCollectionTest.php
@@ -20,9 +20,6 @@ use Aphiria\Console\Commands\ICommandHandler;
 use Aphiria\Console\Commands\ICommandRegistrant;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the command registrant collection
- */
 class CommandRegistrantCollectionTest extends TestCase
 {
     public function testAddingRegistrantCausesItToBeInvokedWhenRegisteringRoutes(): void

--- a/src/Console/tests/Commands/CommandRegistryTest.php
+++ b/src/Console/tests/Commands/CommandRegistryTest.php
@@ -19,9 +19,6 @@ use Aphiria\Console\Commands\ICommandHandler;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the command registry
- */
 class CommandRegistryTest extends TestCase
 {
     private CommandRegistry $commands;

--- a/src/Console/tests/Commands/CommandTest.php
+++ b/src/Console/tests/Commands/CommandTest.php
@@ -20,9 +20,6 @@ use Aphiria\Console\Input\OptionTypes;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the command
- */
 class CommandTest extends TestCase
 {
     public function testEmptyNameThrowsException(): void

--- a/src/Console/tests/Commands/Defaults/AboutCommandHandlerTest.php
+++ b/src/Console/tests/Commands/Defaults/AboutCommandHandlerTest.php
@@ -21,9 +21,6 @@ use Aphiria\Console\Output\IOutput;
 use Closure;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the about command handler
- */
 class AboutCommandHandlerTest extends TestCase
 {
     private AboutCommandHandler $handler;

--- a/src/Console/tests/Commands/Defaults/HelpCommandHandlerTest.php
+++ b/src/Console/tests/Commands/Defaults/HelpCommandHandlerTest.php
@@ -26,9 +26,6 @@ use Aphiria\Console\StatusCodes;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the help command handler
- */
 class HelpCommandHandlerTest extends TestCase
 {
     /** @var IOutput|MockObject */

--- a/src/Console/tests/Input/ArgumentTest.php
+++ b/src/Console/tests/Input/ArgumentTest.php
@@ -17,9 +17,6 @@ use Aphiria\Console\Input\ArgumentTypes;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the console argument
- */
 class ArgumentTest extends TestCase
 {
     private Argument $argument;

--- a/src/Console/tests/Input/Compilers/CommandNotFoundExceptionTest.php
+++ b/src/Console/tests/Input/Compilers/CommandNotFoundExceptionTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Console\Tests\Input\Compilers;
 use Aphiria\Console\Input\Compilers\CommandNotFoundException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the command not found exception
- */
 class CommandNotFoundExceptionTest extends TestCase
 {
     public function testGettingCommandNameReturnsOneSetInConstructor(): void

--- a/src/Console/tests/Input/Compilers/InputCompilerTest.php
+++ b/src/Console/tests/Input/Compilers/InputCompilerTest.php
@@ -24,9 +24,6 @@ use Aphiria\Console\Input\OptionTypes;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the input compiler
- */
 class InputCompilerTest extends TestCase
 {
     private InputCompiler $compiler;

--- a/src/Console/tests/Input/InputTest.php
+++ b/src/Console/tests/Input/InputTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Console\Tests\Input;
 use Aphiria\Console\Input\Input;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the command input
- */
 class InputTest extends TestCase
 {
     public function testPropertiesAreSetInConstructor(): void

--- a/src/Console/tests/Input/OptionTest.php
+++ b/src/Console/tests/Input/OptionTest.php
@@ -17,9 +17,6 @@ use Aphiria\Console\Input\OptionTypes;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the console option
- */
 class OptionTest extends TestCase
 {
     private Option $option;

--- a/src/Console/tests/Input/Tokenizers/ArgvInputTokenizerTest.php
+++ b/src/Console/tests/Input/Tokenizers/ArgvInputTokenizerTest.php
@@ -16,9 +16,6 @@ use Aphiria\Console\Input\Tokenizers\ArgvInputTokenizer;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the argv input tokenizer
- */
 class ArgvInputTokenizerTest extends TestCase
 {
     private ArgvInputTokenizer $tokenizer;

--- a/src/Console/tests/Input/Tokenizers/ArrayListInputTokenizerTest.php
+++ b/src/Console/tests/Input/Tokenizers/ArrayListInputTokenizerTest.php
@@ -17,9 +17,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the array list input tokenizer
- */
 class ArrayListInputTokenizerTest extends TestCase
 {
     private ArrayListInputTokenizer $tokenizer;

--- a/src/Console/tests/Input/Tokenizers/StringInputTokenizerTest.php
+++ b/src/Console/tests/Input/Tokenizers/StringInputTokenizerTest.php
@@ -16,9 +16,6 @@ use Aphiria\Console\Input\Tokenizers\StringInputTokenizer;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the string input tokenizer
- */
 class StringInputTokenizerTest extends TestCase
 {
     private StringInputTokenizer $tokenizer;

--- a/src/Console/tests/Output/Compilers/Elements/ElementRegistryTest.php
+++ b/src/Console/tests/Output/Compilers/Elements/ElementRegistryTest.php
@@ -18,9 +18,6 @@ use Aphiria\Console\Output\Compilers\Elements\Style;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the element registry
- */
 class ElementRegistryTest extends TestCase
 {
     private ElementRegistry $elements;

--- a/src/Console/tests/Output/Compilers/Elements/ElementTest.php
+++ b/src/Console/tests/Output/Compilers/Elements/ElementTest.php
@@ -16,9 +16,6 @@ use Aphiria\Console\Output\Compilers\Elements\Element;
 use Aphiria\Console\Output\Compilers\Elements\Style;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the output element
- */
 class ElementTest extends TestCase
 {
     public function testPropertiesAreSetInConstructor(): void

--- a/src/Console/tests/Output/Compilers/Elements/StyleTest.php
+++ b/src/Console/tests/Output/Compilers/Elements/StyleTest.php
@@ -18,9 +18,6 @@ use Aphiria\Console\Output\Compilers\Elements\TextStyles;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the style class
- */
 class StyleTest extends TestCase
 {
     public function testAddingInvalidTextStyle(): void

--- a/src/Console/tests/Output/Compilers/MockOutputCompilerTest.php
+++ b/src/Console/tests/Output/Compilers/MockOutputCompilerTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Console\Tests\Output\Compilers;
 use Aphiria\Console\Output\Compilers\MockOutputCompiler;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the mock output compiler
- */
 class MockOutputCompilerTest extends TestCase
 {
     public function testCompilingStyledMessage(): void

--- a/src/Console/tests/Output/Compilers/OutputCompilerTest.php
+++ b/src/Console/tests/Output/Compilers/OutputCompilerTest.php
@@ -19,9 +19,6 @@ use Aphiria\Console\Output\Compilers\OutputCompiler;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the output compiler
- */
 class OutputCompilerTest extends TestCase
 {
     private ElementRegistry $elements;

--- a/src/Console/tests/Output/ConsoleOutputTest.php
+++ b/src/Console/tests/Output/ConsoleOutputTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Console\Tests\Output;
 use Aphiria\Console\Output\ConsoleOutput;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the console output
- */
 class ConsoleOutputTest extends TestCase
 {
     public function testClearWritesAsciiCodesToClearScreen(): void

--- a/src/Console/tests/Output/Formatters/CommandFormatterTest.php
+++ b/src/Console/tests/Output/Formatters/CommandFormatterTest.php
@@ -20,9 +20,6 @@ use Aphiria\Console\Input\OptionTypes;
 use Aphiria\Console\Output\Formatters\CommandFormatter;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the command formatter
- */
 class CommandFormatterTest extends TestCase
 {
     private CommandFormatter $formatter;

--- a/src/Console/tests/Output/Formatters/PaddingFormatterTest.php
+++ b/src/Console/tests/Output/Formatters/PaddingFormatterTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Console\Tests\Output\Formatters;
 use Aphiria\Console\Output\Formatters\PaddingFormatter;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the padding formatter
- */
 class PaddingFormatterTest extends TestCase
 {
     private PaddingFormatter $formatter;

--- a/src/Console/tests/Output/Formatters/ProgressBarFormatterTest.php
+++ b/src/Console/tests/Output/Formatters/ProgressBarFormatterTest.php
@@ -18,9 +18,6 @@ use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the progress bar formatter
- */
 class ProgressBarFormatterTest extends TestCase
 {
     /** @var IOutput|MockObject */

--- a/src/Console/tests/Output/Formatters/ProgressBarTest.php
+++ b/src/Console/tests/Output/Formatters/ProgressBarTest.php
@@ -18,9 +18,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the progress bar
- */
 class ProgressBarTest extends TestCase
 {
     private ProgressBar $progressBar;

--- a/src/Console/tests/Output/Formatters/TableFormatterTest.php
+++ b/src/Console/tests/Output/Formatters/TableFormatterTest.php
@@ -16,9 +16,6 @@ use Aphiria\Console\Output\Formatters\PaddingFormatter;
 use Aphiria\Console\Output\Formatters\TableFormatter;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the table formatter
- */
 class TableFormatterTest extends TestCase
 {
     private TableFormatter $formatter;

--- a/src/Console/tests/Output/Lexers/OutputLexerTest.php
+++ b/src/Console/tests/Output/Lexers/OutputLexerTest.php
@@ -18,9 +18,6 @@ use Aphiria\Console\Output\Lexers\OutputTokenTypes;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the output lexer
- */
 class OutputLexerTest extends TestCase
 {
     private OutputLexer $lexer;

--- a/src/Console/tests/Output/Lexers/OutputTokenTest.php
+++ b/src/Console/tests/Output/Lexers/OutputTokenTest.php
@@ -16,9 +16,6 @@ use Aphiria\Console\Output\Lexers\OutputToken;
 use Aphiria\Console\Output\Lexers\OutputTokenTypes;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the output token
- */
 class OutputTokenTest extends TestCase
 {
     public function testPropertiesAreSetInConstructor(): void

--- a/src/Console/tests/Output/OutputTest.php
+++ b/src/Console/tests/Output/OutputTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Console\Tests\Output;
 use Aphiria\Console\Tests\Output\Mocks\Output;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the output class
- */
 class OutputTest extends TestCase
 {
     private Output $output;

--- a/src/Console/tests/Output/Parsers/NodeTest.php
+++ b/src/Console/tests/Output/Parsers/NodeTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Console\Tests\Output\Parsers;
 use Aphiria\Console\Tests\Output\Parsers\Mocks\AstNode;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the output node
- */
 class NodeTest extends TestCase
 {
     public function testAddingChild(): void

--- a/src/Console/tests/Output/Parsers/OutputParserTest.php
+++ b/src/Console/tests/Output/Parsers/OutputParserTest.php
@@ -21,9 +21,6 @@ use Aphiria\Console\Output\Parsers\WordAstNode;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the output parser
- */
 class OutputParserTest extends TestCase
 {
     private OutputParser $parser;

--- a/src/Console/tests/Output/Parsers/RootNodeTest.php
+++ b/src/Console/tests/Output/Parsers/RootNodeTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Console\Tests\Output\Parsers;
 use Aphiria\Console\Output\Parsers\RootAstNode;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the root node
- */
 class RootNodeTest extends TestCase
 {
     public function testIsRoot(): void

--- a/src/Console/tests/Output/Parsers/TagNodeTest.php
+++ b/src/Console/tests/Output/Parsers/TagNodeTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Console\Tests\Output\Parsers;
 use Aphiria\Console\Output\Parsers\TagAstNode;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the tag node
- */
 class TagNodeTest extends TestCase
 {
     public function testIsTag(): void

--- a/src/Console/tests/Output/Parsers/WordNodeTest.php
+++ b/src/Console/tests/Output/Parsers/WordNodeTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Console\Tests\Output\Parsers;
 use Aphiria\Console\Output\Parsers\WordAstNode;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the word node
- */
 class WordNodeTest extends TestCase
 {
     public function testIsTag(): void

--- a/src/Console/tests/Output/Prompts/ConfirmationTest.php
+++ b/src/Console/tests/Output/Prompts/ConfirmationTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Console\Tests\Output\Prompts;
 use Aphiria\Console\Output\Prompts\Confirmation;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the confirmation question
- */
 class ConfirmationTest extends TestCase
 {
     private Confirmation $question;

--- a/src/Console/tests/Output/Prompts/MultipleChoiceTest.php
+++ b/src/Console/tests/Output/Prompts/MultipleChoiceTest.php
@@ -16,9 +16,6 @@ use Aphiria\Console\Output\Prompts\MultipleChoice;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the multiple choice question
- */
 class MultipleChoiceTest extends TestCase
 {
     private MultipleChoice $indexedChoiceQuestion;

--- a/src/Console/tests/Output/Prompts/PromptTest.php
+++ b/src/Console/tests/Output/Prompts/PromptTest.php
@@ -21,9 +21,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the console prompt
- */
 class PromptTest extends TestCase
 {
     /** @var IOutput|MockObject */

--- a/src/Console/tests/Output/Prompts/QuestionTest.php
+++ b/src/Console/tests/Output/Prompts/QuestionTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Console\Tests\Output\Prompts;
 use Aphiria\Console\Output\Prompts\Question;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the console prompt question
- */
 class QuestionTest extends TestCase
 {
     private Question $question;

--- a/src/Console/tests/Output/SilentOutputTest.php
+++ b/src/Console/tests/Output/SilentOutputTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Console\Tests\Output;
 use Aphiria\Console\Output\SilentOutput;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the silent output
- */
 class SilentOutputTest extends TestCase
 {
     private SilentOutput $output;

--- a/src/Console/tests/Output/StreamOutputTest.php
+++ b/src/Console/tests/Output/StreamOutputTest.php
@@ -18,9 +18,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the stream output
- */
 class StreamOutputTest extends TestCase
 {
     private StreamOutput $output;

--- a/src/DependencyInjection/tests/Binders/FileBinderFinderTest.php
+++ b/src/DependencyInjection/tests/Binders/FileBinderFinderTest.php
@@ -19,9 +19,6 @@ use Aphiria\DependencyInjection\Tests\Binders\Mocks\Finder\Subdirectory\BinderC;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the file binder finder
- */
 class FileBinderFinderTest extends TestCase
 {
     private const BINDER_DIRECTORY = __DIR__ . '/Mocks/Finder';

--- a/src/DependencyInjection/tests/Binders/LazyBinderDispatcherTest.php
+++ b/src/DependencyInjection/tests/Binders/LazyBinderDispatcherTest.php
@@ -32,9 +32,6 @@ use Aphiria\DependencyInjection\UniversalContext;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the lazy binder dispatcher
- */
 class LazyBinderDispatcherTest extends TestCase
 {
     /** @var IContainer|MockObject */

--- a/src/DependencyInjection/tests/Binders/Metadata/BinderMetadataCollectionFactoryTest.php
+++ b/src/DependencyInjection/tests/Binders/Metadata/BinderMetadataCollectionFactoryTest.php
@@ -29,9 +29,6 @@ use Aphiria\DependencyInjection\Tests\Binders\Metadata\Mocks\IFoo;
 use Aphiria\DependencyInjection\UniversalContext;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the binder metadata collection factory
- */
 class BinderMetadataCollectionFactoryTest extends TestCase
 {
     private BinderMetadataCollectionFactory $factory;

--- a/src/DependencyInjection/tests/Binders/Metadata/BinderMetadataCollectionTest.php
+++ b/src/DependencyInjection/tests/Binders/Metadata/BinderMetadataCollectionTest.php
@@ -22,9 +22,6 @@ use Aphiria\DependencyInjection\TargetedContext;
 use Aphiria\DependencyInjection\UniversalContext;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the binder metadata collection
- */
 class BinderMetadataCollectionTest extends TestCase
 {
     public function testBinderThatResolvesTargetedInterfaceIsNotReturnedForTargetedBoundInterfaceWithSameInterfaceButDifferentTarget(): void

--- a/src/DependencyInjection/tests/Binders/Metadata/BinderMetadataTest.php
+++ b/src/DependencyInjection/tests/Binders/Metadata/BinderMetadataTest.php
@@ -20,9 +20,6 @@ use Aphiria\DependencyInjection\Tests\Binders\Mocks\Binder;
 use Aphiria\DependencyInjection\UniversalContext;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the binder metadata
- */
 class BinderMetadataTest extends TestCase
 {
     public function testGetBinderReturnsSetBinder(): void

--- a/src/DependencyInjection/tests/Binders/Metadata/BoundInterfaceTest.php
+++ b/src/DependencyInjection/tests/Binders/Metadata/BoundInterfaceTest.php
@@ -17,9 +17,6 @@ use Aphiria\DependencyInjection\TargetedContext;
 use Aphiria\DependencyInjection\UniversalContext;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the bound interface
- */
 class BoundInterfaceTest extends TestCase
 {
     public function testGetInterfaceReturnsSetInterface(): void

--- a/src/DependencyInjection/tests/Binders/Metadata/Caching/FileBinderMetadataCollectionCacheTest.php
+++ b/src/DependencyInjection/tests/Binders/Metadata/Caching/FileBinderMetadataCollectionCacheTest.php
@@ -18,9 +18,6 @@ use Aphiria\DependencyInjection\Binders\Metadata\Caching\FileBinderMetadataColle
 use Aphiria\DependencyInjection\Tests\Binders\Metadata\Caching\Mocks\MockBinder;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the file binder metadata collection cache
- */
 class FileBinderMetadataCollectionCacheTest extends TestCase
 {
     /** string The path to the cache */

--- a/src/DependencyInjection/tests/Binders/Metadata/ContainerBinderMetadataCollectorTest.php
+++ b/src/DependencyInjection/tests/Binders/Metadata/ContainerBinderMetadataCollectorTest.php
@@ -26,9 +26,6 @@ use Exception;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the container binder metadata collector
- */
 class ContainerBinderMetadataCollectorTest extends TestCase
 {
     private IContainer $container;

--- a/src/DependencyInjection/tests/Binders/Metadata/FailedBinderMetadataCollectionExceptionTest.php
+++ b/src/DependencyInjection/tests/Binders/Metadata/FailedBinderMetadataCollectionExceptionTest.php
@@ -21,9 +21,6 @@ use Aphiria\DependencyInjection\Tests\Binders\Mocks\Binder;
 use Aphiria\DependencyInjection\UniversalContext;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the failed binder metadata collection exception
- */
 class FailedBinderMetadataCollectionExceptionTest extends TestCase
 {
     public function testPropertiesAreSet(): void

--- a/src/DependencyInjection/tests/Binders/Metadata/ImpossibleBindingExceptionTest.php
+++ b/src/DependencyInjection/tests/Binders/Metadata/ImpossibleBindingExceptionTest.php
@@ -17,9 +17,6 @@ use Aphiria\DependencyInjection\Binders\Metadata\ImpossibleBindingException;
 use Aphiria\DependencyInjection\IContainer;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the impossible binding exception
- */
 class ImpossibleBindingExceptionTest extends TestCase
 {
     public function testMultipleFailedBindersForSingleInterfaceAreFormattedCorrectly(): void

--- a/src/DependencyInjection/tests/Binders/Metadata/ResolvedInterfaceTest.php
+++ b/src/DependencyInjection/tests/Binders/Metadata/ResolvedInterfaceTest.php
@@ -17,9 +17,6 @@ use Aphiria\DependencyInjection\TargetedContext;
 use Aphiria\DependencyInjection\UniversalContext;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the resolved interface
- */
 class ResolvedInterfaceTest extends TestCase
 {
     public function testGetInterfaceReturnsSetInterface(): void

--- a/src/DependencyInjection/tests/ClassContainerBindingTest.php
+++ b/src/DependencyInjection/tests/ClassContainerBindingTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\DependencyInjection\Tests;
 use Aphiria\DependencyInjection\ClassContainerBinding;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the class container binding
- */
 class ClassContainerBindingTest extends TestCase
 {
     private ClassContainerBinding $binding;

--- a/src/DependencyInjection/tests/ContainerTest.php
+++ b/src/DependencyInjection/tests/ContainerTest.php
@@ -41,9 +41,6 @@ use DateTime;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the dependency injection container
- */
 class ContainerTest extends TestCase
 {
     private Container $container;

--- a/src/DependencyInjection/tests/FactoryContainerBindingTest.php
+++ b/src/DependencyInjection/tests/FactoryContainerBindingTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\DependencyInjection\Tests;
 use Aphiria\DependencyInjection\FactoryContainerBinding;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the factory container binding
- */
 class FactoryContainerBindingTest extends TestCase
 {
     public function testCheckingIfResolvedAsSingleton(): void

--- a/src/DependencyInjection/tests/InstanceContainerBindingTest.php
+++ b/src/DependencyInjection/tests/InstanceContainerBindingTest.php
@@ -16,9 +16,6 @@ use Aphiria\DependencyInjection\InstanceContainerBinding;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-/**
- * Tests the instance container binding
- */
 class InstanceContainerBindingTest extends TestCase
 {
     public function testAlwaysResolvedAsSingleton(): void

--- a/src/DependencyInjection/tests/ResolutionExceptionTest.php
+++ b/src/DependencyInjection/tests/ResolutionExceptionTest.php
@@ -17,9 +17,6 @@ use Aphiria\DependencyInjection\TargetedContext;
 use Aphiria\DependencyInjection\UniversalContext;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the resolution exception
- */
 class ResolutionExceptionTest extends TestCase
 {
     public function testGetContextReturnsContextInjectedInConstructor(): void

--- a/src/DependencyInjection/tests/TargetedContextTest.php
+++ b/src/DependencyInjection/tests/TargetedContextTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\DependencyInjection\Tests;
 use Aphiria\DependencyInjection\TargetedContext;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests a targeted context
- */
 class TargetedContextTest extends TestCase
 {
     public function testMethodsIndicateATargetedContext(): void

--- a/src/DependencyInjection/tests/UniversalContextTest.php
+++ b/src/DependencyInjection/tests/UniversalContextTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\DependencyInjection\Tests;
 use Aphiria\DependencyInjection\UniversalContext;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the universal context
- */
 class UniversalContextTest extends TestCase
 {
     public function testMethodsIndicateUniversalContext(): void

--- a/src/Exceptions/tests/GlobalExceptionHandlerTest.php
+++ b/src/Exceptions/tests/GlobalExceptionHandlerTest.php
@@ -23,9 +23,6 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Throwable;
 
-/**
- * Tests the global exception handler
- */
 class GlobalExceptionHandlerTest extends TestCase
 {
     /** @var IExceptionRenderer|MockObject */

--- a/src/Framework/tests/Api/Binders/ControllerBinderTest.php
+++ b/src/Framework/tests/Api/Binders/ControllerBinderTest.php
@@ -23,9 +23,6 @@ use Aphiria\Validation\IValidator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the controller binder
- */
 class ControllerBinderTest extends TestCase
 {
     /** @var IContainer|MockObject */

--- a/src/Framework/tests/Api/Builders/ApiApplicationBuilderTest.php
+++ b/src/Framework/tests/Api/Builders/ApiApplicationBuilderTest.php
@@ -24,9 +24,6 @@ use Aphiria\Net\Http\Handlers\IRequestHandler;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the API application builder
- */
 class ApiApplicationBuilderTest extends TestCase
 {
     private Container $container;

--- a/src/Framework/tests/Api/Exceptions/ApiExceptionRendererTest.php
+++ b/src/Framework/tests/Api/Exceptions/ApiExceptionRendererTest.php
@@ -24,9 +24,6 @@ use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the API exception renderer
- */
 class ApiExceptionRendererTest extends TestCase
 {
     /** @var IResponseWriter|MockObject */

--- a/src/Framework/tests/Application/AphiriaComponentsTest.php
+++ b/src/Framework/tests/Application/AphiriaComponentsTest.php
@@ -41,9 +41,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 
-/**
- * Tests the Aphiria component trait
- */
 class AphiriaComponentsTest extends TestCase
 {
     /** @var IApplicationBuilder|MockObject */

--- a/src/Framework/tests/Configuration/Bootstrappers/ConfigurationBootstrapperTest.php
+++ b/src/Framework/tests/Configuration/Bootstrappers/ConfigurationBootstrapperTest.php
@@ -18,9 +18,6 @@ use Aphiria\Configuration\HashTableConfiguration;
 use Aphiria\Framework\Configuration\Bootstrappers\ConfigurationBootstrapper;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the configuration bootstrapper
- */
 class ConfigurationBootstrapperTest extends TestCase
 {
     private GlobalConfigurationBuilder $globalConfigurationBuilder;

--- a/src/Framework/tests/Configuration/Bootstrappers/EnvironmentVariableBootstrapperTest.php
+++ b/src/Framework/tests/Configuration/Bootstrappers/EnvironmentVariableBootstrapperTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Framework\Tests\Configuration\Bootstrappers;
 use Aphiria\Framework\Configuration\Bootstrappers\EnvironmentVariableBootstrapper;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the environment variable bootstrapper
- */
 class EnvironmentVariableBootstrapperTest extends TestCase
 {
     private EnvironmentVariableBootstrapper $environmentVariableBootstrapper;

--- a/src/Framework/tests/Console/Binders/CommandBinderTest.php
+++ b/src/Framework/tests/Console/Binders/CommandBinderTest.php
@@ -22,9 +22,6 @@ use Aphiria\Framework\Console\Binders\CommandBinder;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the command binder
- */
 class CommandBinderTest extends TestCase
 {
     /** @var IContainer|MockObject */

--- a/src/Framework/tests/Console/Builders/ConsoleApplicationBuilderTest.php
+++ b/src/Framework/tests/Console/Builders/ConsoleApplicationBuilderTest.php
@@ -25,9 +25,6 @@ use Aphiria\Framework\Console\Builders\ConsoleApplicationBuilder;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the console application builder
- */
 class ConsoleApplicationBuilderTest extends TestCase
 {
     private Container $container;

--- a/src/Framework/tests/Console/Components/CommandComponentTest.php
+++ b/src/Framework/tests/Console/Components/CommandComponentTest.php
@@ -23,9 +23,6 @@ use Aphiria\Framework\Console\Components\CommandComponent;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the command component
- */
 class CommandComponentTest extends TestCase
 {
     private Container $container;

--- a/src/Framework/tests/Console/Exceptions/ConsoleExceptionRendererTest.php
+++ b/src/Framework/tests/Console/Exceptions/ConsoleExceptionRendererTest.php
@@ -19,9 +19,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the console exception renderer
- */
 class ConsoleExceptionRendererTest extends TestCase
 {
     private ConsoleExceptionRenderer $exceptionRenderer;

--- a/src/Framework/tests/DependencyInjection/Components/BinderComponentTest.php
+++ b/src/Framework/tests/DependencyInjection/Components/BinderComponentTest.php
@@ -20,9 +20,6 @@ use Aphiria\Framework\DependencyInjection\Components\BinderComponent;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the binder component
- */
 class BinderComponentTest extends TestCase
 {
     private BinderComponent $binderComponent;

--- a/src/Framework/tests/Exceptions/Binders/ExceptionHandlerBinderTest.php
+++ b/src/Framework/tests/Exceptions/Binders/ExceptionHandlerBinderTest.php
@@ -20,9 +20,6 @@ use Aphiria\Net\Http\IResponseFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the exception handler binder
- */
 class ExceptionHandlerBinderTest extends TestCase
 {
     /** @var IContainer|MockObject */

--- a/src/Framework/tests/Exceptions/Bootstrappers/GlobalExceptionHandlerBootstrapperTest.php
+++ b/src/Framework/tests/Exceptions/Bootstrappers/GlobalExceptionHandlerBootstrapperTest.php
@@ -33,9 +33,6 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
-/**
- * Tests the global exception handler bootstrapper
- */
 class GlobalExceptionHandlerBootstrapperTest extends TestCase
 {
     /** @var IContainer|MockObject */

--- a/src/Framework/tests/Exceptions/Components/ExceptionHandlerComponentTest.php
+++ b/src/Framework/tests/Exceptions/Components/ExceptionHandlerComponentTest.php
@@ -30,9 +30,6 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
-/**
- * Tests the exception handler component
- */
 class ExceptionHandlerComponentTest extends TestCase
 {
     private IContainer $container;

--- a/src/Framework/tests/Middleware/Components/MiddlewareComponentTest.php
+++ b/src/Framework/tests/Middleware/Components/MiddlewareComponentTest.php
@@ -25,9 +25,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the middleware component
- */
 class MiddlewareComponentTest extends TestCase
 {
     private MiddlewareComponent $middlewareComponent;

--- a/src/Framework/tests/Net/Binders/ContentNegotiationBinderTest.php
+++ b/src/Framework/tests/Net/Binders/ContentNegotiationBinderTest.php
@@ -28,9 +28,6 @@ use Aphiria\Net\Http\ContentNegotiation\MediaTypeFormatters\JsonMediaTypeFormatt
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the content negotiation binder
- */
 class ContentNegotiationBinderTest extends TestCase
 {
     /** @var IContainer|MockObject */

--- a/src/Framework/tests/Net/Binders/RequestBinderTest.php
+++ b/src/Framework/tests/Net/Binders/RequestBinderTest.php
@@ -18,9 +18,6 @@ use Aphiria\Net\Http\IHttpRequestMessage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the request binder
- */
 class RequestBinderTest extends TestCase
 {
     /** @var IContainer|MockObject */

--- a/src/Framework/tests/Routing/Binders/RoutingBinderTest.php
+++ b/src/Framework/tests/Routing/Binders/RoutingBinderTest.php
@@ -27,9 +27,6 @@ use Closure;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the routing binder
- */
 class RoutingBinderTest extends TestCase
 {
     private const ROUTE_CACHE_PATH = __DIR__ . '/tmp/routes.txt';

--- a/src/Framework/tests/Routing/Components/RouterComponentTest.php
+++ b/src/Framework/tests/Routing/Components/RouterComponentTest.php
@@ -21,9 +21,6 @@ use Aphiria\Routing\RouteRegistrantCollection;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the router component
- */
 class RouterComponentTest extends TestCase
 {
     private RouterComponent $routerComponent;

--- a/src/Framework/tests/Serialization/Binders/SerializerBinderTest.php
+++ b/src/Framework/tests/Serialization/Binders/SerializerBinderTest.php
@@ -27,9 +27,6 @@ use Aphiria\Serialization\TypeResolver;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the serializer binder
- */
 class SerializerBinderTest extends TestCase
 {
     /** @var IContainer|MockObject */

--- a/src/Framework/tests/Serialization/Components/SerializerComponentTest.php
+++ b/src/Framework/tests/Serialization/Components/SerializerComponentTest.php
@@ -18,9 +18,6 @@ use Aphiria\Serialization\Encoding\EncoderRegistry;
 use Aphiria\Serialization\Encoding\IEncoder;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the serializer component
- */
 class SerializerComponentTest extends TestCase
 {
     private SerializerComponent $serializerComponent;

--- a/src/Framework/tests/Validation/Binders/ValidationBinderTest.php
+++ b/src/Framework/tests/Validation/Binders/ValidationBinderTest.php
@@ -30,9 +30,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the validation binder
- */
 class ValidationBinderTest extends TestCase
 {
     /** @var IContainer|MockObject */

--- a/src/Framework/tests/Validation/Components/ValidationComponentTest.php
+++ b/src/Framework/tests/Validation/Components/ValidationComponentTest.php
@@ -22,9 +22,6 @@ use Aphiria\Validation\Constraints\RequiredConstraint;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the validation component
- */
 class ValidationComponentTest extends TestCase
 {
     private Container $container;

--- a/src/IO/tests/FileSystemTest.php
+++ b/src/IO/tests/FileSystemTest.php
@@ -17,9 +17,6 @@ use Aphiria\IO\FileSystemException;
 use DateTime;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the file system
- */
 class FileSystemTest extends TestCase
 {
     private FileSystem $fileSystem;

--- a/src/IO/tests/Streams/MultiStreamTest.php
+++ b/src/IO/tests/Streams/MultiStreamTest.php
@@ -20,9 +20,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the multi-stream
- */
 class MultiStreamTest extends TestCase
 {
     private MultiStream $multiStream;

--- a/src/Middleware/tests/AttributeMiddlewareTest.php
+++ b/src/Middleware/tests/AttributeMiddlewareTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Middleware\Tests;
 use Aphiria\Middleware\Tests\Mocks\AttributeMiddleware;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the attribute middleware
- */
 class AttributeMiddlewareTest extends TestCase
 {
     private AttributeMiddleware $middleware;

--- a/src/Middleware/tests/MiddlewareBindingTest.php
+++ b/src/Middleware/tests/MiddlewareBindingTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Middleware\Tests;
 use Aphiria\Middleware\MiddlewareBinding;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests middleware bindings
- */
 class MiddlewareBindingTest extends TestCase
 {
     public function testPropertiesAreSetInConstructor(): void

--- a/src/Middleware/tests/MiddlewareCollectionTest.php
+++ b/src/Middleware/tests/MiddlewareCollectionTest.php
@@ -16,9 +16,6 @@ use Aphiria\Middleware\IMiddleware;
 use Aphiria\Middleware\MiddlewareCollection;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the middleware collection
- */
 class MiddlewareCollectionTest extends TestCase
 {
     private MiddlewareCollection $middlewareCollection;

--- a/src/Middleware/tests/MiddlewarePipelineFactoryTest.php
+++ b/src/Middleware/tests/MiddlewarePipelineFactoryTest.php
@@ -20,9 +20,6 @@ use Aphiria\Net\Http\IHttpResponseMessage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the middleware pipeline factory
- */
 class MiddlewarePipelineFactoryTest extends TestCase
 {
     private MiddlewarePipelineFactory $pipelineFactory;

--- a/src/Middleware/tests/MiddlewareRequestHandlerTest.php
+++ b/src/Middleware/tests/MiddlewareRequestHandlerTest.php
@@ -20,9 +20,6 @@ use Aphiria\Net\Http\IHttpResponseMessage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the middleware request handler
- */
 class MiddlewareRequestHandlerTest extends TestCase
 {
     public function testHandlingRequestInvokesMiddlewareWithNextRequestHandler(): void

--- a/src/Net/tests/Formatting/UriParserTest.php
+++ b/src/Net/tests/Formatting/UriParserTest.php
@@ -17,9 +17,6 @@ use Aphiria\Net\Formatting\UriParser;
 use Aphiria\Net\Uri;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the URI parser
- */
 class UriParserTest extends TestCase
 {
     private UriParser $parser;

--- a/src/Net/tests/Http/ContentNegotiation/AcceptCharsetEncodingMatcherTest.php
+++ b/src/Net/tests/Http/ContentNegotiation/AcceptCharsetEncodingMatcherTest.php
@@ -20,9 +20,6 @@ use Aphiria\Net\Http\Request;
 use Aphiria\Net\Uri;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the Accept-Charset encoding matcher
- */
 class AcceptCharsetEncodingMatcherTest extends TestCase
 {
     private AcceptCharsetEncodingMatcher $matcher;

--- a/src/Net/tests/Http/ContentNegotiation/AcceptLanguageMatcherTest.php
+++ b/src/Net/tests/Http/ContentNegotiation/AcceptLanguageMatcherTest.php
@@ -19,9 +19,6 @@ use Aphiria\Net\Http\Request;
 use Aphiria\Net\Uri;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the accept language matcher
- */
 class AcceptLanguageMatcherTest extends TestCase
 {
     private HttpHeaders $headers;

--- a/src/Net/tests/Http/ContentNegotiation/ContentNegotiationResultTest.php
+++ b/src/Net/tests/Http/ContentNegotiation/ContentNegotiationResultTest.php
@@ -16,9 +16,6 @@ use Aphiria\Net\Http\ContentNegotiation\ContentNegotiationResult;
 use Aphiria\Net\Http\ContentNegotiation\MediaTypeFormatters\IMediaTypeFormatter;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the content negotiation result
- */
 class ContentNegotiationResultTest extends TestCase
 {
     public function testGettingEncodingReturnsSameOneInConstructor(): void

--- a/src/Net/tests/Http/ContentNegotiation/ContentNegotiatorTest.php
+++ b/src/Net/tests/Http/ContentNegotiation/ContentNegotiatorTest.php
@@ -22,9 +22,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the content negotiator
- */
 class ContentNegotiatorTest extends TestCase
 {
     /** @var IHttpRequestMessage|MockObject The request message to use in tests */

--- a/src/Net/tests/Http/ContentNegotiation/MediaTypeFormatterMatchTest.php
+++ b/src/Net/tests/Http/ContentNegotiation/MediaTypeFormatterMatchTest.php
@@ -17,9 +17,6 @@ use Aphiria\Net\Http\ContentNegotiation\MediaTypeFormatters\IMediaTypeFormatter;
 use Aphiria\Net\Http\Headers\ContentTypeHeaderValue;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the media type formatter match result
- */
 class MediaTypeFormatterMatchTest extends TestCase
 {
     public function testGettingFormatterReturnsSameOneInConstructor(): void

--- a/src/Net/tests/Http/ContentNegotiation/MediaTypeFormatterMatcherTest.php
+++ b/src/Net/tests/Http/ContentNegotiation/MediaTypeFormatterMatcherTest.php
@@ -23,9 +23,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the media type formatter matcher
- */
 class MediaTypeFormatterMatcherTest extends TestCase
 {
     private HttpHeaders $headers;

--- a/src/Net/tests/Http/ContentNegotiation/MediaTypeFormatters/FormUrlEncodedMediaTypeFormatterTest.php
+++ b/src/Net/tests/Http/ContentNegotiation/MediaTypeFormatters/FormUrlEncodedMediaTypeFormatterTest.php
@@ -20,9 +20,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the form URL-encoded media type formatter
- */
 class FormUrlEncodedMediaTypeFormatterTest extends TestCase
 {
     private FormUrlEncodedMediaTypeFormatter $formatter;

--- a/src/Net/tests/Http/ContentNegotiation/MediaTypeFormatters/HtmlMediaTypeFormatterTest.php
+++ b/src/Net/tests/Http/ContentNegotiation/MediaTypeFormatters/HtmlMediaTypeFormatterTest.php
@@ -19,9 +19,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the HTML media type formatter
- */
 class HtmlMediaTypeFormatterTest extends TestCase
 {
     private HtmlMediaTypeFormatter $formatter;

--- a/src/Net/tests/Http/ContentNegotiation/MediaTypeFormatters/JsonMediaTypeFormatterTest.php
+++ b/src/Net/tests/Http/ContentNegotiation/MediaTypeFormatters/JsonMediaTypeFormatterTest.php
@@ -22,9 +22,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the JSON media type formatter
- */
 class JsonMediaTypeFormatterTest extends TestCase
 {
     private JsonMediaTypeFormatter $formatter;

--- a/src/Net/tests/Http/ContentNegotiation/MediaTypeFormatters/PlainTextMediaTypeFormatterTest.php
+++ b/src/Net/tests/Http/ContentNegotiation/MediaTypeFormatters/PlainTextMediaTypeFormatterTest.php
@@ -19,9 +19,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the plain text media type formatter
- */
 class PlainTextMediaTypeFormatterTest extends TestCase
 {
     private PlainTextMediaTypeFormatter $formatter;

--- a/src/Net/tests/Http/ContentNegotiation/NegotiatedResponseFactoryTest.php
+++ b/src/Net/tests/Http/ContentNegotiation/NegotiatedResponseFactoryTest.php
@@ -33,9 +33,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the negotiated response factory
- */
 class NegotiatedResponseFactoryTest extends TestCase
 {
     private NegotiatedResponseFactory $factory;

--- a/src/Net/tests/Http/Formatting/HttpBodyParserTest.php
+++ b/src/Net/tests/Http/Formatting/HttpBodyParserTest.php
@@ -19,9 +19,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the HTTP body parser
- */
 class HttpBodyParserTest extends TestCase
 {
     private HttpBodyParser $parser;

--- a/src/Net/tests/Http/Formatting/HttpHeaderParserTest.php
+++ b/src/Net/tests/Http/Formatting/HttpHeaderParserTest.php
@@ -17,9 +17,6 @@ use Aphiria\Net\Http\Formatting\HttpHeaderParser;
 use Aphiria\Net\Http\HttpHeaders;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the HTTP header parser
- */
 class HttpHeaderParserTest extends TestCase
 {
     private HttpHeaderParser $parser;

--- a/src/Net/tests/Http/Formatting/RequestHeaderParserTest.php
+++ b/src/Net/tests/Http/Formatting/RequestHeaderParserTest.php
@@ -16,9 +16,6 @@ use Aphiria\Net\Http\Formatting\RequestHeaderParser;
 use Aphiria\Net\Http\HttpHeaders;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the request header parser
- */
 class RequestHeaderParserTest extends TestCase
 {
     private RequestHeaderParser $parser;

--- a/src/Net/tests/Http/Formatting/RequestParserTest.php
+++ b/src/Net/tests/Http/Formatting/RequestParserTest.php
@@ -25,9 +25,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the HTTP request message parser
- */
 class RequestParserTest extends TestCase
 {
     private RequestParser $parser;

--- a/src/Net/tests/Http/Formatting/ResponseFormatterTest.php
+++ b/src/Net/tests/Http/Formatting/ResponseFormatterTest.php
@@ -22,9 +22,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the HTTP response message formatter
- */
 class ResponseFormatterTest extends TestCase
 {
     private ResponseFormatter $formatter;

--- a/src/Net/tests/Http/Formatting/ResponseHeaderFormatterTest.php
+++ b/src/Net/tests/Http/Formatting/ResponseHeaderFormatterTest.php
@@ -18,9 +18,6 @@ use Aphiria\Net\Http\HttpHeaders;
 use DateTime;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the HTTP response header formatter
- */
 class ResponseHeaderFormatterTest extends TestCase
 {
     private ResponseHeaderFormatter $formatter;

--- a/src/Net/tests/Http/Headers/AcceptCharsetHeaderValueTest.php
+++ b/src/Net/tests/Http/Headers/AcceptCharsetHeaderValueTest.php
@@ -19,9 +19,6 @@ use Aphiria\Net\Http\Headers\AcceptCharsetHeaderValue;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the Accept-Charset header value
- */
 class AcceptCharsetHeaderValueTest extends TestCase
 {
     public function qualityScoreOutsideAcceptedRangeProvider(): array

--- a/src/Net/tests/Http/Headers/AcceptLanguageHeaderValueTest.php
+++ b/src/Net/tests/Http/Headers/AcceptLanguageHeaderValueTest.php
@@ -19,9 +19,6 @@ use Aphiria\Net\Http\Headers\AcceptLanguageHeaderValue;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the Accept-Language header value
- */
 class AcceptLanguageHeaderValueTest extends TestCase
 {
     public function qualityScoreOutsideAcceptedRangeProvider(): array

--- a/src/Net/tests/Http/Headers/AcceptMediaTypeHeaderValueTest.php
+++ b/src/Net/tests/Http/Headers/AcceptMediaTypeHeaderValueTest.php
@@ -18,9 +18,6 @@ use Aphiria\Net\Http\Headers\AcceptMediaTypeHeaderValue;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the Accept media type header value
- */
 class AcceptMediaTypeHeaderValueTest extends TestCase
 {
     public function qualityScoreOutsideAcceptedRangeProvider(): array

--- a/src/Net/tests/Http/Headers/ContentTypeHeaderValueTest.php
+++ b/src/Net/tests/Http/Headers/ContentTypeHeaderValueTest.php
@@ -19,9 +19,6 @@ use Aphiria\Net\Http\Headers\ContentTypeHeaderValue;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the Content-Type header value
- */
 class ContentTypeHeaderValueTest extends TestCase
 {
     public function testGettingCharsetReturnsOneSetInConstructor(): void

--- a/src/Net/tests/Http/Headers/CookieTest.php
+++ b/src/Net/tests/Http/Headers/CookieTest.php
@@ -17,9 +17,6 @@ use DateTime;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests cookies
- */
 class CookieTest extends TestCase
 {
     private Cookie $cookie;

--- a/src/Net/tests/Http/Headers/MediaTypeHeaderValueTest.php
+++ b/src/Net/tests/Http/Headers/MediaTypeHeaderValueTest.php
@@ -19,9 +19,6 @@ use Aphiria\Net\Http\Headers\MediaTypeHeaderValue;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the media type header value
- */
 class MediaTypeHeaderValueTest extends TestCase
 {
     public function testGettingCharsetReturnsOneSetInConstructor(): void

--- a/src/Net/tests/Http/HttpExceptionTest.php
+++ b/src/Net/tests/Http/HttpExceptionTest.php
@@ -18,9 +18,6 @@ use Exception;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the HTTP exception
- */
 class HttpExceptionTest extends TestCase
 {
     public function testCodeIsSameOneSetInConstructor(): void

--- a/src/Net/tests/Http/HttpHeadersTest.php
+++ b/src/Net/tests/Http/HttpHeadersTest.php
@@ -18,9 +18,6 @@ use InvalidArgumentException;
 use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the HTTP headers
- */
 class HttpHeadersTest extends TestCase
 {
     private HttpHeaders $headers;

--- a/src/Net/tests/Http/HttpStatusCodesTest.php
+++ b/src/Net/tests/Http/HttpStatusCodesTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Net\Tests\Http;
 use Aphiria\Net\Http\HttpStatusCodes;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the HTTP status codes
- */
 class HttpStatusCodesTest extends TestCase
 {
     public function testExistingStatusCodeReturnsDefaultStatusText(): void

--- a/src/Net/tests/Http/MultipartBodyPartTest.php
+++ b/src/Net/tests/Http/MultipartBodyPartTest.php
@@ -18,9 +18,6 @@ use Aphiria\Net\Http\MultipartBodyPart;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the multipart body part
- */
 class MultipartBodyPartTest extends TestCase
 {
     private MultipartBodyPart $bodyPart;

--- a/src/Net/tests/Http/MultipartBodyTest.php
+++ b/src/Net/tests/Http/MultipartBodyTest.php
@@ -21,9 +21,6 @@ use Aphiria\Net\Http\MultipartBodyPart;
 use Aphiria\Net\Http\StringBody;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the multipart body
- */
 class MultipartBodyTest extends TestCase
 {
     public function testGettingBoundaryReturnsBoundarySpecifiedInConstructor(): void

--- a/src/Net/tests/Http/RequestFactoryTest.php
+++ b/src/Net/tests/Http/RequestFactoryTest.php
@@ -17,9 +17,6 @@ use Aphiria\Net\Http\StreamBody;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the request factory
- */
 class RequestFactoryTest extends TestCase
 {
     private RequestFactory $factory;

--- a/src/Net/tests/Http/RequestTest.php
+++ b/src/Net/tests/Http/RequestTest.php
@@ -24,9 +24,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the request
- */
 class RequestTest extends TestCase
 {
     private Request $request;

--- a/src/Net/tests/Http/ResponseTest.php
+++ b/src/Net/tests/Http/ResponseTest.php
@@ -19,9 +19,6 @@ use Aphiria\Net\Http\Response;
 use Aphiria\Net\Http\StringBody;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the response class
- */
 class ResponseTest extends TestCase
 {
     public function testDefaultReasonPhraseIsSet(): void

--- a/src/Net/tests/Http/StreamBodyTest.php
+++ b/src/Net/tests/Http/StreamBodyTest.php
@@ -17,9 +17,6 @@ use Aphiria\Net\Http\StreamBody;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the stream body
- */
 class StreamBodyTest extends TestCase
 {
     public function testCastingToStringConvertsUnderlyingStreamToString(): void

--- a/src/Net/tests/Http/StreamResponseWriterTest.php
+++ b/src/Net/tests/Http/StreamResponseWriterTest.php
@@ -21,9 +21,6 @@ use Aphiria\Net\Http\StreamResponseWriter;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the stream response writer
- */
 class StreamResponseWriterTest extends TestCase
 {
     private StreamResponseWriter $writer;

--- a/src/Net/tests/Http/StringBodyTest.php
+++ b/src/Net/tests/Http/StringBodyTest.php
@@ -17,9 +17,6 @@ use Aphiria\Net\Http\StringBody;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the string body
- */
 class StringBodyTest extends TestCase
 {
     public function testCastingToStringReturnsContents(): void

--- a/src/Net/tests/UriTest.php
+++ b/src/Net/tests/UriTest.php
@@ -16,9 +16,6 @@ use Aphiria\Net\Uri;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the URI
- */
 class UriTest extends TestCase
 {
     private Uri $uri;

--- a/src/PsrAdapters/tests/Psr11/Psr11ContainerTest.php
+++ b/src/PsrAdapters/tests/Psr11/Psr11ContainerTest.php
@@ -21,9 +21,6 @@ use Aphiria\PsrAdapters\Psr11\Psr11Container;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the PSR-11 container
- */
 class Psr11ContainerTest extends TestCase
 {
     /** @var IContainer|MockObject */

--- a/src/PsrAdapters/tests/Psr11/Psr11FactoryTest.php
+++ b/src/PsrAdapters/tests/Psr11/Psr11FactoryTest.php
@@ -17,9 +17,6 @@ use Aphiria\PsrAdapters\Psr11\Psr11Container;
 use Aphiria\PsrAdapters\Psr11\Psr11Factory;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the PSR-11 factory
- */
 class Psr11FactoryTest extends TestCase
 {
     private Psr11Factory $containerFactory;

--- a/src/PsrAdapters/tests/Psr7/Psr7FactoryTest.php
+++ b/src/PsrAdapters/tests/Psr7/Psr7FactoryTest.php
@@ -32,9 +32,6 @@ use Nyholm\Psr7\Uri as Psr7Uri;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\UploadedFileInterface;
 
-/**
- * Tests the PSR-7 factory
- */
 class Psr7FactoryTest extends TestCase
 {
     private Psr7Factory $psr7Factory;

--- a/src/Reflection/tests/TypeFinderTest.php
+++ b/src/Reflection/tests/TypeFinderTest.php
@@ -21,9 +21,6 @@ use Aphiria\Reflection\TypeFinder;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the type finder
- */
 class TypeFinderTest extends TestCase
 {
     private const DIRECTORY = __DIR__ . '/Mocks';

--- a/src/Router/tests/Annotations/AnnotationRouteRegistrantTest.php
+++ b/src/Router/tests/Annotations/AnnotationRouteRegistrantTest.php
@@ -28,9 +28,6 @@ use Doctrine\Common\Annotations\Reader;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the annotation route registrant
- */
 class AnnotationRouteRegistrantTest extends TestCase
 {
     private const PATH = __DIR__;

--- a/src/Router/tests/Annotations/AnyTest.php
+++ b/src/Router/tests/Annotations/AnyTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests\Annotations;
 use Aphiria\Routing\Annotations\Any;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the annotation for any HTTP method
- */
 class AnyTest extends TestCase
 {
     public function testNoHttpMethodsSet(): void

--- a/src/Router/tests/Annotations/DeleteTest.php
+++ b/src/Router/tests/Annotations/DeleteTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests\Annotations;
 use Aphiria\Routing\Annotations\Delete;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the DELETE annotation
- */
 class DeleteTest extends TestCase
 {
     public function testDeleteHttpMethodIsSet(): void

--- a/src/Router/tests/Annotations/GetTest.php
+++ b/src/Router/tests/Annotations/GetTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests\Annotations;
 use Aphiria\Routing\Annotations\Get;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the GET annotation
- */
 class GetTest extends TestCase
 {
     public function testGetHttpMethodIsSet(): void

--- a/src/Router/tests/Annotations/MiddlewareTest.php
+++ b/src/Router/tests/Annotations/MiddlewareTest.php
@@ -16,9 +16,6 @@ use Aphiria\Routing\Annotations\Middleware;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the middleware annotation
- */
 class MiddlewareTest extends TestCase
 {
     public function testAttributesCanBeSetFromAttributes(): void

--- a/src/Router/tests/Annotations/OptionsTest.php
+++ b/src/Router/tests/Annotations/OptionsTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests\Annotations;
 use Aphiria\Routing\Annotations\Options;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the OPTIONS annotation
- */
 class OptionsTest extends TestCase
 {
     public function testOptionsHttpMethodIsSet(): void

--- a/src/Router/tests/Annotations/PatchTest.php
+++ b/src/Router/tests/Annotations/PatchTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests\Annotations;
 use Aphiria\Routing\Annotations\Patch;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the PATCH annotation
- */
 class PatchTest extends TestCase
 {
     public function testPatchHttpMethodIsSet(): void

--- a/src/Router/tests/Annotations/PostTest.php
+++ b/src/Router/tests/Annotations/PostTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests\Annotations;
 use Aphiria\Routing\Annotations\Post;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the POST annotation
- */
 class PostTest extends TestCase
 {
     public function testPostHttpMethodIsSet(): void

--- a/src/Router/tests/Annotations/PutTest.php
+++ b/src/Router/tests/Annotations/PutTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests\Annotations;
 use Aphiria\Routing\Annotations\Put;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the PUT annotation
- */
 class PutTest extends TestCase
 {
     public function testPutHttpMethodIsSet(): void

--- a/src/Router/tests/Annotations/RouteConstraintTest.php
+++ b/src/Router/tests/Annotations/RouteConstraintTest.php
@@ -16,9 +16,6 @@ use Aphiria\Routing\Annotations\RouteConstraint;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the route constraint annotation
- */
 class RouteConstraintTest extends TestCase
 {
     public function testConstructorParamsCanBeSetFromConstructorParams(): void

--- a/src/Router/tests/Annotations/RouteGroupTest.php
+++ b/src/Router/tests/Annotations/RouteGroupTest.php
@@ -16,9 +16,6 @@ use Aphiria\Routing\Annotations\RouteConstraint;
 use Aphiria\Routing\Annotations\RouteGroup;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the route group annotation
- */
 class RouteGroupTest extends TestCase
 {
     public function testDefaultValuesOfRoutePropertiesAreSet(): void

--- a/src/Router/tests/Annotations/RouteTest.php
+++ b/src/Router/tests/Annotations/RouteTest.php
@@ -16,9 +16,6 @@ use Aphiria\Routing\Annotations\Route;
 use Aphiria\Routing\Annotations\RouteConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the route annotation
- */
 class RouteTest extends TestCase
 {
     public function testDefaultValuesOfRoutePropertiesAreSet(): void

--- a/src/Router/tests/Annotations/TraceTest.php
+++ b/src/Router/tests/Annotations/TraceTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests\Annotations;
 use Aphiria\Routing\Annotations\Trace;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the TRACE annotation
- */
 class TraceTest extends TestCase
 {
     public function testTraceHttpMethodIsSet(): void

--- a/src/Router/tests/Builders/RouteBuilderRegistryTest.php
+++ b/src/Router/tests/Builders/RouteBuilderRegistryTest.php
@@ -20,9 +20,6 @@ use Aphiria\Routing\Matchers\Constraints\IRouteConstraint;
 use Aphiria\Routing\Middleware\MiddlewareBinding;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the route builder registry
- */
 class RouteBuilderRegistryTest extends TestCase
 {
     private RouteBuilderRegistry $registry;

--- a/src/Router/tests/Builders/RouteBuilderRouteRegistrantTest.php
+++ b/src/Router/tests/Builders/RouteBuilderRouteRegistrantTest.php
@@ -18,9 +18,6 @@ use Aphiria\Routing\RouteCollection;
 use Closure;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the route builder route registrant
- */
 class RouteBuilderRouteRegistrantTest extends TestCase
 {
     public function testConstructingWithInvalidCallbackThrowsException(): void

--- a/src/Router/tests/Builders/RouteBuilderTest.php
+++ b/src/Router/tests/Builders/RouteBuilderTest.php
@@ -21,9 +21,6 @@ use LogicException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Defines the tests for the route builder
- */
 class RouteBuilderTest extends TestCase
 {
     private RouteBuilder $routeBuilder;

--- a/src/Router/tests/Builders/RouteGroupOptionsTest.php
+++ b/src/Router/tests/Builders/RouteGroupOptionsTest.php
@@ -17,9 +17,6 @@ use Aphiria\Routing\Matchers\Constraints\IRouteConstraint;
 use Aphiria\Routing\Middleware\MiddlewareBinding;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the route group options
- */
 class RouteGroupOptionsTest extends TestCase
 {
     private RouteGroupOptions $routeGroupOptions;

--- a/src/Router/tests/Caching/FileRouteCacheTest.php
+++ b/src/Router/tests/Caching/FileRouteCacheTest.php
@@ -22,9 +22,6 @@ use Aphiria\Routing\RouteCollection;
 use Aphiria\Routing\UriTemplates\UriTemplate;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the file route cache
- */
 class FileRouteCacheTest extends TestCase
 {
     /** @var string The path to the route cache */

--- a/src/Router/tests/ClosureRouteActionTest.php
+++ b/src/Router/tests/ClosureRouteActionTest.php
@@ -16,9 +16,6 @@ use Aphiria\Routing\ClosureRouteAction;
 use Closure;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the closure route action
- */
 class ClosureRouteActionTest extends TestCase
 {
     private ClosureRouteAction $closureAction;

--- a/src/Router/tests/Matchers/Constraints/HttpMethodRouteConstraintTest.php
+++ b/src/Router/tests/Matchers/Constraints/HttpMethodRouteConstraintTest.php
@@ -20,9 +20,6 @@ use Aphiria\Routing\UriTemplates\UriTemplate;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the HTTP method constraint
- */
 class HttpMethodRouteConstraintTest extends TestCase
 {
     public function testCreatingWithLowercaseStringNormalizesItToUppercase(): void

--- a/src/Router/tests/Matchers/MatchedRouteCandidateTest.php
+++ b/src/Router/tests/Matchers/MatchedRouteCandidateTest.php
@@ -18,9 +18,6 @@ use Aphiria\Routing\Route;
 use Aphiria\Routing\UriTemplates\UriTemplate;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests a matched route candidate
- */
 class MatchedRouteCandidateTest extends TestCase
 {
     public function testPropertiesSetCorrectlyInConstructor(): void

--- a/src/Router/tests/Matchers/RouteMatchingResultTest.php
+++ b/src/Router/tests/Matchers/RouteMatchingResultTest.php
@@ -18,9 +18,6 @@ use Aphiria\Routing\Route;
 use Aphiria\Routing\UriTemplates\UriTemplate;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the route matching result
- */
 class RouteMatchingResultTest extends TestCase
 {
     public function testMatchFoundIsFalseIfMatchedRouteIsNull(): void

--- a/src/Router/tests/Matchers/TrieRouteMatcherTest.php
+++ b/src/Router/tests/Matchers/TrieRouteMatcherTest.php
@@ -24,9 +24,6 @@ use Aphiria\Routing\UriTemplates\Compilers\Tries\VariableTrieNode;
 use Aphiria\Routing\UriTemplates\UriTemplate;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the trie route matcher
- */
 class TrieRouteMatcherTest extends TestCase
 {
     private TrieRouteMatcher $matcher;

--- a/src/Router/tests/MethodRouteActionTest.php
+++ b/src/Router/tests/MethodRouteActionTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests;
 use Aphiria\Routing\MethodRouteAction;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the method route action
- */
 class MethodRouteActionTest extends TestCase
 {
     /** @const The name of the class used in our method action */

--- a/src/Router/tests/MiddlewareBindings/MiddlewareBindingTest.php
+++ b/src/Router/tests/MiddlewareBindings/MiddlewareBindingTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests\Middleware;
 use Aphiria\Routing\Middleware\MiddlewareBinding;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests middleware bindings
- */
 class MiddlewareBindingTest extends TestCase
 {
     public function testPropertiesAreSetInConstructor(): void

--- a/src/Router/tests/Requests/RequestHeaderParserTest.php
+++ b/src/Router/tests/Requests/RequestHeaderParserTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests\Requests;
 use Aphiria\Routing\Requests\RequestHeaderParser;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the request header parser
- */
 class RequestHeaderParserTest extends TestCase
 {
     /** @var array The $_SERVER super global to use */

--- a/src/Router/tests/RouteActionTest.php
+++ b/src/Router/tests/RouteActionTest.php
@@ -17,9 +17,6 @@ use Closure;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the route action
- */
 class RouteActionTest extends TestCase
 {
     /** @const The name of the class used in our method action */

--- a/src/Router/tests/RouteCollectionTest.php
+++ b/src/Router/tests/RouteCollectionTest.php
@@ -18,9 +18,6 @@ use Aphiria\Routing\RouteCollection;
 use Aphiria\Routing\UriTemplates\UriTemplate;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the route collection
- */
 class RouteCollectionTest extends TestCase
 {
     private RouteCollection $collection;

--- a/src/Router/tests/RouteRegistrantCollectionTest.php
+++ b/src/Router/tests/RouteRegistrantCollectionTest.php
@@ -21,9 +21,6 @@ use Aphiria\Routing\RouteRegistrantCollection;
 use Aphiria\Routing\UriTemplates\UriTemplate;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the route registrant collection
- */
 class RouteRegistrantCollectionTest extends TestCase
 {
     public function testAddingRegistrantCausesItToBeInvokedWhenRegisteringRoutes(): void

--- a/src/Router/tests/RouteTest.php
+++ b/src/Router/tests/RouteTest.php
@@ -19,9 +19,6 @@ use Aphiria\Routing\Route;
 use Aphiria\Routing\UriTemplates\UriTemplate;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests a route
- */
 class RouteTest extends TestCase
 {
     private Route $route;

--- a/src/Router/tests/UriTemplateTest.php
+++ b/src/Router/tests/UriTemplateTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests;
 use Aphiria\Routing\UriTemplates\UriTemplate;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the URI template
- */
 class UriTemplateTest extends TestCase
 {
     public function testHostIsNullIfNoValueIsSpecified(): void

--- a/src/Router/tests/UriTemplates/AstRouteUriFactoryTest.php
+++ b/src/Router/tests/UriTemplates/AstRouteUriFactoryTest.php
@@ -25,9 +25,6 @@ use Aphiria\Routing\UriTemplates\UriTemplate;
 use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the AST route URI factory
- */
 class AstRouteUriFactoryTest extends TestCase
 {
     private RouteCollection $routes;

--- a/src/Router/tests/UriTemplates/Compilers/Tries/Caching/FileTrieCacheTest.php
+++ b/src/Router/tests/UriTemplates/Compilers/Tries/Caching/FileTrieCacheTest.php
@@ -22,9 +22,6 @@ use Aphiria\Routing\UriTemplates\Compilers\Tries\RootTrieNode;
 use Aphiria\Routing\UriTemplates\UriTemplate;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the file trie cache
- */
 class FileTrieCacheTest extends TestCase
 {
     /** @var string The path to the trie cache */

--- a/src/Router/tests/UriTemplates/Compilers/Tries/LiteralTrieNodeTest.php
+++ b/src/Router/tests/UriTemplates/Compilers/Tries/LiteralTrieNodeTest.php
@@ -22,9 +22,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionException;
 
-/**
- * Tests the literal trie node
- */
 class LiteralTrieNodeTest extends TestCase
 {
     public function testCreatingWithSingleRouteConvertsItToArrayOfRoutes(): void

--- a/src/Router/tests/UriTemplates/Compilers/Tries/RouteVariableTest.php
+++ b/src/Router/tests/UriTemplates/Compilers/Tries/RouteVariableTest.php
@@ -16,9 +16,6 @@ use Aphiria\Routing\UriTemplates\Compilers\Tries\RouteVariable;
 use Aphiria\Routing\UriTemplates\Constraints\IRouteVariableConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the route variable
- */
 class RouteVariableTest extends TestCase
 {
     public function testPropertiesAreSetFromConstructor(): void

--- a/src/Router/tests/UriTemplates/Compilers/Tries/TrieCompilerTest.php
+++ b/src/Router/tests/UriTemplates/Compilers/Tries/TrieCompilerTest.php
@@ -34,9 +34,6 @@ use Aphiria\Routing\UriTemplates\UriTemplate;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the trie compiler
- */
 class TrieCompilerTest extends TestCase
 {
     private TrieCompiler $compiler;

--- a/src/Router/tests/UriTemplates/Compilers/Tries/TrieFactoryTest.php
+++ b/src/Router/tests/UriTemplates/Compilers/Tries/TrieFactoryTest.php
@@ -24,9 +24,6 @@ use Aphiria\Routing\UriTemplates\UriTemplate;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the trie factory
- */
 class TrieFactoryTest extends TestCase
 {
     private TrieFactory $trieFactory;

--- a/src/Router/tests/UriTemplates/Compilers/Tries/TrieNodeTest.php
+++ b/src/Router/tests/UriTemplates/Compilers/Tries/TrieNodeTest.php
@@ -24,9 +24,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionException;
 
-/**
- * Tests the trie node
- */
 class TrieNodeTest extends TestCase
 {
     /** @var TrieNode|MockObject */

--- a/src/Router/tests/UriTemplates/Compilers/Tries/VariableTrieNodeTest.php
+++ b/src/Router/tests/UriTemplates/Compilers/Tries/VariableTrieNodeTest.php
@@ -24,9 +24,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the variable trie node
- */
 class VariableTrieNodeTest extends TestCase
 {
     public function testCreatingWithEmptyPartsThrowsException(): void

--- a/src/Router/tests/UriTemplates/Constraints/AlphaConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/AlphaConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests\UriTemplates\Constraints;
 use Aphiria\Routing\UriTemplates\Constraints\AlphaConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the alpha constraint
- */
 class AlphaConstraintTest extends TestCase
 {
     public function testAlphaCharsPass(): void

--- a/src/Router/tests/UriTemplates/Constraints/AlphanumericConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/AlphanumericConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests\UriTemplates\Constraints;
 use Aphiria\Routing\UriTemplates\Constraints\AlphanumericConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the alphanumeric constraint
- */
 class AlphanumericConstraintTest extends TestCase
 {
     public function testAlphanumericCharsPass(): void

--- a/src/Router/tests/UriTemplates/Constraints/BetweenConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/BetweenConstraintTest.php
@@ -16,9 +16,6 @@ use Aphiria\Routing\UriTemplates\Constraints\BetweenConstraint;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the between constraint
- */
 class BetweenConstraintTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void

--- a/src/Router/tests/UriTemplates/Constraints/DateConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/DateConstraintTest.php
@@ -17,9 +17,6 @@ use DateTime;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the date constraint
- */
 class DateConstraintTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void

--- a/src/Router/tests/UriTemplates/Constraints/InConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/InConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests\UriTemplates\Constraints;
 use Aphiria\Routing\UriTemplates\Constraints\InConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the in-array constraint
- */
 class InConstraintTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void

--- a/src/Router/tests/UriTemplates/Constraints/IntegerConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/IntegerConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests\UriTemplates\Constraints;
 use Aphiria\Routing\UriTemplates\Constraints\IntegerConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the integer constraint
- */
 class IntegerConstraintTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void

--- a/src/Router/tests/UriTemplates/Constraints/NotInConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/NotInConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests\UriTemplates\Constraints;
 use Aphiria\Routing\UriTemplates\Constraints\NotInConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the not-in-array constraint
- */
 class NotInConstraintTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void

--- a/src/Router/tests/UriTemplates/Constraints/NumericConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/NumericConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests\UriTemplates\Constraints;
 use Aphiria\Routing\UriTemplates\Constraints\NumericConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the numeric constraint
- */
 class NumericConstraintTest extends TestCase
 {
     public function testAlphaCharsPass(): void

--- a/src/Router/tests/UriTemplates/Constraints/RegexConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/RegexConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests\UriTemplates\Constraints;
 use Aphiria\Routing\UriTemplates\Constraints\RegexConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the regex constraint
- */
 class RegexConstraintTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void

--- a/src/Router/tests/UriTemplates/Constraints/RouteVariableConstraintFactoryRegistrantTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/RouteVariableConstraintFactoryRegistrantTest.php
@@ -26,9 +26,6 @@ use Aphiria\Routing\UriTemplates\Constraints\RouteVariableConstraintFactoryRegis
 use Aphiria\Routing\UriTemplates\Constraints\UuidV4Constraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the route variable constraint factory registrant
- */
 class RouteVariableConstraintFactoryRegistrantTest extends TestCase
 {
     private RouteVariableConstraintFactoryRegistrant $registrant;

--- a/src/Router/tests/UriTemplates/Constraints/RouteVariableConstraintFactoryTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/RouteVariableConstraintFactoryTest.php
@@ -18,9 +18,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * Tests the route variable constraint factory
- */
 class RouteVariableConstraintFactoryTest extends TestCase
 {
     private RouteVariableConstraintFactory $constraintFactory;

--- a/src/Router/tests/UriTemplates/Constraints/UuidV4ConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/UuidV4ConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Routing\Tests\UriTemplates\Constraints;
 use Aphiria\Routing\UriTemplates\Constraints\UuidV4Constraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the UUIDV4 constraint
- */
 class UuidV4ConstraintTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void

--- a/src/Router/tests/UriTemplates/Lexers/TokenStreamTest.php
+++ b/src/Router/tests/UriTemplates/Lexers/TokenStreamTest.php
@@ -17,9 +17,6 @@ use Aphiria\Routing\UriTemplates\Lexers\TokenStream;
 use Aphiria\Routing\UriTemplates\Lexers\UnexpectedTokenException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the lexer token stream
- */
 class TokenStreamTest extends TestCase
 {
     public function testCheckingNextTypeAlwaysReturnsNextType(): void

--- a/src/Router/tests/UriTemplates/Lexers/TokenTest.php
+++ b/src/Router/tests/UriTemplates/Lexers/TokenTest.php
@@ -16,9 +16,6 @@ use Aphiria\Routing\UriTemplates\Lexers\Token;
 use Aphiria\Routing\UriTemplates\Lexers\TokenTypes;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests a lexer token
- */
 class TokenTest extends TestCase
 {
     public function testPropertiesAreSetInConstructor(): void

--- a/src/Router/tests/UriTemplates/Lexers/UriTemplateLexerTest.php
+++ b/src/Router/tests/UriTemplates/Lexers/UriTemplateLexerTest.php
@@ -19,9 +19,6 @@ use Aphiria\Routing\UriTemplates\Lexers\TokenTypes;
 use Aphiria\Routing\UriTemplates\Lexers\UriTemplateLexer;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the URI template lexer
- */
 class UriTemplateLexerTest extends TestCase
 {
     private UriTemplateLexer $lexer;

--- a/src/Router/tests/UriTemplates/Parsers/AstNodeTest.php
+++ b/src/Router/tests/UriTemplates/Parsers/AstNodeTest.php
@@ -16,9 +16,6 @@ use Aphiria\Routing\UriTemplates\Parsers\AstNode;
 use Aphiria\Routing\UriTemplates\Parsers\AstNodeTypes;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the abstract syntax tree node
- */
 class AstNodeTest extends TestCase
 {
     public function testCheckingForChildrenReturnsCorrectValue(): void

--- a/src/Router/tests/UriTemplates/Parsers/UriTemplateParserTest.php
+++ b/src/Router/tests/UriTemplates/Parsers/UriTemplateParserTest.php
@@ -21,9 +21,6 @@ use Aphiria\Routing\UriTemplates\Parsers\AstNodeTypes;
 use Aphiria\Routing\UriTemplates\Parsers\UriTemplateParser;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the URI template parser
- */
 class UriTemplateParserTest extends TestCase
 {
     private UriTemplateParser $parser;

--- a/src/Serialization/tests/Encoding/ArrayEncoderTest.php
+++ b/src/Serialization/tests/Encoding/ArrayEncoderTest.php
@@ -19,9 +19,6 @@ use Aphiria\Serialization\Encoding\IEncoder;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the array encoder
- */
 class ArrayEncoderTest extends TestCase
 {
     private EncoderRegistry $encoders;

--- a/src/Serialization/tests/Encoding/CamelCasePropertyNameFormatterTest.php
+++ b/src/Serialization/tests/Encoding/CamelCasePropertyNameFormatterTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Serialization\Tests\Encoding;
 use Aphiria\Serialization\Encoding\CamelCasePropertyNameFormatter;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the camel case property name formatter
- */
 class CamelCasePropertyNameFormatterTest extends TestCase
 {
     private CamelCasePropertyNameFormatter $formatter;

--- a/src/Serialization/tests/Encoding/DateTimeEncoderTest.php
+++ b/src/Serialization/tests/Encoding/DateTimeEncoderTest.php
@@ -20,9 +20,6 @@ use DateTimeInterface;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the DateTime encoder
- */
 class DateTimeEncoderTest extends TestCase
 {
     private DateTimeEncoder $dateTimeEncoder;

--- a/src/Serialization/tests/Encoding/EncoderRegistryTest.php
+++ b/src/Serialization/tests/Encoding/EncoderRegistryTest.php
@@ -19,9 +19,6 @@ use OutOfBoundsException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the encoder registry
- */
 class EncoderRegistryTest extends TestCase
 {
     private EncoderRegistry $encoderRegistry;

--- a/src/Serialization/tests/Encoding/EncodingContextTest.php
+++ b/src/Serialization/tests/Encoding/EncodingContextTest.php
@@ -16,9 +16,6 @@ use Aphiria\Serialization\Encoding\EncodingContext;
 use Aphiria\Serialization\Tests\Encoding\Mocks\User;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the encoding context
- */
 class EncodingContextTest extends TestCase
 {
     private EncodingContext $context;

--- a/src/Serialization/tests/Encoding/ObjectEncoderTest.php
+++ b/src/Serialization/tests/Encoding/ObjectEncoderTest.php
@@ -46,9 +46,6 @@ use Aphiria\Serialization\Tests\Encoding\Mocks\User;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the object encoder
- */
 class ObjectEncoderTest extends TestCase
 {
     private EncoderRegistry $encoders;

--- a/src/Serialization/tests/Encoding/ScalarEncoderTest.php
+++ b/src/Serialization/tests/Encoding/ScalarEncoderTest.php
@@ -17,9 +17,6 @@ use Aphiria\Serialization\Encoding\ScalarEncoder;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the scalar encoder
- */
 class ScalarEncoderTest extends TestCase
 {
     private ScalarEncoder $scalarEncoder;

--- a/src/Serialization/tests/Encoding/SnakeCasePropertyNameFormatterTest.php
+++ b/src/Serialization/tests/Encoding/SnakeCasePropertyNameFormatterTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Serialization\Tests\Encoding;
 use Aphiria\Serialization\Encoding\SnakeCasePropertyNameFormatter;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the snake case property name formatter
- */
 class SnakeCasePropertyNameFormatterTest extends TestCase
 {
     private SnakeCasePropertyNameFormatter $formatter;

--- a/src/Serialization/tests/FormUrlEncodedSerializerTest.php
+++ b/src/Serialization/tests/FormUrlEncodedSerializerTest.php
@@ -20,9 +20,6 @@ use Aphiria\Serialization\SerializationException;
 use Aphiria\Serialization\Tests\Encoding\Mocks\User;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the form URL-encoded serializer
- */
 class FormUrlEncodedSerializerTest extends TestCase
 {
     private FormUrlEncodedSerializer $serializer;

--- a/src/Serialization/tests/JsonSerializerTest.php
+++ b/src/Serialization/tests/JsonSerializerTest.php
@@ -21,9 +21,6 @@ use Aphiria\Serialization\SerializationException;
 use Aphiria\Serialization\Tests\Encoding\Mocks\User;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the JSON serializer
- */
 class JsonSerializerTest extends TestCase
 {
     private JsonSerializer $serializer;

--- a/src/Serialization/tests/TypeResolverTest.php
+++ b/src/Serialization/tests/TypeResolverTest.php
@@ -16,9 +16,6 @@ use Aphiria\Serialization\Tests\Encoding\Mocks\User;
 use Aphiria\Serialization\TypeResolver;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the type resolver
- */
 class TypeResolverTest extends TestCase
 {
     public function testGettingArrayTypeReturnsNullForNonTypedArrays(): void

--- a/src/Sessions/tests/Handlers/ArraySessionDriverTest.php
+++ b/src/Sessions/tests/Handlers/ArraySessionDriverTest.php
@@ -16,9 +16,6 @@ use Aphiria\Sessions\Handlers\ArraySessionDriver;
 use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the array session driver
- */
 class ArraySessionDriverTest extends TestCase
 {
     private ArraySessionDriver $driver;

--- a/src/Sessions/tests/Handlers/DriverSessionHandlerTest.php
+++ b/src/Sessions/tests/Handlers/DriverSessionHandlerTest.php
@@ -19,9 +19,6 @@ use Aphiria\Sessions\Handlers\SessionEncryptionException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the session handler powered by a driver
- */
 class DriverSessionHandlerTest extends TestCase
 {
     /** @var ISessionDriver|MockObject */

--- a/src/Sessions/tests/Handlers/FileSessionDriverTest.php
+++ b/src/Sessions/tests/Handlers/FileSessionDriverTest.php
@@ -16,9 +16,6 @@ use Aphiria\Sessions\Handlers\FileSessionDriver;
 use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the file session driver
- */
 class FileSessionDriverTest extends TestCase
 {
     private const BASE_PATH = __DIR__ . '/tmp';

--- a/src/Sessions/tests/Ids/UuidV4IdGeneratorTest.php
+++ b/src/Sessions/tests/Ids/UuidV4IdGeneratorTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Sessions\Tests\Ids;
 use Aphiria\Sessions\Ids\UuidV4IdGenerator;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the UUID V4 ID generator
- */
 class UuidV4IdGeneratorTest extends TestCase
 {
     private UuidV4IdGenerator $idGenerator;

--- a/src/Sessions/tests/Middleware/SessionTest.php
+++ b/src/Sessions/tests/Middleware/SessionTest.php
@@ -22,9 +22,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use SessionHandlerInterface;
 
-/**
- * Tests the session middleware
- */
 class SessionTest extends TestCase
 {
     /** @var ISession|MockObject */

--- a/src/Sessions/tests/SessionTest.php
+++ b/src/Sessions/tests/SessionTest.php
@@ -17,9 +17,6 @@ use Aphiria\Sessions\Session;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests sessions
- */
 class SessionTest extends TestCase
 {
     public function testAgingFlashDataEvictsOldData(): void

--- a/src/Validation/tests/Builders/ObjectConstraintsBuilderRegistrantTest.php
+++ b/src/Validation/tests/Builders/ObjectConstraintsBuilderRegistrantTest.php
@@ -18,9 +18,6 @@ use Aphiria\Validation\Constraints\IConstraint;
 use Aphiria\Validation\Constraints\ObjectConstraintsRegistry;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the closure constraint registrant
- */
 class ObjectConstraintsBuilderRegistrantTest extends TestCase
 {
     public function testRegisteringConstraintsRegistersConstraintsFromClosures(): void

--- a/src/Validation/tests/Builders/ObjectConstraintsBuilderTest.php
+++ b/src/Validation/tests/Builders/ObjectConstraintsBuilderTest.php
@@ -16,9 +16,6 @@ use Aphiria\Validation\Builders\ObjectConstraintsBuilder;
 use Aphiria\Validation\Constraints\IConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the object constraints builder
- */
 class ObjectConstraintsBuilderTest extends TestCase
 {
     private ObjectConstraintsBuilder $builder;

--- a/src/Validation/tests/Builders/ObjectConstraintsRegistryBuilderTest.php
+++ b/src/Validation/tests/Builders/ObjectConstraintsRegistryBuilderTest.php
@@ -17,9 +17,6 @@ use Aphiria\Validation\Constraints\ObjectConstraints;
 use Aphiria\Validation\Constraints\ObjectConstraintsRegistry;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the object constraints registry builder
- */
 class ObjectConstraintsRegistryBuilderTest extends TestCase
 {
     private ObjectConstraintsRegistryBuilder $builder;

--- a/src/Validation/tests/ConstraintViolationTest.php
+++ b/src/Validation/tests/ConstraintViolationTest.php
@@ -16,9 +16,6 @@ use Aphiria\Validation\Constraints\IConstraint;
 use Aphiria\Validation\ConstraintViolation;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the constraint violation
- */
 class ConstraintViolationTest extends TestCase
 {
     public function testGettingErrorMessageReturnsOneSetInConstructor(): void

--- a/src/Validation/tests/Constraints/AlphaConstraintTest.php
+++ b/src/Validation/tests/Constraints/AlphaConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints;
 use Aphiria\Validation\Constraints\AlphaConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the alphabetic constraint
- */
 class AlphaConstraintTest extends TestCase
 {
     public function testFailingValue(): void

--- a/src/Validation/tests/Constraints/AlphanumericConstraintTest.php
+++ b/src/Validation/tests/Constraints/AlphanumericConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints;
 use Aphiria\Validation\Constraints\AlphanumericConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the alpha-numeric constraint
- */
 class AlphanumericConstraintTest extends TestCase
 {
     public function testFailingValue(): void

--- a/src/Validation/tests/Constraints/Annotations/AlphaTest.php
+++ b/src/Validation/tests/Constraints/Annotations/AlphaTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints\Annotations;
 use Aphiria\Validation\Constraints\Annotations\Alpha;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the alpha constraint annotation
- */
 class AlphaTest extends TestCase
 {
     public function testCreatingConstraintFromAnnotationCreatesCorrectConstraint(): void

--- a/src/Validation/tests/Constraints/Annotations/AlphanumericTest.php
+++ b/src/Validation/tests/Constraints/Annotations/AlphanumericTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints\Annotations;
 use Aphiria\Validation\Constraints\Annotations\Alphanumeric;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the alphanumeric constraint annotation
- */
 class AlphanumericTest extends TestCase
 {
     public function testCreatingConstraintFromAnnotationCreatesCorrectConstraint(): void

--- a/src/Validation/tests/Constraints/Annotations/AnnotationConstraintsRegistrantTest.php
+++ b/src/Validation/tests/Constraints/Annotations/AnnotationConstraintsRegistrantTest.php
@@ -22,9 +22,6 @@ use Doctrine\Common\Annotations\Reader;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the annotation constraint registrant
- */
 class AnnotationConstraintsRegistrantTest extends TestCase
 {
     private const PATH = __DIR__;

--- a/src/Validation/tests/Constraints/Annotations/BetweenTest.php
+++ b/src/Validation/tests/Constraints/Annotations/BetweenTest.php
@@ -16,9 +16,6 @@ use Aphiria\Validation\Constraints\Annotations\Between;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the between constraint annotation
- */
 class BetweenTest extends TestCase
 {
     public function testCreatingConstraintFromAnnotationCreatesCorrectConstraint(): void

--- a/src/Validation/tests/Constraints/Annotations/DateTest.php
+++ b/src/Validation/tests/Constraints/Annotations/DateTest.php
@@ -16,9 +16,6 @@ use Aphiria\Validation\Constraints\Annotations\Date;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the date constraint annotation
- */
 class DateTest extends TestCase
 {
     public function testCreatingConstraintFromAnnotationCreatesCorrectConstraint(): void

--- a/src/Validation/tests/Constraints/Annotations/EachTest.php
+++ b/src/Validation/tests/Constraints/Annotations/EachTest.php
@@ -18,9 +18,6 @@ use Aphiria\Validation\Constraints\Annotations\Required;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the each constraint annotation
- */
 class EachTest extends TestCase
 {
     public function testCreatingConstraintFromAnnotationCreatesCorrectConstraint(): void

--- a/src/Validation/tests/Constraints/Annotations/EmailTest.php
+++ b/src/Validation/tests/Constraints/Annotations/EmailTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints\Annotations;
 use Aphiria\Validation\Constraints\Annotations\Email;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the email constraint annotation
- */
 class EmailTest extends TestCase
 {
     public function testCreatingConstraintFromAnnotationCreatesCorrectConstraint(): void

--- a/src/Validation/tests/Constraints/Annotations/EqualsTest.php
+++ b/src/Validation/tests/Constraints/Annotations/EqualsTest.php
@@ -16,9 +16,6 @@ use Aphiria\Validation\Constraints\Annotations\Equals;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the equals constraint annotation
- */
 class EqualsTest extends TestCase
 {
     public function testCreatingConstraintFromAnnotationCreatesCorrectConstraint(): void

--- a/src/Validation/tests/Constraints/Annotations/IPAddressTest.php
+++ b/src/Validation/tests/Constraints/Annotations/IPAddressTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints\Annotations;
 use Aphiria\Validation\Constraints\Annotations\IPAddress;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the IP address constraint annotation
- */
 class IPAddressTest extends TestCase
 {
     public function testCreatingConstraintFromAnnotationCreatesCorrectConstraint(): void

--- a/src/Validation/tests/Constraints/Annotations/InTest.php
+++ b/src/Validation/tests/Constraints/Annotations/InTest.php
@@ -16,9 +16,6 @@ use Aphiria\Validation\Constraints\Annotations\In;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the in constraint annotation
- */
 class InTest extends TestCase
 {
     public function testCreatingConstraintFromAnnotationCreatesCorrectConstraint(): void

--- a/src/Validation/tests/Constraints/Annotations/IntegerTest.php
+++ b/src/Validation/tests/Constraints/Annotations/IntegerTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints\Annotations;
 use Aphiria\Validation\Constraints\Annotations\Integer;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the integer constraint annotation
- */
 class IntegerTest extends TestCase
 {
     public function testCreatingConstraintFromAnnotationCreatesCorrectConstraint(): void

--- a/src/Validation/tests/Constraints/Annotations/MaxTest.php
+++ b/src/Validation/tests/Constraints/Annotations/MaxTest.php
@@ -16,9 +16,6 @@ use Aphiria\Validation\Constraints\Annotations\Max;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the max constraint annotation
- */
 class MaxTest extends TestCase
 {
     public function testCreatingConstraintFromAnnotationCreatesCorrectConstraint(): void

--- a/src/Validation/tests/Constraints/Annotations/MinTest.php
+++ b/src/Validation/tests/Constraints/Annotations/MinTest.php
@@ -16,9 +16,6 @@ use Aphiria\Validation\Constraints\Annotations\Min;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the min constraint annotation
- */
 class MinTest extends TestCase
 {
     public function testCreatingConstraintFromAnnotationCreatesCorrectConstraint(): void

--- a/src/Validation/tests/Constraints/Annotations/NotInTest.php
+++ b/src/Validation/tests/Constraints/Annotations/NotInTest.php
@@ -16,9 +16,6 @@ use Aphiria\Validation\Constraints\Annotations\NotIn;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the not-in constraint annotation
- */
 class NotInTest extends TestCase
 {
     public function testCreatingConstraintFromAnnotationCreatesCorrectConstraint(): void

--- a/src/Validation/tests/Constraints/Annotations/NumericTest.php
+++ b/src/Validation/tests/Constraints/Annotations/NumericTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints\Annotations;
 use Aphiria\Validation\Constraints\Annotations\Numeric;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the numeric constraint annotation
- */
 class NumericTest extends TestCase
 {
     public function testCreatingConstraintFromAnnotationCreatesCorrectConstraint(): void

--- a/src/Validation/tests/Constraints/Annotations/RegexTest.php
+++ b/src/Validation/tests/Constraints/Annotations/RegexTest.php
@@ -16,9 +16,6 @@ use Aphiria\Validation\Constraints\Annotations\Regex;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the regex constraint annotation
- */
 class RegexTest extends TestCase
 {
     public function testCreatingConstraintFromAnnotationCreatesCorrectConstraint(): void

--- a/src/Validation/tests/Constraints/Annotations/RequiredTest.php
+++ b/src/Validation/tests/Constraints/Annotations/RequiredTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints\Annotations;
 use Aphiria\Validation\Constraints\Annotations\Required;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the required constraint annotation
- */
 class RequiredTest extends TestCase
 {
     public function testCreatingConstraintFromAnnotationCreatesCorrectConstraint(): void

--- a/src/Validation/tests/Constraints/BetweenConstraintTest.php
+++ b/src/Validation/tests/Constraints/BetweenConstraintTest.php
@@ -16,9 +16,6 @@ use Aphiria\Validation\Constraints\BetweenConstraint;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the between constraint
- */
 class BetweenConstraintTest extends TestCase
 {
     public function testFailingConstraint(): void

--- a/src/Validation/tests/Constraints/Caching/FileObjectConstraintsRegistryCacheTest.php
+++ b/src/Validation/tests/Constraints/Caching/FileObjectConstraintsRegistryCacheTest.php
@@ -18,9 +18,6 @@ use Aphiria\Validation\Constraints\ObjectConstraintsRegistry;
 use Aphiria\Validation\Tests\Constraints\Mocks\MockConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the file constraint registry cache
- */
 class FileObjectConstraintsRegistryCacheTest extends TestCase
 {
     /** @var string The path to the constraint cache */

--- a/src/Validation/tests/Constraints/CallbackConstraintTest.php
+++ b/src/Validation/tests/Constraints/CallbackConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints;
 use Aphiria\Validation\Constraints\CallbackConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the callback constraint
- */
 class CallbackConstraintTest extends TestCase
 {
     public function testCallbackIsExecuted(): void

--- a/src/Validation/tests/Constraints/ConstraintTest.php
+++ b/src/Validation/tests/Constraints/ConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints;
 use Aphiria\Validation\Constraints\Constraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the constraint
- */
 class ConstraintTest extends TestCase
 {
     private Constraint $constraint;

--- a/src/Validation/tests/Constraints/DateConstraintTest.php
+++ b/src/Validation/tests/Constraints/DateConstraintTest.php
@@ -17,9 +17,6 @@ use DateTime;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the date constraint
- */
 class DateConstraintTest extends TestCase
 {
     public function testEmptyAcceptableFormatsThrowsException(): void

--- a/src/Validation/tests/Constraints/EachConstraintTest.php
+++ b/src/Validation/tests/Constraints/EachConstraintTest.php
@@ -17,9 +17,6 @@ use Aphiria\Validation\Constraints\IConstraint;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the each constraint
- */
 class EachConstraintTest extends TestCase
 {
     public function testGettingErrorMessagePlaceholdersIncludesValue(): void

--- a/src/Validation/tests/Constraints/EmailConstraintTest.php
+++ b/src/Validation/tests/Constraints/EmailConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints;
 use Aphiria\Validation\Constraints\EmailConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the email constraint
- */
 class EmailConstraintTest extends TestCase
 {
     public function testGettingErrorMessageId(): void

--- a/src/Validation/tests/Constraints/EqualsConstraintTest.php
+++ b/src/Validation/tests/Constraints/EqualsConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints;
 use Aphiria\Validation\Constraints\EqualsConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the equals constraint
- */
 class EqualsConstraintTest extends TestCase
 {
     public function testEqualValuesPass(): void

--- a/src/Validation/tests/Constraints/IPAddressConstraintTest.php
+++ b/src/Validation/tests/Constraints/IPAddressConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints;
 use Aphiria\Validation\Constraints\IPAddressConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the IP address constraint
- */
 class IPAddressConstraintTest extends TestCase
 {
     public function testFailingValue(): void

--- a/src/Validation/tests/Constraints/InConstraintTest.php
+++ b/src/Validation/tests/Constraints/InConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints;
 use Aphiria\Validation\Constraints\InConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the in-array constraint
- */
 class InConstraintTest extends TestCase
 {
     public function testGettingErrorMessageId(): void

--- a/src/Validation/tests/Constraints/IntegerConstraintTest.php
+++ b/src/Validation/tests/Constraints/IntegerConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints;
 use Aphiria\Validation\Constraints\IntegerConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the integer constraint
- */
 class IntegerConstraintTest extends TestCase
 {
     public function testFailingValue(): void

--- a/src/Validation/tests/Constraints/MaxConstraintTest.php
+++ b/src/Validation/tests/Constraints/MaxConstraintTest.php
@@ -16,9 +16,6 @@ use Aphiria\Validation\Constraints\MaxConstraint;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the max constraint
- */
 class MaxConstraintTest extends TestCase
 {
     public function testFailingConstraint(): void

--- a/src/Validation/tests/Constraints/MinConstraintTest.php
+++ b/src/Validation/tests/Constraints/MinConstraintTest.php
@@ -16,9 +16,6 @@ use Aphiria\Validation\Constraints\MinConstraint;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the min constraint
- */
 class MinConstraintTest extends TestCase
 {
     public function testFailingConstraint(): void

--- a/src/Validation/tests/Constraints/NotInConstraintTest.php
+++ b/src/Validation/tests/Constraints/NotInConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints;
 use Aphiria\Validation\Constraints\NotInConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the not-in-array constraint
- */
 class NotInConstraintTest extends TestCase
 {
     public function testGettingErrorMessageId(): void

--- a/src/Validation/tests/Constraints/NumericConstraintTest.php
+++ b/src/Validation/tests/Constraints/NumericConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints;
 use Aphiria\Validation\Constraints\NumericConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the numeric constraint
- */
 class NumericConstraintTest extends TestCase
 {
     public function testFailingValue(): void

--- a/src/Validation/tests/Constraints/ObjectConstraintsRegistrantCollectionTest.php
+++ b/src/Validation/tests/Constraints/ObjectConstraintsRegistrantCollectionTest.php
@@ -19,9 +19,6 @@ use Aphiria\Validation\Constraints\ObjectConstraintsRegistrantCollection;
 use Aphiria\Validation\Constraints\ObjectConstraintsRegistry;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the object constraints registrant collection
- */
 class ObjectConstraintsRegistrantCollectionTest extends TestCase
 {
     public function testAddingRegistrantCausesItToBeInvokedWhenRegisteringRoutes(): void

--- a/src/Validation/tests/Constraints/ObjectConstraintsRegistryTest.php
+++ b/src/Validation/tests/Constraints/ObjectConstraintsRegistryTest.php
@@ -16,9 +16,6 @@ use Aphiria\Validation\Constraints\ObjectConstraints;
 use Aphiria\Validation\Constraints\ObjectConstraintsRegistry;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the object constraint registry
- */
 class ObjectConstraintsRegistryTest extends TestCase
 {
     private ObjectConstraintsRegistry $objectConstraints;

--- a/src/Validation/tests/Constraints/ObjectConstraintsTest.php
+++ b/src/Validation/tests/Constraints/ObjectConstraintsTest.php
@@ -16,9 +16,6 @@ use Aphiria\Validation\Constraints\IConstraint;
 use Aphiria\Validation\Constraints\ObjectConstraints;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests object constraints
- */
 class ObjectConstraintsTest extends TestCase
 {
     public function testAddingMultipleMethodConstraintsMakesThemGettable(): void

--- a/src/Validation/tests/Constraints/RegexConstraintTest.php
+++ b/src/Validation/tests/Constraints/RegexConstraintTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\Constraints;
 use Aphiria\Validation\Constraints\RegexConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the regex constraint
- */
 class RegexConstraintTest extends TestCase
 {
     public function testGettingErrorMessageId(): void

--- a/src/Validation/tests/Constraints/RequiredConstraintTest.php
+++ b/src/Validation/tests/Constraints/RequiredConstraintTest.php
@@ -16,9 +16,6 @@ use Aphiria\Validation\Constraints\RequiredConstraint;
 use Countable;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the required constraint
- */
 class RequiredConstraintTest extends TestCase
 {
     public function testEmptyArrayFails(): void

--- a/src/Validation/tests/ErrorMessages/DefaultErrorMessageTemplateRegistryTest.php
+++ b/src/Validation/tests/ErrorMessages/DefaultErrorMessageTemplateRegistryTest.php
@@ -15,9 +15,6 @@ namespace Aphiria\Validation\Tests\ErrorMessages;
 use Aphiria\Validation\ErrorMessages\DefaultErrorMessageTemplateRegistry;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the default error message template registry
- */
 class DefaultErrorMessageTemplateRegistryTest extends TestCase
 {
     public function testGetErrorMessageTemplateReturnsErrorMessageIdRegardlessOfLocale(): void

--- a/src/Validation/tests/ErrorMessages/IcuFormatErrorMessageInterpolatorTest.php
+++ b/src/Validation/tests/ErrorMessages/IcuFormatErrorMessageInterpolatorTest.php
@@ -17,9 +17,6 @@ use Aphiria\Validation\ErrorMessages\IcuFormatErrorMessageInterpolator;
 use Aphiria\Validation\ErrorMessages\IErrorMessageTemplateRegistry;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the ICU format error message interpolator
- */
 class IcuFormatErrorMessageInterpolatorTest extends TestCase
 {
     public function testInterpolatingCorrectlyFormatsIcuFormattedErrorMessageIdWithNoPlaceholders(): void

--- a/src/Validation/tests/ErrorMessages/StringReplaceErrorMessageInterpolatorTest.php
+++ b/src/Validation/tests/ErrorMessages/StringReplaceErrorMessageInterpolatorTest.php
@@ -16,9 +16,6 @@ use Aphiria\Validation\ErrorMessages\IErrorMessageTemplateRegistry;
 use Aphiria\Validation\ErrorMessages\StringReplaceErrorMessageInterpolator;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the string replacement error message interpolator
- */
 class StringReplaceErrorMessageInterpolatorTest extends TestCase
 {
     public function testErrorMessageIdWithNoPlaceholdersIsReturnedIntact(): void

--- a/src/Validation/tests/ValidationContextTest.php
+++ b/src/Validation/tests/ValidationContextTest.php
@@ -18,9 +18,6 @@ use Aphiria\Validation\ConstraintViolation;
 use Aphiria\Validation\ValidationContext;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the validation context
- */
 class ValidationContextTest extends TestCase
 {
     public function testAddingManyConstraintViolations(): void

--- a/src/Validation/tests/ValidationExceptionTest.php
+++ b/src/Validation/tests/ValidationExceptionTest.php
@@ -17,9 +17,6 @@ use Aphiria\Validation\ConstraintViolation;
 use Aphiria\Validation\ValidationException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the validation exception
- */
 class ValidationExceptionTest extends TestCase
 {
     public function testViolationsAreSameOnesPassedViaConstructor(): void

--- a/src/Validation/tests/ValidatorTest.php
+++ b/src/Validation/tests/ValidatorTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Aphiria\Validation\Tests;
 
-use Aphiria\Collections\Tests\Mocks\MockObject;
+use Aphiria\Collections\Tests\Mocks\FakeObject;
 use Aphiria\Validation\CircularDependencyException;
 use Aphiria\Validation\Constraints\IConstraint;
 use Aphiria\Validation\Constraints\ObjectConstraints;
@@ -24,14 +24,11 @@ use Aphiria\Validation\Validator;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the validator
- */
 class ValidatorTest extends TestCase
 {
     private Validator $validator;
     private ObjectConstraintsRegistry $objectConstraints;
-    /** @var IErrorMessageInterpolator|MockObject */
+    /** @var IErrorMessageInterpolator|FakeObject */
     private IErrorMessageInterpolator $errorMessageInterpolator;
 
     protected function setUp(): void


### PR DESCRIPTION
…nfo, renamed "MockObject" to "FakeObject" so that it wouldn't get confused with the MockObject provided by PHPUnit