### PR TITLE
Using the assertSame to make assert equals strict

### DIFF
--- a/src/Api/tests/Controllers/ControllerParameterResolverTest.php
+++ b/src/Api/tests/Controllers/ControllerParameterResolverTest.php
@@ -213,7 +213,7 @@ class ControllerParameterResolverTest extends TestCase
             $this->createMock(IRequest::class),
             ['foo' => 'bar']
         );
-        $this->assertEquals('bar', $resolvedParameter);
+        $this->assertSame('bar', $resolvedParameter);
     }
 
     public function testResolvingScalarParameterWithUnsupportedTypeThrowsException(): void
@@ -279,7 +279,7 @@ class ControllerParameterResolverTest extends TestCase
             $this->createRequestWithoutBody('http://foo.com'),
             []
         );
-        $this->assertEquals('bar', $resolvedParameter);
+        $this->assertSame('bar', $resolvedParameter);
     }
 
     public function testResolvingStringParameterUsesMatchingQueryStringVariable(): void
@@ -289,7 +289,7 @@ class ControllerParameterResolverTest extends TestCase
             $this->createRequestWithoutBody('http://foo.com/?foo=bar'),
             []
         );
-        $this->assertEquals('bar', $resolvedParameter);
+        $this->assertSame('bar', $resolvedParameter);
     }
 
     public function testResolvingStringParameterUsesMatchingRouteVariableOverQueryStringVariable(): void
@@ -299,7 +299,7 @@ class ControllerParameterResolverTest extends TestCase
             $this->createRequestWithoutBody('http://foo.com/?foo=baz'),
             ['foo' => 'dave']
         );
-        $this->assertEquals('dave', $resolvedParameter);
+        $this->assertSame('dave', $resolvedParameter);
     }
 
     /**

--- a/src/Api/tests/Controllers/ControllerTest.php
+++ b/src/Api/tests/Controllers/ControllerTest.php
@@ -127,7 +127,7 @@ class ControllerTest extends TestCase
         $expectedBody = $this->createMock(IBody::class);
         $expectedHeaders = new Headers();
         $response = $this->controller->accepted($expectedBody, $expectedHeaders);
-        $this->assertEquals(HttpStatusCodes::HTTP_ACCEPTED, $response->getStatusCode());
+        $this->assertSame(HttpStatusCodes::HTTP_ACCEPTED, $response->getStatusCode());
         $this->assertSame($expectedBody, $response->getBody());
         $this->assertSame($expectedHeaders, $response->getHeaders());
     }
@@ -138,7 +138,7 @@ class ControllerTest extends TestCase
         $expectedBody = $this->createMock(IBody::class);
         $expectedHeaders = new Headers();
         $response = $this->controller->badRequest($expectedBody, $expectedHeaders);
-        $this->assertEquals(HttpStatusCodes::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertSame(HttpStatusCodes::HTTP_BAD_REQUEST, $response->getStatusCode());
         $this->assertSame($expectedBody, $response->getBody());
         $this->assertSame($expectedHeaders, $response->getHeaders());
     }
@@ -149,7 +149,7 @@ class ControllerTest extends TestCase
         $expectedBody = $this->createMock(IBody::class);
         $expectedHeaders = new Headers();
         $response = $this->controller->conflict($expectedBody, $expectedHeaders);
-        $this->assertEquals(HttpStatusCodes::HTTP_CONFLICT, $response->getStatusCode());
+        $this->assertSame(HttpStatusCodes::HTTP_CONFLICT, $response->getStatusCode());
         $this->assertSame($expectedBody, $response->getBody());
         $this->assertSame($expectedHeaders, $response->getHeaders());
     }
@@ -170,8 +170,8 @@ class ControllerTest extends TestCase
         $expectedBody = $this->createMock(IBody::class);
         $expectedHeaders = new Headers();
         $response = $this->controller->created('https://example.com', $expectedBody, $expectedHeaders);
-        $this->assertEquals(HttpStatusCodes::HTTP_CREATED, $response->getStatusCode());
-        $this->assertEquals('https://example.com', $response->getHeaders()->getFirst('Location'));
+        $this->assertSame(HttpStatusCodes::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame('https://example.com', $response->getHeaders()->getFirst('Location'));
         $this->assertSame($expectedBody, $response->getBody());
         $this->assertSame($expectedHeaders, $response->getHeaders());
     }
@@ -182,8 +182,8 @@ class ControllerTest extends TestCase
         $expectedBody = $this->createMock(IBody::class);
         $expectedHeaders = new Headers();
         $response = $this->controller->created(new Uri('https://example.com'), $expectedBody, $expectedHeaders);
-        $this->assertEquals(HttpStatusCodes::HTTP_CREATED, $response->getStatusCode());
-        $this->assertEquals('https://example.com', $response->getHeaders()->getFirst('Location'));
+        $this->assertSame(HttpStatusCodes::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame('https://example.com', $response->getHeaders()->getFirst('Location'));
         $this->assertSame($expectedBody, $response->getBody());
         $this->assertSame($expectedHeaders, $response->getHeaders());
     }
@@ -204,8 +204,8 @@ class ControllerTest extends TestCase
         $expectedBody = $this->createMock(IBody::class);
         $expectedHeaders = new Headers();
         $response = $this->controller->found('https://example.com', $expectedBody, $expectedHeaders);
-        $this->assertEquals(HttpStatusCodes::HTTP_FOUND, $response->getStatusCode());
-        $this->assertEquals('https://example.com', $response->getHeaders()->getFirst('Location'));
+        $this->assertSame(HttpStatusCodes::HTTP_FOUND, $response->getStatusCode());
+        $this->assertSame('https://example.com', $response->getHeaders()->getFirst('Location'));
         $this->assertSame($expectedBody, $response->getBody());
         $this->assertSame($expectedHeaders, $response->getHeaders());
     }
@@ -216,8 +216,8 @@ class ControllerTest extends TestCase
         $expectedBody = $this->createMock(IBody::class);
         $expectedHeaders = new Headers();
         $response = $this->controller->found(new Uri('https://example.com'), $expectedBody, $expectedHeaders);
-        $this->assertEquals(HttpStatusCodes::HTTP_FOUND, $response->getStatusCode());
-        $this->assertEquals('https://example.com', $response->getHeaders()->getFirst('Location'));
+        $this->assertSame(HttpStatusCodes::HTTP_FOUND, $response->getStatusCode());
+        $this->assertSame('https://example.com', $response->getHeaders()->getFirst('Location'));
         $this->assertSame($expectedBody, $response->getBody());
         $this->assertSame($expectedHeaders, $response->getHeaders());
     }
@@ -228,7 +228,7 @@ class ControllerTest extends TestCase
         $expectedBody = $this->createMock(IBody::class);
         $expectedHeaders = new Headers();
         $response = $this->controller->forbidden($expectedBody, $expectedHeaders);
-        $this->assertEquals(HttpStatusCodes::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertSame(HttpStatusCodes::HTTP_FORBIDDEN, $response->getStatusCode());
         $this->assertSame($expectedBody, $response->getBody());
         $this->assertSame($expectedHeaders, $response->getHeaders());
     }
@@ -256,7 +256,7 @@ class ControllerTest extends TestCase
                 $helperCallback();
                 $this->fail('Failed to throw exception');
             } catch (LogicException $ex) {
-                $this->assertEquals('Request is not set', $ex->getMessage());
+                $this->assertSame('Request is not set', $ex->getMessage());
             }
         }
     }
@@ -267,7 +267,7 @@ class ControllerTest extends TestCase
         $expectedBody = $this->createMock(IBody::class);
         $expectedHeaders = new Headers();
         $response = $this->controller->internalServerError($expectedBody, $expectedHeaders);
-        $this->assertEquals(HttpStatusCodes::HTTP_INTERNAL_SERVER_ERROR, $response->getStatusCode());
+        $this->assertSame(HttpStatusCodes::HTTP_INTERNAL_SERVER_ERROR, $response->getStatusCode());
         $this->assertSame($expectedBody, $response->getBody());
         $this->assertSame($expectedHeaders, $response->getHeaders());
     }
@@ -288,8 +288,8 @@ class ControllerTest extends TestCase
         $expectedBody = $this->createMock(IBody::class);
         $expectedHeaders = new Headers();
         $response = $this->controller->movedPermanently('https://example.com', $expectedBody, $expectedHeaders);
-        $this->assertEquals(HttpStatusCodes::HTTP_MOVED_PERMANENTLY, $response->getStatusCode());
-        $this->assertEquals('https://example.com', $response->getHeaders()->getFirst('Location'));
+        $this->assertSame(HttpStatusCodes::HTTP_MOVED_PERMANENTLY, $response->getStatusCode());
+        $this->assertSame('https://example.com', $response->getHeaders()->getFirst('Location'));
         $this->assertSame($expectedBody, $response->getBody());
         $this->assertSame($expectedHeaders, $response->getHeaders());
     }
@@ -300,8 +300,8 @@ class ControllerTest extends TestCase
         $expectedBody = $this->createMock(IBody::class);
         $expectedHeaders = new Headers();
         $response = $this->controller->movedPermanently(new Uri('https://example.com'), $expectedBody, $expectedHeaders);
-        $this->assertEquals(HttpStatusCodes::HTTP_MOVED_PERMANENTLY, $response->getStatusCode());
-        $this->assertEquals('https://example.com', $response->getHeaders()->getFirst('Location'));
+        $this->assertSame(HttpStatusCodes::HTTP_MOVED_PERMANENTLY, $response->getStatusCode());
+        $this->assertSame('https://example.com', $response->getHeaders()->getFirst('Location'));
         $this->assertSame($expectedBody, $response->getBody());
         $this->assertSame($expectedHeaders, $response->getHeaders());
     }
@@ -311,7 +311,7 @@ class ControllerTest extends TestCase
         $this->controller->setRequest($this->request);
         $expectedHeaders = new Headers();
         $response = $this->controller->noContent($expectedHeaders);
-        $this->assertEquals(HttpStatusCodes::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame(HttpStatusCodes::HTTP_NO_CONTENT, $response->getStatusCode());
         $this->assertSame($expectedHeaders, $response->getHeaders());
     }
 
@@ -321,7 +321,7 @@ class ControllerTest extends TestCase
         $expectedBody = $this->createMock(IBody::class);
         $expectedHeaders = new Headers();
         $response = $this->controller->notFound($expectedBody, $expectedHeaders);
-        $this->assertEquals(HttpStatusCodes::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame(HttpStatusCodes::HTTP_NOT_FOUND, $response->getStatusCode());
         $this->assertSame($expectedBody, $response->getBody());
         $this->assertSame($expectedHeaders, $response->getHeaders());
     }
@@ -332,7 +332,7 @@ class ControllerTest extends TestCase
         $expectedBody = $this->createMock(IBody::class);
         $expectedHeaders = new Headers();
         $response = $this->controller->ok($expectedBody, $expectedHeaders);
-        $this->assertEquals(HttpStatusCodes::HTTP_OK, $response->getStatusCode());
+        $this->assertSame(HttpStatusCodes::HTTP_OK, $response->getStatusCode());
         $this->assertSame($expectedBody, $response->getBody());
         $this->assertSame($expectedHeaders, $response->getHeaders());
     }
@@ -371,8 +371,8 @@ class ControllerTest extends TestCase
             $this->controller->readRequestBodyAs('foo');
             $this->fail('Failed to throw exception');
         } catch (HttpException $ex) {
-            $this->assertEquals(HttpStatusCodes::HTTP_UNSUPPORTED_MEDIA_TYPE, $ex->getResponse()->getStatusCode());
-            $this->assertEquals('Failed to negotiate request content with type foo', $ex->getMessage());
+            $this->assertSame(HttpStatusCodes::HTTP_UNSUPPORTED_MEDIA_TYPE, $ex->getResponse()->getStatusCode());
+            $this->assertSame('Failed to negotiate request content with type foo', $ex->getMessage());
         }
     }
 
@@ -401,8 +401,8 @@ class ControllerTest extends TestCase
             $this->controller->readRequestBodyAs('foo');
             $this->fail('Failed to throw exception');
         } catch (HttpException $ex) {
-            $this->assertEquals(HttpStatusCodes::HTTP_UNPROCESSABLE_ENTITY, $ex->getResponse()->getStatusCode());
-            $this->assertEquals('Failed to deserialize request body when resolving body as type foo', $ex->getMessage());
+            $this->assertSame(HttpStatusCodes::HTTP_UNPROCESSABLE_ENTITY, $ex->getResponse()->getStatusCode());
+            $this->assertSame('Failed to deserialize request body when resolving body as type foo', $ex->getMessage());
         }
     }
 
@@ -427,7 +427,7 @@ class ControllerTest extends TestCase
             ->willReturn(new StringBody('foo'));
         $this->controller->setContentNegotiator($contentNegotiator);
         $this->controller->setRequest($this->request);
-        $this->assertEquals('bar', $this->controller->readRequestBodyAs('foo'));
+        $this->assertSame('bar', $this->controller->readRequestBodyAs('foo'));
     }
 
     public function testUnauthorizedCreatesCorrectResponse(): void
@@ -436,7 +436,7 @@ class ControllerTest extends TestCase
         $expectedBody = $this->createMock(IBody::class);
         $expectedHeaders = new Headers();
         $response = $this->controller->unauthorized($expectedBody, $expectedHeaders);
-        $this->assertEquals(HttpStatusCodes::HTTP_UNAUTHORIZED, $response->getStatusCode());
+        $this->assertSame(HttpStatusCodes::HTTP_UNAUTHORIZED, $response->getStatusCode());
         $this->assertSame($expectedBody, $response->getBody());
         $this->assertSame($expectedHeaders, $response->getHeaders());
     }

--- a/src/Api/tests/Controllers/RouteActionInvokerTest.php
+++ b/src/Api/tests/Controllers/RouteActionInvokerTest.php
@@ -81,7 +81,7 @@ class RouteActionInvokerTest extends TestCase
             );
             $this->fail('Failed to assert that a 415 was thrown');
         } catch (HttpException $ex) {
-            $this->assertEquals(HttpStatusCodes::HTTP_UNSUPPORTED_MEDIA_TYPE, $ex->getResponse()->getStatusCode());
+            $this->assertSame(HttpStatusCodes::HTTP_UNSUPPORTED_MEDIA_TYPE, $ex->getResponse()->getStatusCode());
         }
     }
 
@@ -99,7 +99,7 @@ class RouteActionInvokerTest extends TestCase
             );
             $this->fail('Failed to assert that a 400 was thrown');
         } catch (HttpException $ex) {
-            $this->assertEquals(HttpStatusCodes::HTTP_BAD_REQUEST, $ex->getResponse()->getStatusCode());
+            $this->assertSame(HttpStatusCodes::HTTP_BAD_REQUEST, $ex->getResponse()->getStatusCode());
         }
     }
 
@@ -107,7 +107,7 @@ class RouteActionInvokerTest extends TestCase
     {
         $expectedResponse = $this->createMock(IResponse::class);
         $closure = function (int $foo) use ($expectedResponse) {
-            $this->assertEquals(123, $foo);
+            $this->assertSame(123, $foo);
 
             return $expectedResponse;
         };
@@ -176,7 +176,7 @@ class RouteActionInvokerTest extends TestCase
             []
         );
         $this->assertNotNull($response->getBody());
-        $this->assertEquals('noParameters', $response->getBody()->readAsString());
+        $this->assertSame('noParameters', $response->getBody()->readAsString());
     }
 
     public function testInvokingMethodWithValidObjectParameterDoesNotThrowException(): void
@@ -207,7 +207,7 @@ class RouteActionInvokerTest extends TestCase
             []
         );
         $this->assertNull($response->getBody());
-        $this->assertEquals(HttpStatusCodes::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame(HttpStatusCodes::HTTP_NO_CONTENT, $response->getStatusCode());
     }
 
     public function testInvokingRouteActionWithUnreflectableRouteActionDelegateThrowsException(): void
@@ -255,7 +255,7 @@ class RouteActionInvokerTest extends TestCase
             );
             $this->fail('Failed to assert that a 400 was thrown');
         } catch (HttpException $ex) {
-            $this->assertEquals(HttpStatusCodes::HTTP_BAD_REQUEST, $ex->getResponse()->getStatusCode());
+            $this->assertSame(HttpStatusCodes::HTTP_BAD_REQUEST, $ex->getResponse()->getStatusCode());
         }
     }
 
@@ -291,7 +291,7 @@ class RouteActionInvokerTest extends TestCase
             );
             $this->fail('Failed to assert that a 522 was thrown');
         } catch (HttpException $ex) {
-            $this->assertEquals(HttpStatusCodes::HTTP_UNPROCESSABLE_ENTITY, $ex->getResponse()->getStatusCode());
+            $this->assertSame(HttpStatusCodes::HTTP_UNPROCESSABLE_ENTITY, $ex->getResponse()->getStatusCode());
         }
     }
 

--- a/src/Api/tests/Errors/ProblemDetailsResponseMutatorTest.php
+++ b/src/Api/tests/Errors/ProblemDetailsResponseMutatorTest.php
@@ -44,20 +44,20 @@ class ProblemDetailsResponseMutatorTest extends TestCase
     {
         $this->headers->add('Content-Type', 'application/json');
         $mutatedResponse = $this->mutator->mutateResponse($this->response);
-        $this->assertEquals('application/problem+json', $mutatedResponse->getHeaders()->getFirst('Content-Type'));
+        $this->assertSame('application/problem+json', $mutatedResponse->getHeaders()->getFirst('Content-Type'));
         $this->headers->add('Content-Type', 'text/json');
         $mutatedResponse = $this->mutator->mutateResponse($this->response);
-        $this->assertEquals('application/problem+json', $mutatedResponse->getHeaders()->getFirst('Content-Type'));
+        $this->assertSame('application/problem+json', $mutatedResponse->getHeaders()->getFirst('Content-Type'));
     }
 
     public function testMutatingResponseWithAcceptableXmlContentTypesGetChangedToProblemDetailsXmlContentType(): void
     {
         $this->headers->add('Content-Type', 'application/xml');
         $mutatedResponse = $this->mutator->mutateResponse($this->response);
-        $this->assertEquals('application/problem+xml', $mutatedResponse->getHeaders()->getFirst('Content-Type'));
+        $this->assertSame('application/problem+xml', $mutatedResponse->getHeaders()->getFirst('Content-Type'));
         $this->headers->add('Content-Type', 'text/xml');
         $mutatedResponse = $this->mutator->mutateResponse($this->response);
-        $this->assertEquals('application/problem+xml', $mutatedResponse->getHeaders()->getFirst('Content-Type'));
+        $this->assertSame('application/problem+xml', $mutatedResponse->getHeaders()->getFirst('Content-Type'));
     }
 
     public function testMutatingResponseWithNoContentTypeDoesNothing(): void
@@ -73,6 +73,6 @@ class ProblemDetailsResponseMutatorTest extends TestCase
     {
         $this->headers->add('Content-Type', 'foo/bar');
         $mutatedResponse = $this->mutator->mutateResponse($this->response);
-        $this->assertEquals('foo/bar', $mutatedResponse->getHeaders()->getFirst('Content-Type'));
+        $this->assertSame('foo/bar', $mutatedResponse->getHeaders()->getFirst('Content-Type'));
     }
 }

--- a/src/Api/tests/Errors/ProblemDetailsTest.php
+++ b/src/Api/tests/Errors/ProblemDetailsTest.php
@@ -20,10 +20,10 @@ class ProblemDetailsTest extends TestCase
     public function testConstructorSetsProperties(): void
     {
         $problemDetails = new ProblemDetails('type', 'title', 'detail', 1, 'instance');
-        $this->assertEquals('type', $problemDetails->type);
-        $this->assertEquals('title', $problemDetails->title);
-        $this->assertEquals('detail', $problemDetails->detail);
-        $this->assertEquals(1, $problemDetails->status);
-        $this->assertEquals('instance', $problemDetails->instance);
+        $this->assertSame('type', $problemDetails->type);
+        $this->assertSame('title', $problemDetails->title);
+        $this->assertSame('detail', $problemDetails->detail);
+        $this->assertSame(1, $problemDetails->status);
+        $this->assertSame('instance', $problemDetails->instance);
     }
 }

--- a/src/Api/tests/RouterTest.php
+++ b/src/Api/tests/RouterTest.php
@@ -93,7 +93,7 @@ class RouterTest extends TestCase
             ->willReturn($matchingResult);
         $this->router->handle($request);
         // Test that the middleware actually set the headers
-        $this->assertEquals('bar', $middleware->getAttribute('foo'));
+        $this->assertSame('bar', $middleware->getAttribute('foo'));
     }
 
     public function testInvalidMiddlewareThrowsExceptionThatIsCaught(): void
@@ -142,7 +142,7 @@ class RouterTest extends TestCase
             $this->router->handle($request);
         } catch (HttpException $ex) {
             $exceptionThrown = true;
-            $this->assertEquals('GET', $ex->getResponse()->getHeaders()->getFirst('Allow'));
+            $this->assertSame('GET', $ex->getResponse()->getHeaders()->getFirst('Allow'));
         }
 
         $this->assertTrue($exceptionThrown, 'Failed to throw exception');
@@ -207,7 +207,7 @@ class RouterTest extends TestCase
             $this->router->handle($request);
             $this->fail('Failed to throw exception');
         } catch (HttpException $ex) {
-            $this->assertEquals(HttpStatusCodes::HTTP_NOT_FOUND, $ex->getResponse()->getStatusCode());
+            $this->assertSame(HttpStatusCodes::HTTP_NOT_FOUND, $ex->getResponse()->getStatusCode());
         }
     }
 

--- a/src/Api/tests/Validation/RequestBodyValidatorTest.php
+++ b/src/Api/tests/Validation/RequestBodyValidatorTest.php
@@ -105,7 +105,7 @@ class RequestBodyValidatorTest extends TestCase
             $this->fail('Failed to assert that ' . InvalidRequestBodyException::class . ' is thrown');
         } catch (InvalidRequestBodyException $ex) {
             $this->assertEquals(['error1', 'error2'], $ex->getErrors());
-            $this->assertEquals('Invalid request body', $ex->getMessage());
+            $this->assertSame('Invalid request body', $ex->getMessage());
             // Dummy assertion
             $this->assertTrue(true);
         }

--- a/src/Api/tests/Validation/ValidationProblemDetailsTest.php
+++ b/src/Api/tests/Validation/ValidationProblemDetailsTest.php
@@ -21,10 +21,10 @@ class ValidationProblemDetailsTest extends TestCase
     {
         $problemDetails = new ValidationProblemDetails(['error'], 'type', 'title', 'detail', 1, 'instance');
         $this->assertEquals(['error'], $problemDetails->errors);
-        $this->assertEquals('type', $problemDetails->type);
-        $this->assertEquals('title', $problemDetails->title);
-        $this->assertEquals('detail', $problemDetails->detail);
-        $this->assertEquals(1, $problemDetails->status);
-        $this->assertEquals('instance', $problemDetails->instance);
+        $this->assertSame('type', $problemDetails->type);
+        $this->assertSame('title', $problemDetails->title);
+        $this->assertSame('detail', $problemDetails->detail);
+        $this->assertSame(1, $problemDetails->status);
+        $this->assertSame('instance', $problemDetails->instance);
     }
 }

--- a/src/Application/tests/Configuration/Bootstrappers/ConfigurationBootstrapperTest.php
+++ b/src/Application/tests/Configuration/Bootstrappers/ConfigurationBootstrapperTest.php
@@ -35,6 +35,6 @@ class ConfigurationBootstrapperTest extends TestCase
         $expectedConfiguration = new HashTableConfiguration(['foo' => 'bar']);
         $this->globalConfigurationBuilder->withConfigurationSource($expectedConfiguration);
         $this->configurationBootstrapper->bootstrap();
-        $this->assertEquals('bar', GlobalConfiguration::getString('foo'));
+        $this->assertSame('bar', GlobalConfiguration::getString('foo'));
     }
 }

--- a/src/Application/tests/Configuration/Bootstrappers/DotEnvBootstrapperTest.php
+++ b/src/Application/tests/Configuration/Bootstrappers/DotEnvBootstrapperTest.php
@@ -27,6 +27,6 @@ class DotEnvBootstrapperTest extends TestCase
     public function testBootstrapReadsDotEnvFilesIntoEnvironmentVariables(): void
     {
         $this->dotEnvBootstrapper->bootstrap();
-        $this->assertEquals('bar', \getenv('FOO'));
+        $this->assertSame('bar', \getenv('FOO'));
     }
 }

--- a/src/Application/tests/Configuration/GlobalConfigurationBuilderTest.php
+++ b/src/Application/tests/Configuration/GlobalConfigurationBuilderTest.php
@@ -35,8 +35,8 @@ class GlobalConfigurationBuilderTest extends TestCase
         $this->builder->withConfigurationSource($configurationSource1)
             ->withConfigurationSource($configurationSource2)
             ->build();
-        $this->assertEquals('bar', GlobalConfiguration::getString('foo'));
-        $this->assertEquals('blah', GlobalConfiguration::getString('baz'));
+        $this->assertSame('bar', GlobalConfiguration::getString('foo'));
+        $this->assertSame('blah', GlobalConfiguration::getString('baz'));
     }
 
     public function testBuildRemovesExistingSources(): void
@@ -47,7 +47,7 @@ class GlobalConfigurationBuilderTest extends TestCase
             ->build();
         $value = null;
         $this->assertFalse(GlobalConfiguration::tryGetString('foo', $value));
-        $this->assertEquals('blah', GlobalConfiguration::getString('baz'));
+        $this->assertSame('blah', GlobalConfiguration::getString('baz'));
     }
 
     public function testWithEnvironmentVariablesAddsConfigurationSourceWithEnvironmentVariables(): void
@@ -57,7 +57,7 @@ class GlobalConfigurationBuilderTest extends TestCase
         $_ENV[$varName] = 'foo';
         $this->builder->withEnvironmentVariables()
             ->build();
-        $this->assertEquals('foo', GlobalConfiguration::getString($varName));
+        $this->assertSame('foo', GlobalConfiguration::getString($varName));
     }
 
     public function testWithEnvironmentVariablesIncludesVariablesSetAfterSourceIsAdded(): void
@@ -67,7 +67,7 @@ class GlobalConfigurationBuilderTest extends TestCase
         $varName = '__aphiria_test_' . __METHOD__;
         $_ENV[$varName] = 'foo';
         $this->builder->build();
-        $this->assertEquals('foo', GlobalConfiguration::getString($varName));
+        $this->assertSame('foo', GlobalConfiguration::getString($varName));
     }
 
     public function testWithJsonFileAddsConfigurationSourceFromContentsOfJsonFile(): void
@@ -77,7 +77,7 @@ class GlobalConfigurationBuilderTest extends TestCase
             $this->builder->withJsonFileConfigurationSource(__DIR__ . '/files/configuration.json')
         );
         $this->builder->build();
-        $this->assertEquals('bar', GlobalConfiguration::getString('foo'));
+        $this->assertSame('bar', GlobalConfiguration::getString('foo'));
     }
 
     public function testWithJsonFileThatContainsInvalidJsonThrowsException(): void
@@ -104,7 +104,7 @@ class GlobalConfigurationBuilderTest extends TestCase
             $this->builder->withJsonFileConfigurationSource(__DIR__ . '/files/configuration-delimiter.json', ':')
         );
         $this->builder->build();
-        $this->assertEquals('baz', GlobalConfiguration::getString('foo:bar'));
+        $this->assertSame('baz', GlobalConfiguration::getString('foo:bar'));
     }
 
     public function testWithPhpFileAddsConfigurationSourceFromContentsOfPhpFile(): void
@@ -114,7 +114,7 @@ class GlobalConfigurationBuilderTest extends TestCase
             $this->builder->withPhpFileConfigurationSource(__DIR__ . '/files/configuration.php')
         );
         $this->builder->build();
-        $this->assertEquals('bar', GlobalConfiguration::getString('foo'));
+        $this->assertSame('bar', GlobalConfiguration::getString('foo'));
     }
 
     public function testWithPhpFileDefersReadingOfFilesUntilBuild(): void
@@ -127,7 +127,7 @@ class GlobalConfigurationBuilderTest extends TestCase
         $this->builder->withPhpFileConfigurationSource(__DIR__ . '/files/configuration-env-var.php');
         \putenv('__APHIRIA_TEST=bar');
         $this->builder->build();
-        $this->assertEquals('bar', GlobalConfiguration::getString('foo'));
+        $this->assertSame('bar', GlobalConfiguration::getString('foo'));
     }
 
     public function testWithPhpFileThatContainsInvalidPhpThrowsException(): void
@@ -154,6 +154,6 @@ class GlobalConfigurationBuilderTest extends TestCase
             $this->builder->withPhpFileConfigurationSource(__DIR__ . '/files/configuration-delimiter.php', ':')
         );
         $this->builder->build();
-        $this->assertEquals('baz', GlobalConfiguration::getString('foo:bar'));
+        $this->assertSame('baz', GlobalConfiguration::getString('foo:bar'));
     }
 }

--- a/src/Application/tests/Configuration/GlobalConfigurationTest.php
+++ b/src/Application/tests/Configuration/GlobalConfigurationTest.php
@@ -29,8 +29,8 @@ class GlobalConfigurationTest extends TestCase
     {
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(['foo' => 'bar']));
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(['baz' => 'blah']));
-        $this->assertEquals('bar', GlobalConfiguration::getValue('foo'));
-        $this->assertEquals('blah', GlobalConfiguration::getValue('baz'));
+        $this->assertSame('bar', GlobalConfiguration::getValue('foo'));
+        $this->assertSame('blah', GlobalConfiguration::getValue('baz'));
     }
 
     public function testGetArrayForNestedValueReturnsArray(): void
@@ -60,50 +60,50 @@ class GlobalConfigurationTest extends TestCase
     public function testGetFloatForNestedValueReturnsFloat(): void
     {
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(['foo' => ['bar' => 1.2]]));
-        $this->assertEquals(1.2, GlobalConfiguration::getFloat('foo.bar'));
+        $this->assertSame(1.2, GlobalConfiguration::getFloat('foo.bar'));
     }
 
     public function testGetFloatReturnsFloat(): void
     {
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(['foo' => 1.2]));
-        $this->assertEquals(1.2, GlobalConfiguration::getFloat('foo'));
+        $this->assertSame(1.2, GlobalConfiguration::getFloat('foo'));
     }
 
     public function testGetIntForNestedValueReturnsInt(): void
     {
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(['foo' => ['bar' => 1]]));
-        $this->assertEquals(1, GlobalConfiguration::getInt('foo.bar'));
+        $this->assertSame(1, GlobalConfiguration::getInt('foo.bar'));
     }
 
     public function testGetIntReturnsInt(): void
     {
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(['foo' => 1]));
-        $this->assertEquals(1, GlobalConfiguration::getInt('foo'));
+        $this->assertSame(1, GlobalConfiguration::getInt('foo'));
     }
 
     public function testGetStringForNestedValueReturnsString(): void
     {
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(['foo' => ['bar' => 'baz']]));
-        $this->assertEquals('baz', GlobalConfiguration::getString('foo.bar'));
+        $this->assertSame('baz', GlobalConfiguration::getString('foo.bar'));
     }
 
     public function testGetStringReturnsString(): void
     {
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(['foo' => 'bar']));
-        $this->assertEquals('bar', GlobalConfiguration::getString('foo'));
+        $this->assertSame('bar', GlobalConfiguration::getString('foo'));
     }
 
     public function testGetValueFallsBackToAnotherSourceIfTheFirstOneDoesNotHaveIt(): void
     {
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(['foo' => 'bar']));
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(['baz' => 'blah']));
-        $this->assertEquals('blah', GlobalConfiguration::getValue('baz'));
+        $this->assertSame('blah', GlobalConfiguration::getValue('baz'));
     }
 
     public function testGetValueForNestedPathReturnsValue(): void
     {
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(['foo' => ['bar' => ['baz' => 'blah']]]));
-        $this->assertEquals('blah', GlobalConfiguration::getValue('foo.bar.baz'));
+        $this->assertSame('blah', GlobalConfiguration::getValue('foo.bar.baz'));
     }
 
     public function testGetValueForNonExistentNestedPathThrowsException(): void
@@ -169,7 +169,7 @@ class GlobalConfigurationTest extends TestCase
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(['foo' => 1.2]));
         $value = null;
         $this->assertTrue(GlobalConfiguration::tryGetFloat('foo', $value));
-        $this->assertEquals(1.2, $value);
+        $this->assertSame(1.2, $value);
     }
 
     public function testTryGetFloatForNonExistentValueSetsItToNullAndReturnsFalse(): void
@@ -185,7 +185,7 @@ class GlobalConfigurationTest extends TestCase
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(['foo' => 1]));
         $value = null;
         $this->assertTrue(GlobalConfiguration::tryGetInt('foo', $value));
-        $this->assertEquals(1, $value);
+        $this->assertSame(1, $value);
     }
 
     public function testTryGetIntForNonExistentValueSetsItToNullAndReturnsFalse(): void
@@ -201,7 +201,7 @@ class GlobalConfigurationTest extends TestCase
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(['foo' => 'bar']));
         $value = null;
         $this->assertTrue(GlobalConfiguration::tryGetString('foo', $value));
-        $this->assertEquals('bar', $value);
+        $this->assertSame('bar', $value);
     }
 
     public function testTryGetStringForNonExistentValueSetsItToNullAndReturnsFalse(): void
@@ -217,7 +217,7 @@ class GlobalConfigurationTest extends TestCase
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(['foo' => 'bar']));
         $value = null;
         $this->assertTrue(GlobalConfiguration::tryGetValue('foo', $value));
-        $this->assertEquals('bar', $value);
+        $this->assertSame('bar', $value);
     }
 
     public function testTryGetValueForNonExistentValueSetsItToNullAndReturnsFalse(): void

--- a/src/Application/tests/Configuration/HashTableConfigurationTest.php
+++ b/src/Application/tests/Configuration/HashTableConfigurationTest.php
@@ -45,43 +45,43 @@ class HashTableConfigurationTest extends TestCase
     public function testGetFloatForNestedValueReturnsFloat(): void
     {
         $configuration = new HashTableConfiguration(['foo' => ['bar' => 1.2]]);
-        $this->assertEquals(1.2, $configuration->getFloat('foo.bar'));
+        $this->assertSame(1.2, $configuration->getFloat('foo.bar'));
     }
 
     public function testGetFloatReturnsFloat(): void
     {
         $configuration = new HashTableConfiguration(['foo' => 1.2]);
-        $this->assertEquals(1.2, $configuration->getFloat('foo'));
+        $this->assertSame(1.2, $configuration->getFloat('foo'));
     }
 
     public function testGetIntForNestedValueReturnsInt(): void
     {
         $configuration = new HashTableConfiguration(['foo' => ['bar' => 1]]);
-        $this->assertEquals(1, $configuration->getInt('foo.bar'));
+        $this->assertSame(1, $configuration->getInt('foo.bar'));
     }
 
     public function testGetIntReturnsInt(): void
     {
         $configuration = new HashTableConfiguration(['foo' => 1]);
-        $this->assertEquals(1, $configuration->getInt('foo'));
+        $this->assertSame(1, $configuration->getInt('foo'));
     }
 
     public function testGetStringForNestedValueReturnsString(): void
     {
         $configuration = new HashTableConfiguration(['foo' => ['bar' => 'baz']]);
-        $this->assertEquals('baz', $configuration->getString('foo.bar'));
+        $this->assertSame('baz', $configuration->getString('foo.bar'));
     }
 
     public function testGetStringReturnsString(): void
     {
         $configuration = new HashTableConfiguration(['foo' => 'bar']);
-        $this->assertEquals('bar', $configuration->getString('foo'));
+        $this->assertSame('bar', $configuration->getString('foo'));
     }
 
     public function testGetValueForNestedPathReturnsValue(): void
     {
         $configuration = new HashTableConfiguration(['foo' => ['bar' => ['baz' => 'blah']]]);
-        $this->assertEquals('blah', $configuration->getValue('foo.bar.baz'));
+        $this->assertSame('blah', $configuration->getValue('foo.bar.baz'));
     }
 
     public function testGetValueForNonExistentNestedPathThrowsException(): void
@@ -104,7 +104,7 @@ class HashTableConfigurationTest extends TestCase
     {
         // We're specifically testing multiple levels deep to test the top level of keys and further down levels
         $configuration = new HashTableConfiguration(['foo' => ['bar' => ['baz' => 'blah']]], ':');
-        $this->assertEquals('blah', $configuration->getValue('foo:bar:baz'));
+        $this->assertSame('blah', $configuration->getValue('foo:bar:baz'));
     }
 
     public function testTryGetArrayForExistentValueSetsItAndReturnsTrue(): void
@@ -144,7 +144,7 @@ class HashTableConfigurationTest extends TestCase
         $configuration = new HashTableConfiguration(['foo' => 1.2]);
         $value = null;
         $this->assertTrue($configuration->tryGetFloat('foo', $value));
-        $this->assertEquals(1.2, $value);
+        $this->assertSame(1.2, $value);
     }
 
     public function testTryGetFloatForNonExistentValueSetsItToNullAndReturnsFalse(): void
@@ -160,7 +160,7 @@ class HashTableConfigurationTest extends TestCase
         $configuration = new HashTableConfiguration(['foo' => 1]);
         $value = null;
         $this->assertTrue($configuration->tryGetInt('foo', $value));
-        $this->assertEquals(1, $value);
+        $this->assertSame(1, $value);
     }
 
     public function testTryGetIntForNonExistentValueSetsItToNullAndReturnsFalse(): void
@@ -176,7 +176,7 @@ class HashTableConfigurationTest extends TestCase
         $configuration = new HashTableConfiguration(['foo' => 'bar']);
         $value = null;
         $this->assertTrue($configuration->tryGetString('foo', $value));
-        $this->assertEquals('bar', $value);
+        $this->assertSame('bar', $value);
     }
 
     public function testTryGetStringForNonExistentValueSetsItToNullAndReturnsFalse(): void
@@ -192,7 +192,7 @@ class HashTableConfigurationTest extends TestCase
         $configuration = new HashTableConfiguration(['foo' => 'bar']);
         $value = null;
         $this->assertTrue($configuration->tryGetValue('foo', $value));
-        $this->assertEquals('bar', $value);
+        $this->assertSame('bar', $value);
     }
 
     public function testTryGetValueForNonExistentValueSetsItToNullAndReturnsFalse(): void

--- a/src/Application/tests/Configuration/JsonConfigurationFileReaderTest.php
+++ b/src/Application/tests/Configuration/JsonConfigurationFileReaderTest.php
@@ -28,13 +28,13 @@ class JsonConfigurationFileReaderTest extends TestCase
     public function testReadingConfigurationCreatesConfigurationFromContentsOfJsonFile(): void
     {
         $configuration = $this->reader->readConfiguration(__DIR__ . '/files/configuration.json');
-        $this->assertEquals('bar', $configuration->getString('foo'));
+        $this->assertSame('bar', $configuration->getString('foo'));
     }
 
     public function testReadingConfigurationWithCustomDelimiterAllowsAccessWithThatDelimiter(): void
     {
         $configuration = $this->reader->readConfiguration(__DIR__ . '/files/configuration-delimiter.json', ':');
-        $this->assertEquals('baz', $configuration->getString('foo:bar'));
+        $this->assertSame('baz', $configuration->getString('foo:bar'));
     }
 
     public function testReadingInvalidJsonThrowsException(): void

--- a/src/Application/tests/Configuration/PhpConfigurationFileReaderTest.php
+++ b/src/Application/tests/Configuration/PhpConfigurationFileReaderTest.php
@@ -28,13 +28,13 @@ class PhpConfigurationFileReaderTest extends TestCase
     public function testReadingConfigurationCreatesConfigurationFromContentsOfPhpFile(): void
     {
         $configuration = $this->reader->readConfiguration(__DIR__ . '/files/configuration.php');
-        $this->assertEquals('bar', $configuration->getString('foo'));
+        $this->assertSame('bar', $configuration->getString('foo'));
     }
 
     public function testReadingConfigurationWithCustomDelimiterAllowsAccessWithThatDelimiter(): void
     {
         $configuration = $this->reader->readConfiguration(__DIR__ . '/files/configuration-delimiter.php', ':');
-        $this->assertEquals('baz', $configuration->getString('foo:bar'));
+        $this->assertSame('baz', $configuration->getString('foo:bar'));
     }
 
     public function testReadingInvalidPhpThrowsException(): void

--- a/src/Collections/tests/ArrayListTest.php
+++ b/src/Collections/tests/ArrayListTest.php
@@ -28,7 +28,7 @@ class ArrayListTest extends TestCase
     public function testAdding(): void
     {
         $this->arrayList->add('foo');
-        $this->assertEquals('foo', $this->arrayList->get(0));
+        $this->assertSame('foo', $this->arrayList->get(0));
     }
 
     public function testAddingRangeOfValues(): void
@@ -67,15 +67,15 @@ class ArrayListTest extends TestCase
     public function testCount(): void
     {
         $this->arrayList->add('foo');
-        $this->assertEquals(1, $this->arrayList->count());
+        $this->assertSame(1, $this->arrayList->count());
         $this->arrayList->add('bar');
-        $this->assertEquals(2, $this->arrayList->count());
+        $this->assertSame(2, $this->arrayList->count());
     }
 
     public function testGetting(): void
     {
         $this->arrayList->add('foo');
-        $this->assertEquals('foo', $this->arrayList->get(0));
+        $this->assertSame('foo', $this->arrayList->get(0));
     }
 
     public function testGettingIndexGreaterThanListLengthThrowsException(): void
@@ -102,7 +102,7 @@ class ArrayListTest extends TestCase
     public function testGettingAsArray(): void
     {
         $this->arrayList->add('foo');
-        $this->assertEquals('foo', $this->arrayList[0]);
+        $this->assertSame('foo', $this->arrayList[0]);
     }
 
     public function testInsertingValue(): void
@@ -110,8 +110,8 @@ class ArrayListTest extends TestCase
         $this->arrayList->add('foo');
         $this->arrayList->add('bar');
         $this->arrayList->insert(1, 'baz');
-        $this->assertEquals('baz', $this->arrayList->get(1));
-        $this->assertEquals('bar', $this->arrayList->get(2));
+        $this->assertSame('baz', $this->arrayList->get(1));
+        $this->assertSame('bar', $this->arrayList->get(2));
         $this->assertEquals(['foo', 'baz', 'bar'], $this->arrayList->toArray());
     }
 
@@ -146,7 +146,7 @@ class ArrayListTest extends TestCase
     {
         $this->arrayList->add('foo');
         $this->arrayList->removeValue('foo');
-        $this->assertEquals(0, $this->arrayList->count());
+        $this->assertSame(0, $this->arrayList->count());
         $this->assertFalse($this->arrayList->containsValue('foo'));
         $this->assertEquals([], $this->arrayList->toArray());
     }
@@ -155,7 +155,7 @@ class ArrayListTest extends TestCase
     {
         $this->arrayList->add('foo');
         $this->arrayList->removeIndex(0);
-        $this->assertEquals(0, $this->arrayList->count());
+        $this->assertSame(0, $this->arrayList->count());
         $this->assertFalse($this->arrayList->containsValue('foo'));
         $this->assertEquals([], $this->arrayList->toArray());
     }
@@ -173,7 +173,7 @@ class ArrayListTest extends TestCase
         $this->arrayList->add('foo');
         $this->arrayList->add('bar');
         $this->arrayList[1] = 'baz';
-        $this->assertEquals('baz', $this->arrayList[1]);
+        $this->assertSame('baz', $this->arrayList[1]);
         $this->assertEquals(['foo', 'baz', 'bar'], $this->arrayList->toArray());
     }
 
@@ -197,7 +197,7 @@ class ArrayListTest extends TestCase
     {
         $this->arrayList->add('foo');
         unset($this->arrayList[0]);
-        $this->assertEquals(0, $this->arrayList->count());
+        $this->assertSame(0, $this->arrayList->count());
         $this->assertFalse($this->arrayList->containsValue('foo'));
         $this->assertEquals([], $this->arrayList->toArray());
     }

--- a/src/Collections/tests/HashSetTest.php
+++ b/src/Collections/tests/HashSetTest.php
@@ -81,13 +81,13 @@ class HashSetTest extends TestCase
     {
         $object1 = new FakeObject();
         $object2 = new FakeObject();
-        $this->assertEquals(0, $this->set->count());
+        $this->assertSame(0, $this->set->count());
         $this->set->add($object1);
-        $this->assertEquals(1, $this->set->count());
+        $this->assertSame(1, $this->set->count());
         $this->set->add($object1);
-        $this->assertEquals(1, $this->set->count());
+        $this->assertSame(1, $this->set->count());
         $this->set->add($object2);
-        $this->assertEquals(2, $this->set->count());
+        $this->assertSame(2, $this->set->count());
     }
 
     public function testEqualButNotSameObjectsAreNotIntersected(): void
@@ -123,7 +123,7 @@ class HashSetTest extends TestCase
 
         foreach ($this->set as $key => $value) {
             // Make sure the hash keys aren't returned by the iterator
-            $this->assertTrue(\is_int($key));
+            $this->assertIsInt($key);
             $actualValues[] = $value;
         }
 

--- a/src/Collections/tests/HashTableTest.php
+++ b/src/Collections/tests/HashTableTest.php
@@ -31,14 +31,14 @@ class HashTableTest extends TestCase
     public function testAddingRangeMakesEachValueRetrievable(): void
     {
         $this->hashTable->addRange([new KeyValuePair('foo', 'bar'), new KeyValuePair('baz', 'blah')]);
-        $this->assertEquals('bar', $this->hashTable->get('foo'));
-        $this->assertEquals('blah', $this->hashTable->get('baz'));
+        $this->assertSame('bar', $this->hashTable->get('foo'));
+        $this->assertSame('blah', $this->hashTable->get('baz'));
     }
 
     public function testAddingValueMakesItRetrievable(): void
     {
         $this->hashTable->add('foo', 'bar');
-        $this->assertEquals('bar', $this->hashTable->get('foo'));
+        $this->assertSame('bar', $this->hashTable->get('foo'));
     }
 
     public function testCheckingOffsetExists(): void
@@ -77,15 +77,15 @@ class HashTableTest extends TestCase
     public function testCount(): void
     {
         $this->hashTable->add('foo', 'bar');
-        $this->assertEquals(1, $this->hashTable->count());
+        $this->assertSame(1, $this->hashTable->count());
         $this->hashTable->add('bar', 'foo');
-        $this->assertEquals(2, $this->hashTable->count());
+        $this->assertSame(2, $this->hashTable->count());
     }
 
     public function testGetting(): void
     {
         $this->hashTable->add('foo', 'bar');
-        $this->assertEquals('bar', $this->hashTable->get('foo'));
+        $this->assertSame('bar', $this->hashTable->get('foo'));
     }
 
     public function testGettingAbsentVariableThrowsException(): void
@@ -97,7 +97,7 @@ class HashTableTest extends TestCase
     public function testGettingAsArray(): void
     {
         $this->hashTable->add('foo', 'bar');
-        $this->assertEquals('bar', $this->hashTable['foo']);
+        $this->assertSame('bar', $this->hashTable['foo']);
     }
 
     /**
@@ -131,7 +131,7 @@ class HashTableTest extends TestCase
 
         foreach ($this->hashTable as $key => $value) {
             // Make sure the hash keys aren't returned by the iterator
-            $this->assertTrue(\is_int($key));
+            $this->assertIsInt($key);
             $actualValues[] = $value;
         }
 
@@ -159,8 +159,8 @@ class HashTableTest extends TestCase
     public function testPassingParametersInConstructor(): void
     {
         $hashTable = new HashTable([new KeyValuePair('foo', 'bar'), new KeyValuePair('baz', 'blah')]);
-        $this->assertEquals('bar', $hashTable->get('foo'));
-        $this->assertEquals('blah', $hashTable->get('baz'));
+        $this->assertSame('bar', $hashTable->get('foo'));
+        $this->assertSame('blah', $hashTable->get('baz'));
     }
 
     public function testRemoveKey(): void
@@ -173,7 +173,7 @@ class HashTableTest extends TestCase
     public function testSettingItem(): void
     {
         $this->hashTable['foo'] = 'bar';
-        $this->assertEquals('bar', $this->hashTable['foo']);
+        $this->assertSame('bar', $this->hashTable['foo']);
     }
 
     public function testToArray(): void
@@ -197,7 +197,7 @@ class HashTableTest extends TestCase
         $this->assertNull($value);
         $this->hashTable->add('foo', 'bar');
         $this->assertTrue($this->hashTable->tryGet('foo', $value));
-        $this->assertEquals('bar', $value);
+        $this->assertSame('bar', $value);
     }
 
     public function testUnsetting(): void

--- a/src/Collections/tests/ImmutableArrayListTest.php
+++ b/src/Collections/tests/ImmutableArrayListTest.php
@@ -41,21 +41,21 @@ class ImmutableArrayListTest extends TestCase
     public function testCount(): void
     {
         $arrayList = new ImmutableArrayList(['foo']);
-        $this->assertEquals(1, $arrayList->count());
+        $this->assertSame(1, $arrayList->count());
         $arrayList = new ImmutableArrayList(['foo', 'bar']);
-        $this->assertEquals(2, $arrayList->count());
+        $this->assertSame(2, $arrayList->count());
     }
 
     public function testGetting(): void
     {
         $arrayList = new ImmutableArrayList(['foo']);
-        $this->assertEquals('foo', $arrayList->get(0));
+        $this->assertSame('foo', $arrayList->get(0));
     }
 
     public function testGettingAsArray(): void
     {
         $arrayList = new ImmutableArrayList(['foo']);
-        $this->assertEquals('foo', $arrayList[0]);
+        $this->assertSame('foo', $arrayList[0]);
     }
 
     public function testGettingIndexGreaterThanListLengthThrowsException(): void

--- a/src/Collections/tests/ImmutableHashSetTest.php
+++ b/src/Collections/tests/ImmutableHashSetTest.php
@@ -66,13 +66,13 @@ class ImmutableHashSetTest extends TestCase
     {
         $object1 = new FakeObject();
         $object2 = new FakeObject();
-        $this->assertEquals(0, (new ImmutableHashSet([]))->count());
+        $this->assertSame(0, (new ImmutableHashSet([]))->count());
         $setWithOneValue = new ImmutableHashSet([$object1]);
-        $this->assertEquals(1, $setWithOneValue->count());
+        $this->assertSame(1, $setWithOneValue->count());
         $setWithOneUniqueValue = new ImmutableHashSet([$object1, $object1]);
-        $this->assertEquals(1, $setWithOneUniqueValue->count());
+        $this->assertSame(1, $setWithOneUniqueValue->count());
         $setWithTwoalues = new ImmutableHashSet([$object1, $object2]);
-        $this->assertEquals(2, $setWithTwoalues->count());
+        $this->assertSame(2, $setWithTwoalues->count());
     }
 
     /**
@@ -89,7 +89,7 @@ class ImmutableHashSetTest extends TestCase
 
         foreach ($set as $key => $value) {
             // Make sure the hash keys aren't returned by the iterator
-            $this->assertTrue(\is_int($key));
+            $this->assertIsInt($key);
             $actualValues[] = $value;
         }
 

--- a/src/Collections/tests/ImmutableHashTableTest.php
+++ b/src/Collections/tests/ImmutableHashTableTest.php
@@ -25,7 +25,7 @@ class ImmutableHashTableTest extends TestCase
     public function testArrayAccessReturnsValuesAtKeys(): void
     {
         $hashTable = new ImmutableHashTable([new KeyValuePair('foo', 'bar')]);
-        $this->assertEquals('bar', $hashTable['foo']);
+        $this->assertSame('bar', $hashTable['foo']);
     }
 
     public function testContainsKey(): void
@@ -51,13 +51,13 @@ class ImmutableHashTableTest extends TestCase
     public function testCount(): void
     {
         $hashTable = new ImmutableHashTable([new KeyValuePair('foo', 'bar'), new KeyValuePair('baz', 'blah')]);
-        $this->assertEquals(2, $hashTable->count());
+        $this->assertSame(2, $hashTable->count());
     }
 
     public function testGetting(): void
     {
         $hashTable = new ImmutableHashTable([new KeyValuePair('foo', 'bar')]);
-        $this->assertEquals('bar', $hashTable->get('foo'));
+        $this->assertSame('bar', $hashTable->get('foo'));
     }
 
     public function testGettingAbsentVariableThrowsException(): void
@@ -101,7 +101,7 @@ class ImmutableHashTableTest extends TestCase
 
         foreach ($hashTable as $key => $value) {
             // Make sure the hash keys aren't returned by the iterator
-            $this->assertTrue(\is_int($key));
+            $this->assertIsInt($key);
             $actualValues[] = $value;
         }
 
@@ -138,7 +138,7 @@ class ImmutableHashTableTest extends TestCase
         $this->assertFalse($hashTable->tryGet('baz', $value));
         $this->assertNull($value);
         $this->assertTrue($hashTable->tryGet('foo', $value));
-        $this->assertEquals('bar', $value);
+        $this->assertSame('bar', $value);
     }
 
     public function testUnsettingValueThrowsException(): void

--- a/src/Collections/tests/KeyHasherTest.php
+++ b/src/Collections/tests/KeyHasherTest.php
@@ -29,25 +29,25 @@ class KeyHasherTest extends TestCase
     public function testArraysAreHashedToCorrectKey(): void
     {
         $array = ['foo'];
-        $this->assertEquals('__aphiria:a:' . md5(serialize($array)), $this->keyHasher->getHashKey($array));
+        $this->assertSame('__aphiria:a:' . md5(serialize($array)), $this->keyHasher->getHashKey($array));
     }
 
     public function testNullCanBeHashed(): void
     {
-        $this->assertEquals('__aphiria:u', $this->keyHasher->getHashKey(null));
+        $this->assertSame('__aphiria:u', $this->keyHasher->getHashKey(null));
     }
 
     public function testScalarsAreHashedToCorrectKey(): void
     {
-        $this->assertEquals('__aphiria:s:1', $this->keyHasher->getHashKey('1'));
-        $this->assertEquals('__aphiria:i:1', $this->keyHasher->getHashKey(1));
-        $this->assertEquals('__aphiria:f:1.1', $this->keyHasher->getHashKey(1.1));
+        $this->assertSame('__aphiria:s:1', $this->keyHasher->getHashKey('1'));
+        $this->assertSame('__aphiria:i:1', $this->keyHasher->getHashKey(1));
+        $this->assertSame('__aphiria:f:1.1', $this->keyHasher->getHashKey(1.1));
     }
 
     public function testResourceIsHashedUsingItsStringValue(): void
     {
         $resource = fopen('php://temp', 'r+b');
-        $this->assertEquals("__aphiria:r:$resource", $this->keyHasher->getHashKey($resource));
+        $this->assertSame("__aphiria:r:$resource", $this->keyHasher->getHashKey($resource));
     }
 
     /**
@@ -56,12 +56,12 @@ class KeyHasherTest extends TestCase
     public function testSerializableObjectIsHashedWithToStringMethod(): void
     {
         $object = new SerializableObject('foo');
-        $this->assertEquals('__aphiria:so:foo', $this->keyHasher->getHashKey($object));
+        $this->assertSame('__aphiria:so:foo', $this->keyHasher->getHashKey($object));
     }
 
     public function testUnserializableObjectIsHashedWithObjectHash(): void
     {
         $object = new UnserializableObject();
-        $this->assertEquals('__aphiria:o:' . spl_object_hash($object), $this->keyHasher->getHashKey($object));
+        $this->assertSame('__aphiria:o:' . spl_object_hash($object), $this->keyHasher->getHashKey($object));
     }
 }

--- a/src/Collections/tests/KeyValuePairTest.php
+++ b/src/Collections/tests/KeyValuePairTest.php
@@ -20,12 +20,12 @@ class KeyValuePairTest extends TestCase
     public function testGettingKey(): void
     {
         $kvp = new KeyValuePair('foo', 'bar');
-        $this->assertEquals('foo', $kvp->getKey());
+        $this->assertSame('foo', $kvp->getKey());
     }
 
     public function testGettingValue(): void
     {
         $kvp = new KeyValuePair('foo', 'bar');
-        $this->assertEquals('bar', $kvp->getValue());
+        $this->assertSame('bar', $kvp->getValue());
     }
 }

--- a/src/Collections/tests/QueueTest.php
+++ b/src/Collections/tests/QueueTest.php
@@ -40,20 +40,20 @@ class QueueTest extends TestCase
 
     public function testCounting(): void
     {
-        $this->assertEquals(0, $this->queue->count());
+        $this->assertSame(0, $this->queue->count());
         $this->queue->enqueue('foo');
-        $this->assertEquals(1, $this->queue->count());
+        $this->assertSame(1, $this->queue->count());
         $this->queue->enqueue('bar');
-        $this->assertEquals(2, $this->queue->count());
+        $this->assertSame(2, $this->queue->count());
     }
 
     public function testDequeuingRemovesValueFromBeginningOfQueue(): void
     {
         $this->queue->enqueue('foo');
         $this->queue->enqueue('bar');
-        $this->assertEquals('foo', $this->queue->dequeue());
+        $this->assertSame('foo', $this->queue->dequeue());
         $this->assertEquals(['bar'], $this->queue->toArray());
-        $this->assertEquals('bar', $this->queue->dequeue());
+        $this->assertSame('bar', $this->queue->dequeue());
         $this->assertEquals([], $this->queue->toArray());
     }
 
@@ -66,8 +66,8 @@ class QueueTest extends TestCase
     {
         $this->queue->enqueue('foo');
         $this->queue->enqueue('bar');
-        $this->assertEquals('foo', $this->queue->dequeue());
-        $this->assertEquals('bar', $this->queue->dequeue());
+        $this->assertSame('foo', $this->queue->dequeue());
+        $this->assertSame('bar', $this->queue->dequeue());
     }
 
     public function testIteratingOverValues(): void
@@ -91,9 +91,9 @@ class QueueTest extends TestCase
     public function testPeekReturnsValueAtBeginning(): void
     {
         $this->queue->enqueue('foo');
-        $this->assertEquals('foo', $this->queue->peek());
+        $this->assertSame('foo', $this->queue->peek());
         $this->queue->enqueue('bar');
-        $this->assertEquals('foo', $this->queue->peek());
+        $this->assertSame('foo', $this->queue->peek());
     }
 
     public function testToArrayConvertsTheQueueToArray(): void

--- a/src/Collections/tests/StackTest.php
+++ b/src/Collections/tests/StackTest.php
@@ -40,11 +40,11 @@ class StackTest extends TestCase
 
     public function testCounting(): void
     {
-        $this->assertEquals(0, $this->stack->count());
+        $this->assertSame(0, $this->stack->count());
         $this->stack->push('foo');
-        $this->assertEquals(1, $this->stack->count());
+        $this->assertSame(1, $this->stack->count());
         $this->stack->push('bar');
-        $this->assertEquals(2, $this->stack->count());
+        $this->assertSame(2, $this->stack->count());
     }
 
     public function testIteratingOverValues(): void
@@ -68,18 +68,18 @@ class StackTest extends TestCase
     public function testPeekReturnsTopValue(): void
     {
         $this->stack->push('foo');
-        $this->assertEquals('foo', $this->stack->peek());
+        $this->assertSame('foo', $this->stack->peek());
         $this->stack->push('bar');
-        $this->assertEquals('bar', $this->stack->peek());
+        $this->assertSame('bar', $this->stack->peek());
     }
 
     public function testPoppingRemovesValueFromTopOfStack(): void
     {
         $this->stack->push('foo');
         $this->stack->push('bar');
-        $this->assertEquals('bar', $this->stack->pop());
+        $this->assertSame('bar', $this->stack->pop());
         $this->assertEquals(['foo'], $this->stack->toArray());
-        $this->assertEquals('foo', $this->stack->pop());
+        $this->assertSame('foo', $this->stack->pop());
         $this->assertEquals([], $this->stack->toArray());
     }
 
@@ -92,8 +92,8 @@ class StackTest extends TestCase
     {
         $this->stack->push('foo');
         $this->stack->push('bar');
-        $this->assertEquals('bar', $this->stack->pop());
-        $this->assertEquals('foo', $this->stack->pop());
+        $this->assertSame('bar', $this->stack->pop());
+        $this->assertSame('foo', $this->stack->pop());
     }
 
     public function testToArrayConvertsTheStackToArray(): void

--- a/src/Console/tests/ApplicationTest.php
+++ b/src/Console/tests/ApplicationTest.php
@@ -68,7 +68,7 @@ class ApplicationTest extends TestCase
             }
         };
         $status = $app->handle('', $output);
-        $this->assertEquals(StatusCodes::FATAL, $status);
+        $this->assertSame(StatusCodes::FATAL, $status);
     }
 
     public function testHandlingCommandWithNoHandlerThrowsException(): void
@@ -93,7 +93,7 @@ class ApplicationTest extends TestCase
             }
         };
         $status = $app->handle('foo', $output);
-        $this->assertEquals(StatusCodes::ERROR, $status);
+        $this->assertSame(StatusCodes::ERROR, $status);
     }
 
     public function testHandlingEmptyCommandReturnsOk(): void
@@ -105,7 +105,7 @@ class ApplicationTest extends TestCase
         ob_start();
         $status = $this->app->handle('', $this->output);
         ob_get_clean();
-        $this->assertEquals(StatusCodes::OK, $status);
+        $this->assertSame(StatusCodes::OK, $status);
     }
 
     public function testHandlingException(): void
@@ -113,7 +113,7 @@ class ApplicationTest extends TestCase
         ob_start();
         $status = $this->app->handle("unclosed quote '", $this->output);
         ob_end_clean();
-        $this->assertEquals(StatusCodes::FATAL, $status);
+        $this->assertSame(StatusCodes::FATAL, $status);
     }
 
     public function testHandlingHelpCommand(): void
@@ -127,13 +127,13 @@ class ApplicationTest extends TestCase
         ob_start();
         $status = $this->app->handle('help holiday', $this->output);
         ob_get_clean();
-        $this->assertEquals(StatusCodes::OK, $status);
+        $this->assertSame(StatusCodes::OK, $status);
 
         // Try with command name with no argument
         ob_start();
         $status = $this->app->handle('help', $this->output);
         ob_get_clean();
-        $this->assertEquals(StatusCodes::OK, $status);
+        $this->assertSame(StatusCodes::OK, $status);
     }
 
     public function testHandlingHelpCommandWithNonExistentCommand(): void
@@ -145,7 +145,7 @@ class ApplicationTest extends TestCase
         ob_start();
         $status = $this->app->handle('help fake', $this->output);
         ob_end_clean();
-        $this->assertEquals(StatusCodes::ERROR, $status);
+        $this->assertSame(StatusCodes::ERROR, $status);
     }
 
     public function testHandlingHolidayCommand(): void
@@ -179,14 +179,14 @@ class ApplicationTest extends TestCase
         );
         ob_start();
         $status = $this->app->handle('holiday birthday -y', $this->output);
-        $this->assertEquals('Happy birthday!', ob_get_clean());
-        $this->assertEquals(StatusCodes::OK, $status);
+        $this->assertSame('Happy birthday!', ob_get_clean());
+        $this->assertSame(StatusCodes::OK, $status);
 
         // Test with long option
         ob_start();
         $status = $this->app->handle('holiday Easter --yell=no', $this->output);
-        $this->assertEquals('Happy Easter', ob_get_clean());
-        $this->assertEquals(StatusCodes::OK, $status);
+        $this->assertSame('Happy Easter', ob_get_clean());
+        $this->assertSame(StatusCodes::OK, $status);
     }
 
     public function testHandlingInvalidInputReturnsError(): void
@@ -194,7 +194,7 @@ class ApplicationTest extends TestCase
         ob_start();
         $status = $this->app->handle($this, $this->output);
         ob_end_clean();
-        $this->assertEquals(StatusCodes::ERROR, $status);
+        $this->assertSame(StatusCodes::ERROR, $status);
     }
 
     public function testHandlingMissingCommandReturnsError(): void
@@ -202,7 +202,7 @@ class ApplicationTest extends TestCase
         ob_start();
         $status = $this->app->handle('fake', $this->output);
         ob_get_clean();
-        $this->assertEquals(StatusCodes::ERROR, $status);
+        $this->assertSame(StatusCodes::ERROR, $status);
     }
 
     public function testHandlingSimpleCommand(): void
@@ -220,8 +220,8 @@ class ApplicationTest extends TestCase
         $this->commands->registerCommand(new Command('foo'), \get_class($commandHandler));
         ob_start();
         $status = $this->app->handle('foo', $this->output);
-        $this->assertEquals('foo', ob_get_clean());
-        $this->assertEquals(StatusCodes::OK, $status);
+        $this->assertSame('foo', ob_get_clean());
+        $this->assertSame(StatusCodes::OK, $status);
     }
 
     public function testHandlingWithHandlerThatDoesNotReturnAnythingDefaultsToOk(): void
@@ -238,6 +238,6 @@ class ApplicationTest extends TestCase
             ->willReturn($commandHandler);
         $this->commands->registerCommand(new Command('foo'), \get_class($commandHandler));
         $statusCode = $this->app->handle('foo', $this->output);
-        $this->assertEquals(StatusCodes::OK, $statusCode);
+        $this->assertSame(StatusCodes::OK, $statusCode);
     }
 }

--- a/src/Console/tests/Commands/Annotations/AnnotationCommandRegistrantTest.php
+++ b/src/Console/tests/Commands/Annotations/AnnotationCommandRegistrantTest.php
@@ -96,25 +96,25 @@ class AnnotationCommandRegistrantTest extends TestCase
 
         // Command assertions
         $command = $this->commands->getAllCommands()[0];
-        $this->assertEquals('foo', $command->name);
-        $this->assertEquals('command description', $command->description);
-        $this->assertEquals('command help text', $command->helpText);
+        $this->assertSame('foo', $command->name);
+        $this->assertSame('command description', $command->description);
+        $this->assertSame('command help text', $command->helpText);
 
         // Argument assertions
         $this->assertCount(1, $command->arguments);
         $arg1 = $command->arguments[0];
-        $this->assertEquals('arg1', $arg1->name);
-        $this->assertEquals(ArgumentTypes::REQUIRED, $arg1->type);
-        $this->assertEquals('arg1 description', $arg1->description);
-        $this->assertEquals('arg1 value', $arg1->defaultValue);
+        $this->assertSame('arg1', $arg1->name);
+        $this->assertSame(ArgumentTypes::REQUIRED, $arg1->type);
+        $this->assertSame('arg1 description', $arg1->description);
+        $this->assertSame('arg1 value', $arg1->defaultValue);
 
         // Option assertions
         $this->assertCount(1, $command->options);
         $opt1 = $command->options[0];
-        $this->assertEquals('opt1', $opt1->name);
-        $this->assertEquals('o', $opt1->shortName);
-        $this->assertEquals(OptionTypes::REQUIRED_VALUE, $opt1->type);
-        $this->assertEquals('opt1 description', $opt1->description);
-        $this->assertEquals('opt1 value', $opt1->defaultValue);
+        $this->assertSame('opt1', $opt1->name);
+        $this->assertSame('o', $opt1->shortName);
+        $this->assertSame(OptionTypes::REQUIRED_VALUE, $opt1->type);
+        $this->assertSame('opt1 description', $opt1->description);
+        $this->assertSame('opt1 value', $opt1->defaultValue);
     }
 }

--- a/src/Console/tests/Commands/Annotations/ArgumentTest.php
+++ b/src/Console/tests/Commands/Annotations/ArgumentTest.php
@@ -22,8 +22,8 @@ class ArgumentTest extends TestCase
     public function testDefaultValuesOfArgumentPropertiesAreSet(): void
     {
         $argument = new Argument(['value' => 'foo', 'type' => ArgumentTypes::REQUIRED]);
-        $this->assertEquals('foo', $argument->name);
-        $this->assertEquals(ArgumentTypes::REQUIRED, $argument->type);
+        $this->assertSame('foo', $argument->name);
+        $this->assertSame(ArgumentTypes::REQUIRED, $argument->type);
         $this->assertNull($argument->description);
         $this->assertNull($argument->defaultValue);
     }
@@ -31,13 +31,13 @@ class ArgumentTest extends TestCase
     public function testNameCanBeSetViaName(): void
     {
         $argument = new Argument(['name' => 'foo', 'type' => ArgumentTypes::REQUIRED]);
-        $this->assertEquals('foo', $argument->name);
+        $this->assertSame('foo', $argument->name);
     }
 
     public function testNameCanBeSetViaValue(): void
     {
         $argument = new Argument(['value' => 'foo', 'type' => ArgumentTypes::REQUIRED]);
-        $this->assertEquals('foo', $argument->name);
+        $this->assertSame('foo', $argument->name);
     }
 
     public function testNoNameThrowsException(): void
@@ -62,9 +62,9 @@ class ArgumentTest extends TestCase
             'description' => 'description',
             'defaultValue' => 'val'
         ]);
-        $this->assertEquals('foo', $argument->name);
-        $this->assertEquals(ArgumentTypes::REQUIRED, $argument->type);
-        $this->assertEquals('description', $argument->description);
-        $this->assertEquals('val', $argument->defaultValue);
+        $this->assertSame('foo', $argument->name);
+        $this->assertSame(ArgumentTypes::REQUIRED, $argument->type);
+        $this->assertSame('description', $argument->description);
+        $this->assertSame('val', $argument->defaultValue);
     }
 }

--- a/src/Console/tests/Commands/Annotations/CommandTest.php
+++ b/src/Console/tests/Commands/Annotations/CommandTest.php
@@ -25,7 +25,7 @@ class CommandTest extends TestCase
     public function testDefaultValuesOfCommandPropertiesAreSet(): void
     {
         $command = new Command(['value' => 'foo']);
-        $this->assertEquals('foo', $command->name);
+        $this->assertSame('foo', $command->name);
         $this->assertEmpty($command->arguments);
         $this->assertEmpty($command->options);
         $this->assertNull($command->description);
@@ -35,13 +35,13 @@ class CommandTest extends TestCase
     public function testNameCanBeSetViaName(): void
     {
         $command = new Command(['name' => 'foo']);
-        $this->assertEquals('foo', $command->name);
+        $this->assertSame('foo', $command->name);
     }
 
     public function testNameCanBeSetViaValue(): void
     {
         $command = new Command(['value' => 'foo']);
-        $this->assertEquals('foo', $command->name);
+        $this->assertSame('foo', $command->name);
     }
 
     public function testNoNameThrowsException(): void
@@ -60,14 +60,14 @@ class CommandTest extends TestCase
             'description' => 'command description',
             'helpText' => 'help text'
         ]);
-        $this->assertEquals('foo', $command->name);
+        $this->assertSame('foo', $command->name);
         $this->assertCount(1, $command->arguments);
-        $this->assertEquals('arg1', $command->arguments[0]->name);
-        $this->assertEquals(ArgumentTypes::REQUIRED, $command->arguments[0]->type);
+        $this->assertSame('arg1', $command->arguments[0]->name);
+        $this->assertSame(ArgumentTypes::REQUIRED, $command->arguments[0]->type);
         $this->assertCount(1, $command->options);
-        $this->assertEquals('opt1', $command->options[0]->name);
-        $this->assertEquals(OptionTypes::REQUIRED_VALUE, $command->options[0]->type);
-        $this->assertEquals('command description', $command->description);
-        $this->assertEquals('help text', $command->helpText);
+        $this->assertSame('opt1', $command->options[0]->name);
+        $this->assertSame(OptionTypes::REQUIRED_VALUE, $command->options[0]->type);
+        $this->assertSame('command description', $command->description);
+        $this->assertSame('help text', $command->helpText);
     }
 }

--- a/src/Console/tests/Commands/Annotations/OptionTest.php
+++ b/src/Console/tests/Commands/Annotations/OptionTest.php
@@ -22,9 +22,9 @@ class OptionTest extends TestCase
     public function testDefaultValuesOfOptionPropertiesAreSet(): void
     {
         $option = new Option(['value' => 'foo', 'type' => OptionTypes::REQUIRED_VALUE]);
-        $this->assertEquals('foo', $option->name);
+        $this->assertSame('foo', $option->name);
         $this->assertNull($option->shortName);
-        $this->assertEquals(OptionTypes::REQUIRED_VALUE, $option->type);
+        $this->assertSame(OptionTypes::REQUIRED_VALUE, $option->type);
         $this->assertNull($option->description);
         $this->assertNull($option->defaultValue);
     }
@@ -32,13 +32,13 @@ class OptionTest extends TestCase
     public function testNameCanBeSetViaName(): void
     {
         $option = new Option(['name' => 'foo', 'type' => OptionTypes::REQUIRED_VALUE]);
-        $this->assertEquals('foo', $option->name);
+        $this->assertSame('foo', $option->name);
     }
 
     public function testNameCanBeSetViaValue(): void
     {
         $option = new Option(['value' => 'foo', 'type' => OptionTypes::REQUIRED_VALUE]);
-        $this->assertEquals('foo', $option->name);
+        $this->assertSame('foo', $option->name);
     }
 
     public function testNoNameThrowsException(): void
@@ -64,10 +64,10 @@ class OptionTest extends TestCase
             'description' => 'description',
             'defaultValue' => 'val'
         ]);
-        $this->assertEquals('foo', $option->name);
-        $this->assertEquals('f', $option->shortName);
-        $this->assertEquals(OptionTypes::REQUIRED_VALUE, $option->type);
-        $this->assertEquals('description', $option->description);
-        $this->assertEquals('val', $option->defaultValue);
+        $this->assertSame('foo', $option->name);
+        $this->assertSame('f', $option->shortName);
+        $this->assertSame(OptionTypes::REQUIRED_VALUE, $option->type);
+        $this->assertSame('description', $option->description);
+        $this->assertSame('val', $option->defaultValue);
     }
 }

--- a/src/Console/tests/Commands/CommandBindingTest.php
+++ b/src/Console/tests/Commands/CommandBindingTest.php
@@ -23,6 +23,6 @@ class CommandBindingTest extends TestCase
         $expectedCommand = new Command('name', [], [], '', '');
         $binding = new CommandBinding($expectedCommand, 'Foo');
         $this->assertSame($expectedCommand, $binding->command);
-        $this->assertEquals('Foo', $binding->commandHandlerClassName);
+        $this->assertSame('Foo', $binding->commandHandlerClassName);
     }
 }

--- a/src/Console/tests/Commands/Defaults/HelpCommandHandlerTest.php
+++ b/src/Console/tests/Commands/Defaults/HelpCommandHandlerTest.php
@@ -45,7 +45,7 @@ class HelpCommandHandlerTest extends TestCase
         $this->output->expects($this->once())
             ->method('writeln')
             ->with('<error>Command foo does not exist</error>');
-        $this->assertEquals(StatusCodes::ERROR, $this->handler->handle(new Input('help', ['command' => 'foo'], []), $this->output));
+        $this->assertSame(StatusCodes::ERROR, $this->handler->handle(new Input('help', ['command' => 'foo'], []), $this->output));
     }
 
     public function testHandlingCommandWithHelpTextIncludesIt(): void
@@ -90,7 +90,7 @@ class HelpCommandHandlerTest extends TestCase
         $this->output->expects($this->once())
             ->method('writeln')
             ->with("<comment>Pass in the name of the command you'd like help with</comment>");
-        $this->assertEquals(StatusCodes::OK, $this->handler->handle(new Input('help', [], []), $this->output));
+        $this->assertSame(StatusCodes::OK, $this->handler->handle(new Input('help', [], []), $this->output));
     }
 
     public function testHandlingWithNoArgumentsStillHasDefaultArgumentDescription(): void

--- a/src/Console/tests/Drivers/UnixLikeDriverTest.php
+++ b/src/Console/tests/Drivers/UnixLikeDriverTest.php
@@ -74,8 +74,8 @@ class UnixLikeDriverTest extends TestCase
                 return null;
             }
         };
-        $this->assertEquals(80, $driver->getCliWidth());
-        $this->assertEquals(60, $driver->getCliHeight());
+        $this->assertSame(80, $driver->getCliWidth());
+        $this->assertSame(60, $driver->getCliHeight());
     }
 
     public function testCliDimensionsCanBeReadFromOS(): void
@@ -89,8 +89,8 @@ class UnixLikeDriverTest extends TestCase
                 return [10, 15];
             }
         };
-        $this->assertEquals(10, $driver->getCliWidth());
-        $this->assertEquals(15, $driver->getCliHeight());
+        $this->assertSame(10, $driver->getCliWidth());
+        $this->assertSame(15, $driver->getCliHeight());
     }
 
     public function testCliDimensionsCanBeReadFromSttyIfEnabled(): void
@@ -117,16 +117,16 @@ class UnixLikeDriverTest extends TestCase
     public function testCliHeightIsMemoized(): void
     {
         \putenv('LINES=10');
-        $this->assertEquals(10, $this->driver->getCliHeight());
+        $this->assertSame(10, $this->driver->getCliHeight());
         \putenv('LINES=0');
-        $this->assertEquals(10, $this->driver->getCliHeight());
+        $this->assertSame(10, $this->driver->getCliHeight());
     }
 
     public function testCliWidthIsMemoized(): void
     {
         \putenv('COLUMNS=10');
-        $this->assertEquals(10, $this->driver->getCliWidth());
+        $this->assertSame(10, $this->driver->getCliWidth());
         \putenv('COLUMNS=0');
-        $this->assertEquals(10, $this->driver->getCliWidth());
+        $this->assertSame(10, $this->driver->getCliWidth());
     }
 }

--- a/src/Console/tests/Drivers/WindowsDriverTest.php
+++ b/src/Console/tests/Drivers/WindowsDriverTest.php
@@ -60,8 +60,8 @@ class WindowsDriverTest extends TestCase
                 return null;
             }
         };
-        $this->assertEquals(60, $driver->getCliHeight());
-        $this->assertEquals(80, $driver->getCliWidth());
+        $this->assertSame(60, $driver->getCliHeight());
+        $this->assertSame(80, $driver->getCliWidth());
     }
 
     public function testCliDimensionsCanBeReadFromAnsicon(): void
@@ -69,8 +69,8 @@ class WindowsDriverTest extends TestCase
         \putenv('COLUMNS');
         \putenv('LINES');
         \putenv('ANSICON=10x15');
-        $this->assertEquals(10, $this->driver->getCliWidth());
-        $this->assertEquals(15, $this->driver->getCliHeight());
+        $this->assertSame(10, $this->driver->getCliWidth());
+        $this->assertSame(15, $this->driver->getCliHeight());
     }
 
     public function testCliDimensionsCanBeReadFromOS(): void
@@ -84,8 +84,8 @@ class WindowsDriverTest extends TestCase
                 return [10, 15];
             }
         };
-        $this->assertEquals(10, $driver->getCliWidth());
-        $this->assertEquals(15, $driver->getCliHeight());
+        $this->assertSame(10, $driver->getCliWidth());
+        $this->assertSame(15, $driver->getCliHeight());
     }
 
     public function testCliDimensionsCanBeReadFromSttyIfEnabled(): void
@@ -116,16 +116,16 @@ class WindowsDriverTest extends TestCase
     public function testCliHeightIsMemoized(): void
     {
         \putenv('LINES=10');
-        $this->assertEquals(10, $this->driver->getCliHeight());
+        $this->assertSame(10, $this->driver->getCliHeight());
         \putenv('LINES=0');
-        $this->assertEquals(10, $this->driver->getCliHeight());
+        $this->assertSame(10, $this->driver->getCliHeight());
     }
 
     public function testCliWidthIsMemoized(): void
     {
         \putenv('COLUMNS=10');
-        $this->assertEquals(10, $this->driver->getCliWidth());
+        $this->assertSame(10, $this->driver->getCliWidth());
         \putenv('COLUMNS=0');
-        $this->assertEquals(10, $this->driver->getCliWidth());
+        $this->assertSame(10, $this->driver->getCliWidth());
     }
 }

--- a/src/Console/tests/Input/ArgumentTest.php
+++ b/src/Console/tests/Input/ArgumentTest.php
@@ -62,17 +62,17 @@ class ArgumentTest extends TestCase
 
     public function testGettingDefaultValue(): void
     {
-        $this->assertEquals('bar', $this->argument->defaultValue);
+        $this->assertSame('bar', $this->argument->defaultValue);
     }
 
     public function testGettingDescription(): void
     {
-        $this->assertEquals('Foo argument', $this->argument->description);
+        $this->assertSame('Foo argument', $this->argument->description);
     }
 
     public function testGettingName(): void
     {
-        $this->assertEquals('foo', $this->argument->name);
+        $this->assertSame('foo', $this->argument->name);
     }
 
     public function testSettingTypeToOptionalAndRequired(): void

--- a/src/Console/tests/Input/Compilers/CommandNotFoundExceptionTest.php
+++ b/src/Console/tests/Input/Compilers/CommandNotFoundExceptionTest.php
@@ -20,6 +20,6 @@ class CommandNotFoundExceptionTest extends TestCase
     public function testGettingCommandNameReturnsOneSetInConstructor(): void
     {
         $exception = new CommandNotFoundException('foo');
-        $this->assertEquals('foo', $exception->getCommandName());
+        $this->assertSame('foo', $exception->getCommandName());
     }
 }

--- a/src/Console/tests/Input/Compilers/InputCompilerTest.php
+++ b/src/Console/tests/Input/Compilers/InputCompilerTest.php
@@ -46,7 +46,7 @@ class InputCompilerTest extends TestCase
             'Handler'
         );
         $input = $this->compiler->compile('foo bar\\baz');
-        $this->assertEquals('bar\\baz', $input->arguments['arg']);
+        $this->assertSame('bar\\baz', $input->arguments['arg']);
     }
 
     public function testCompilingArgvInputIsCompiledCorrectly(): void
@@ -56,7 +56,7 @@ class InputCompilerTest extends TestCase
             'Handler'
         );
         $input = $this->compiler->compile(['foo', 'bar']);
-        $this->assertEquals('bar', $input->commandName);
+        $this->assertSame('bar', $input->commandName);
     }
 
     public function testCompilingArgumentShortOptionLongOption(): void
@@ -74,10 +74,10 @@ class InputCompilerTest extends TestCase
             'Handler'
         );
         $input = $this->compiler->compile('foo bar -r --opt1=dave');
-        $this->assertEquals('foo', $input->commandName);
-        $this->assertEquals('bar', $input->arguments['arg']);
+        $this->assertSame('foo', $input->commandName);
+        $this->assertSame('bar', $input->arguments['arg']);
         $this->assertNull($input->options['opt2']);
-        $this->assertEquals('dave', $input->options['opt1']);
+        $this->assertSame('dave', $input->options['opt1']);
     }
 
     public function testCompilingArrayArgumentWithOptionalArgumentAfterIsAcceptable(): void
@@ -97,7 +97,7 @@ class InputCompilerTest extends TestCase
         );
         $input = $this->compiler->compile('foo bar baz');
         $this->assertEquals(['bar', 'baz'], $input->arguments['arg1']);
-        $this->assertEquals('blah', $input->arguments['arg2']);
+        $this->assertSame('blah', $input->arguments['arg2']);
     }
 
     public function testCompilingArrayArgumentCreatesListOfValues(): void
@@ -141,7 +141,7 @@ class InputCompilerTest extends TestCase
     {
         $this->commands->registerCommand(new Command('foo', [], [], ''), 'Handler');
         $input = $this->compiler->compile(['name' => 'foo']);
-        $this->assertEquals('foo', $input->commandName);
+        $this->assertSame('foo', $input->commandName);
     }
 
     public function testCompilingArrayLongOptionWithEqualsSign(): void
@@ -158,7 +158,7 @@ class InputCompilerTest extends TestCase
             'Handler'
         );
         $input = $this->compiler->compile('foo --opt=dave --opt=young');
-        $this->assertEquals('foo', $input->commandName);
+        $this->assertSame('foo', $input->commandName);
         $this->assertEquals([], $input->arguments);
         $this->assertEquals(['dave', 'young'], $input->options['opt']);
     }
@@ -177,7 +177,7 @@ class InputCompilerTest extends TestCase
             'Handler'
         );
         $input = $this->compiler->compile('foo --opt dave --opt young');
-        $this->assertEquals('foo', $input->commandName);
+        $this->assertSame('foo', $input->commandName);
         $this->assertEquals([], $input->arguments);
         $this->assertEquals(['dave', 'young'], $input->options['opt']);
     }
@@ -194,7 +194,7 @@ class InputCompilerTest extends TestCase
             'Handler'
         );
         $input = $this->compiler->compile('foo');
-        $this->assertEquals('foo', $input->commandName);
+        $this->assertSame('foo', $input->commandName);
         $this->assertEquals([], $input->arguments);
         $this->assertEquals([], $input->options);
     }
@@ -217,9 +217,9 @@ class InputCompilerTest extends TestCase
             'Handler'
         );
         $input = $this->compiler->compile('foo --opt=dave');
-        $this->assertEquals('foo', $input->commandName);
+        $this->assertSame('foo', $input->commandName);
         $this->assertEquals([], $input->arguments);
-        $this->assertEquals('dave', $input->options['opt']);
+        $this->assertSame('dave', $input->options['opt']);
     }
 
     public function testCompilingLongOptionWithoutEqualsSign(): void
@@ -234,9 +234,9 @@ class InputCompilerTest extends TestCase
             'Handler'
         );
         $input = $this->compiler->compile('foo --opt dave');
-        $this->assertEquals('foo', $input->commandName);
+        $this->assertSame('foo', $input->commandName);
         $this->assertEquals([], $input->arguments);
-        $this->assertEquals('dave', $input->options['opt']);
+        $this->assertSame('dave', $input->options['opt']);
     }
 
     public function testCompilingLongOptionWithoutEqualsSignWithArgumentAfter(): void
@@ -251,9 +251,9 @@ class InputCompilerTest extends TestCase
             'Handler'
         );
         $input = $this->compiler->compile('foo --opt dave bar');
-        $this->assertEquals('foo', $input->commandName);
-        $this->assertEquals('bar', $input->arguments['arg']);
-        $this->assertEquals('dave', $input->options['opt']);
+        $this->assertSame('foo', $input->commandName);
+        $this->assertSame('bar', $input->arguments['arg']);
+        $this->assertSame('dave', $input->options['opt']);
     }
 
     public function testCompilingLongOptionWithoutEqualsSignWithQuotedValue(): void
@@ -271,10 +271,10 @@ class InputCompilerTest extends TestCase
             'Handler'
         );
         $input = $this->compiler->compile("foo --opt1 'dave' --opt2=\"young\"");
-        $this->assertEquals('foo', $input->commandName);
+        $this->assertSame('foo', $input->commandName);
         $this->assertEquals([], $input->arguments);
-        $this->assertEquals('dave', $input->options['opt1']);
-        $this->assertEquals('young', $input->options['opt2']);
+        $this->assertSame('dave', $input->options['opt1']);
+        $this->assertSame('young', $input->options['opt2']);
     }
 
 
@@ -294,10 +294,10 @@ class InputCompilerTest extends TestCase
             'Handler'
         );
         $input = $this->compiler->compile('foo bar baz blah');
-        $this->assertEquals('foo', $input->commandName);
-        $this->assertEquals('bar', $input->arguments['arg1']);
-        $this->assertEquals('baz', $input->arguments['arg2']);
-        $this->assertEquals('blah', $input->arguments['arg3']);
+        $this->assertSame('foo', $input->commandName);
+        $this->assertSame('bar', $input->arguments['arg1']);
+        $this->assertSame('baz', $input->arguments['arg2']);
+        $this->assertSame('blah', $input->arguments['arg3']);
         $this->assertEquals([], $input->options);
     }
 
@@ -317,7 +317,7 @@ class InputCompilerTest extends TestCase
             'Handler'
         );
         $input = $this->compiler->compile('foo -r -f -d');
-        $this->assertEquals('foo', $input->commandName);
+        $this->assertSame('foo', $input->commandName);
         $this->assertNull($input->options['opt1']);
         $this->assertNull($input->options['opt2']);
         $this->assertNull($input->options['opt3']);
@@ -340,7 +340,7 @@ class InputCompilerTest extends TestCase
             'Handler'
         );
         $input = $this->compiler->compile('foo -rfd');
-        $this->assertEquals('foo', $input->commandName);
+        $this->assertSame('foo', $input->commandName);
         $this->assertNull($input->options['opt1']);
         $this->assertNull($input->options['opt2']);
         $this->assertNull($input->options['opt3']);
@@ -376,7 +376,7 @@ class InputCompilerTest extends TestCase
             'Handler'
         );
         $input = $this->compiler->compile('foo');
-        $this->assertEquals('bar', $input->arguments['arg']);
+        $this->assertSame('bar', $input->arguments['arg']);
     }
 
     public function testCompilingRequiredArgumentsWithoutSpecifyingAllValuesThrowsException(): void
@@ -423,8 +423,8 @@ class InputCompilerTest extends TestCase
             'Handler'
         );
         $input = $this->compiler->compile('foo bar');
-        $this->assertEquals('foo', $input->commandName);
-        $this->assertEquals('bar', $input->arguments['arg']);
+        $this->assertSame('foo', $input->commandName);
+        $this->assertSame('bar', $input->arguments['arg']);
         $this->assertEquals([], $input->options);
     }
 
@@ -440,7 +440,7 @@ class InputCompilerTest extends TestCase
             'Handler'
         );
         $input = $this->compiler->compile('foo -r');
-        $this->assertEquals('foo', $input->commandName);
+        $this->assertSame('foo', $input->commandName);
         $this->assertNull($input->options['opt']);
         $this->assertEquals([], $input->arguments);
     }
@@ -460,7 +460,7 @@ class InputCompilerTest extends TestCase
             'Handler'
         );
         $input = $this->compiler->compile('foo --opt1 --opt2');
-        $this->assertEquals('foo', $input->commandName);
+        $this->assertSame('foo', $input->commandName);
         $this->assertEquals([], $input->arguments);
         $this->assertEquals(null, $input->options['opt1']);
         $this->assertEquals(null, $input->options['opt2']);
@@ -470,7 +470,7 @@ class InputCompilerTest extends TestCase
     {
         $this->commands->registerCommand(new Command('foo'), 'Handler');
         $input = $this->compiler->compile('foo');
-        $this->assertEquals('foo', $input->commandName);
+        $this->assertSame('foo', $input->commandName);
     }
 
     public function testCompilingUnregisteredCommandThrowsException(): void
@@ -496,8 +496,8 @@ class InputCompilerTest extends TestCase
             'Handler'
         );
         $input = $this->compiler->compile('foo');
-        $this->assertEquals('foo value', $input->options['foo']);
-        $this->assertEquals('bar value', $input->options['bar']);
+        $this->assertSame('foo value', $input->options['foo']);
+        $this->assertSame('bar value', $input->options['bar']);
         $this->assertFalse(isset($input->options['baz']));
     }
 

--- a/src/Console/tests/Input/OptionTest.php
+++ b/src/Console/tests/Input/OptionTest.php
@@ -58,22 +58,22 @@ class OptionTest extends TestCase
 
     public function testGettingDefaultValue(): void
     {
-        $this->assertEquals('bar', $this->option->defaultValue);
+        $this->assertSame('bar', $this->option->defaultValue);
     }
 
     public function testGettingDescription(): void
     {
-        $this->assertEquals('Foo option', $this->option->description);
+        $this->assertSame('Foo option', $this->option->description);
     }
 
     public function testGettingName(): void
     {
-        $this->assertEquals('foo', $this->option->name);
+        $this->assertSame('foo', $this->option->name);
     }
 
     public function testGettingShortName(): void
     {
-        $this->assertEquals('f', $this->option->shortName);
+        $this->assertSame('f', $this->option->shortName);
     }
 
     public function testNonAlphabeticShortName(): void

--- a/src/Console/tests/Output/Compilers/Elements/StyleTest.php
+++ b/src/Console/tests/Output/Compilers/Elements/StyleTest.php
@@ -46,19 +46,19 @@ class StyleTest extends TestCase
     public function testFormattingEmptyString(): void
     {
         $styles = new Style(Colors::RED, Colors::GREEN, [TextStyles::BOLD, TextStyles::UNDERLINE, TextStyles::BLINK]);
-        $this->assertEquals('', $styles->format(''));
+        $this->assertSame('', $styles->format(''));
     }
 
     public function testFormattingStringWithAllStyles(): void
     {
         $styles = new Style(Colors::RED, Colors::GREEN, [TextStyles::BOLD, TextStyles::UNDERLINE, TextStyles::BLINK]);
-        $this->assertEquals("\033[31;42;1;4;5mfoo\033[39;49;22;24;25m", $styles->format('foo'));
+        $this->assertSame("\033[31;42;1;4;5mfoo\033[39;49;22;24;25m", $styles->format('foo'));
     }
 
     public function testFormattingStringWithoutStyles(): void
     {
         $styles = new Style();
-        $this->assertEquals('foo', $styles->format('foo'));
+        $this->assertSame('foo', $styles->format('foo'));
     }
 
     public function testNotPassingAnythingInConstructor(): void
@@ -71,8 +71,8 @@ class StyleTest extends TestCase
     public function testPassingColorsInConstructor(): void
     {
         $style = new Style(Colors::BLUE, Colors::GREEN);
-        $this->assertEquals(Colors::BLUE, $style->foregroundColor);
-        $this->assertEquals(Colors::GREEN, $style->backgroundColor);
+        $this->assertSame(Colors::BLUE, $style->foregroundColor);
+        $this->assertSame(Colors::GREEN, $style->backgroundColor);
     }
 
     public function testRemovingInvalidTextStyle(): void
@@ -94,14 +94,14 @@ class StyleTest extends TestCase
     {
         $style = new Style();
         $style->backgroundColor = Colors::GREEN;
-        $this->assertEquals(Colors::GREEN, $style->backgroundColor);
+        $this->assertSame(Colors::GREEN, $style->backgroundColor);
     }
 
     public function testSettingForegroundColor(): void
     {
         $style = new Style();
         $style->foregroundColor = Colors::BLUE;
-        $this->assertEquals(Colors::BLUE, $style->foregroundColor);
+        $this->assertSame(Colors::BLUE, $style->foregroundColor);
     }
 
     public function testSettingNullBackgroundColor(): void

--- a/src/Console/tests/Output/Compilers/MockOutputCompilerTest.php
+++ b/src/Console/tests/Output/Compilers/MockOutputCompilerTest.php
@@ -20,12 +20,12 @@ class MockOutputCompilerTest extends TestCase
     public function testCompilingStyledMessage(): void
     {
         $compiler = new MockOutputCompiler();
-        $this->assertEquals('<foo>bar</foo>', $compiler->compile('<foo>bar</foo>', true));
+        $this->assertSame('<foo>bar</foo>', $compiler->compile('<foo>bar</foo>', true));
     }
 
     public function testCompilingUnstyledMessage(): void
     {
         $compiler = new MockOutputCompiler();
-        $this->assertEquals('<foo>bar</foo>', $compiler->compile('<foo>bar</foo>', false));
+        $this->assertSame('<foo>bar</foo>', $compiler->compile('<foo>bar</foo>', false));
     }
 }

--- a/src/Console/tests/Output/Compilers/OutputCompilerTest.php
+++ b/src/Console/tests/Output/Compilers/OutputCompilerTest.php
@@ -35,7 +35,7 @@ class OutputCompilerTest extends TestCase
         $this->elements->registerElement(new Element('foo', new Style('green', 'white')));
         $this->elements->registerElement(new Element('bar', new Style('cyan')));
         $expectedOutput = "\033[32;47mbaz\033[39;49m\033[36mblah\033[39m";
-        $this->assertEquals(
+        $this->assertSame(
             $expectedOutput,
             $this->compiler->compile('<foo>baz</foo><bar>blah</bar>')
         );
@@ -46,7 +46,7 @@ class OutputCompilerTest extends TestCase
         $this->elements->registerElement(new Element('foo', new Style('green', 'white')));
         $this->elements->registerElement(new Element('bar', new Style('cyan')));
         $expectedOutput = '';
-        $this->assertEquals(
+        $this->assertSame(
             $expectedOutput,
             $this->compiler->compile('<foo></foo>')
         );
@@ -56,27 +56,27 @@ class OutputCompilerTest extends TestCase
     {
         $this->elements->registerElement(new Element('foo', new Style('green', 'white')));
         $this->elements->registerElement(new Element('bar', new Style('cyan')));
-        $this->assertEquals('bazblah', $this->compiler->compile('<foo>baz</foo><bar>blah</bar>', false));
+        $this->assertSame('bazblah', $this->compiler->compile('<foo>baz</foo><bar>blah</bar>', false));
     }
 
     public function testCompilingElementWithZeroAsInnerText(): void
     {
         $this->elements->registerElement(new Element('foo', new Style('green')));
-        $this->assertEquals("\033[32m0\033[39m", $this->compiler->compile('<foo>0</foo>'));
+        $this->assertSame("\033[32m0\033[39m", $this->compiler->compile('<foo>0</foo>'));
     }
 
     public function testCompilingEscapedTagAtBeginning(): void
     {
         $this->elements->registerElement(new Element('foo', new Style('green')));
         $expectedOutput = '<bar>';
-        $this->assertEquals($expectedOutput, $this->compiler->compile('\\<bar>'));
+        $this->assertSame($expectedOutput, $this->compiler->compile('\\<bar>'));
     }
 
     public function testCompilingEscapedTagInBetweenTags(): void
     {
         $this->elements->registerElement(new Element('foo', new Style('green')));
         $expectedOutput = "\033[32m<bar>\033[39m";
-        $this->assertEquals($expectedOutput, $this->compiler->compile('<foo>\\<bar></foo>'));
+        $this->assertSame($expectedOutput, $this->compiler->compile('<foo>\\<bar></foo>'));
     }
 
     public function testCompilingNestedElements(): void
@@ -84,7 +84,7 @@ class OutputCompilerTest extends TestCase
         $this->elements->registerElement(new Element('foo', new Style('green', 'white')));
         $this->elements->registerElement(new Element('bar', new Style('cyan')));
         $expectedOutput = "\033[32;47m\033[36mbaz\033[39m\033[39;49m";
-        $this->assertEquals(
+        $this->assertSame(
             $expectedOutput,
             $this->compiler->compile('<foo><bar>baz</bar></foo>')
         );
@@ -95,7 +95,7 @@ class OutputCompilerTest extends TestCase
         $this->elements->registerElement(new Element('foo', new Style('green', 'white')));
         $this->elements->registerElement(new Element('bar', new Style('cyan')));
         $expectedOutput = '';
-        $this->assertEquals(
+        $this->assertSame(
             $expectedOutput,
             $this->compiler->compile('<foo><bar></bar></foo>')
         );
@@ -106,7 +106,7 @@ class OutputCompilerTest extends TestCase
         $this->elements->registerElement(new Element('foo', new Style('green', 'white')));
         $this->elements->registerElement(new Element('bar', new Style('cyan')));
         $expectedOutput = "\033[32;47mbar\033[39;49m\033[32;47m\033[36mblah\033[39m\033[39;49m\033[32;47mbaz\033[39;49m";
-        $this->assertEquals(
+        $this->assertSame(
             $expectedOutput,
             $this->compiler->compile('<foo>bar<bar>blah</bar>baz</foo>')
         );
@@ -115,7 +115,7 @@ class OutputCompilerTest extends TestCase
     public function testCompilingPlainText(): void
     {
         $expectedOutput = 'foobar';
-        $this->assertEquals(
+        $this->assertSame(
             $expectedOutput,
             $this->compiler->compile('foobar')
         );
@@ -125,7 +125,7 @@ class OutputCompilerTest extends TestCase
     {
         $this->elements->registerElement(new Element('foo', new Style('green')));
         $expectedOutput = "\033[32mbar\033[39m";
-        $this->assertEquals($expectedOutput, $this->compiler->compile('<foo>bar</foo>'));
+        $this->assertSame($expectedOutput, $this->compiler->compile('<foo>bar</foo>'));
     }
 
     public function testCompilingUnclosedElement(): void

--- a/src/Console/tests/Output/ConsoleOutputTest.php
+++ b/src/Console/tests/Output/ConsoleOutputTest.php
@@ -28,6 +28,6 @@ class ConsoleOutputTest extends TestCase
             }
         };
         $output->clear();
-        $this->assertEquals(\chr(27) . '[2J' . \chr(27) . '[;H', $output->message);
+        $this->assertSame(\chr(27) . '[2J' . \chr(27) . '[;H', $output->message);
     }
 }

--- a/src/Console/tests/Output/Formatters/CommandFormatterTest.php
+++ b/src/Console/tests/Output/Formatters/CommandFormatterTest.php
@@ -41,7 +41,7 @@ class CommandFormatterTest extends TestCase
             [],
             ''
         );
-        $this->assertEquals('foo bar [baz] blah1...blahN', $this->formatter->format($command));
+        $this->assertSame('foo bar [baz] blah1...blahN', $this->formatter->format($command));
     }
 
     public function testFormattingCommandWithMultipleArguments(): void
@@ -55,7 +55,7 @@ class CommandFormatterTest extends TestCase
             [],
             ''
         );
-        $this->assertEquals('foo bar baz', $this->formatter->format($command));
+        $this->assertSame('foo bar baz', $this->formatter->format($command));
     }
 
     public function testFormattingCommandWithNoArgumentsOrOptions(): void
@@ -66,7 +66,7 @@ class CommandFormatterTest extends TestCase
             [],
             'Foo command'
         );
-        $this->assertEquals('foo', $this->formatter->format($command));
+        $this->assertSame('foo', $this->formatter->format($command));
     }
 
     public function testFormattingCommandWithOneArgument(): void
@@ -79,7 +79,7 @@ class CommandFormatterTest extends TestCase
             [],
             'Foo command'
         );
-        $this->assertEquals('foo bar', $this->formatter->format($command));
+        $this->assertSame('foo bar', $this->formatter->format($command));
     }
 
     public function testFormattingCommandWithOneOptionWithDefaultValue(): void
@@ -92,7 +92,7 @@ class CommandFormatterTest extends TestCase
             ],
             'Foo command'
         );
-        $this->assertEquals('foo [--bar=yes|-b]', $this->formatter->format($command));
+        $this->assertSame('foo [--bar=yes|-b]', $this->formatter->format($command));
     }
 
     public function testFormattingCommandWithOneOptionWithDefaultValueButNoShortName(): void
@@ -105,7 +105,7 @@ class CommandFormatterTest extends TestCase
             ],
             'Foo command'
         );
-        $this->assertEquals('foo [--bar=yes]', $this->formatter->format($command));
+        $this->assertSame('foo [--bar=yes]', $this->formatter->format($command));
     }
 
     public function testFormattingCommandWithOneOptionWithoutShortName(): void
@@ -118,7 +118,7 @@ class CommandFormatterTest extends TestCase
             ],
             'Foo command'
         );
-        $this->assertEquals('foo [--bar]', $this->formatter->format($command));
+        $this->assertSame('foo [--bar]', $this->formatter->format($command));
     }
 
     public function testFormattingCommandWithOneOptionalArgument(): void
@@ -131,7 +131,7 @@ class CommandFormatterTest extends TestCase
             [],
             'Foo command'
         );
-        $this->assertEquals('foo [bar]', $this->formatter->format($command));
+        $this->assertSame('foo [bar]', $this->formatter->format($command));
     }
 
     public function testFormattingCommandWithOptionalArrayArgument(): void
@@ -144,6 +144,6 @@ class CommandFormatterTest extends TestCase
             [],
             'Foo command'
         );
-        $this->assertEquals('foo [blah1]...[blahN]', $this->formatter->format($command));
+        $this->assertSame('foo [blah1]...[blahN]', $this->formatter->format($command));
     }
 }

--- a/src/Console/tests/Output/Formatters/PaddingFormatterTest.php
+++ b/src/Console/tests/Output/Formatters/PaddingFormatterTest.php
@@ -34,7 +34,7 @@ class PaddingFormatterTest extends TestCase
         ];
         $this->formatter->setPaddingString('+');
         $formattedText = $this->formatter->format($rows, fn ($row) => $row[0] . '-' . $row[1]);
-        $this->assertEquals(
+        $this->assertSame(
             'a++-b++' . PHP_EOL . 'cd+-ee+' . PHP_EOL . 'fg+-hhh' . PHP_EOL . 'ijk-ll+',
             $formattedText
         );
@@ -50,7 +50,7 @@ class PaddingFormatterTest extends TestCase
         ];
         $this->formatter->setPaddingString('+');
         $formattedText = $this->formatter->format($rows, fn ($row) => $row[0]);
-        $this->assertEquals('a++' . PHP_EOL . 'cd+' . PHP_EOL . 'fg+' . PHP_EOL . 'ijk', $formattedText);
+        $this->assertSame('a++' . PHP_EOL . 'cd+' . PHP_EOL . 'fg+' . PHP_EOL . 'ijk', $formattedText);
     }
 
     public function testCustomRowSeparatorWithRowArrays(): void
@@ -63,7 +63,7 @@ class PaddingFormatterTest extends TestCase
         ];
         $this->formatter->setEolChar('<br>');
         $formattedText = $this->formatter->format($rows, fn ($row) => $row[0] . '-' . $row[1]);
-        $this->assertEquals('a  -b  <br>cd -ee <br>fg -hhh<br>ijk-ll ', $formattedText);
+        $this->assertSame('a  -b  <br>cd -ee <br>fg -hhh<br>ijk-ll ', $formattedText);
     }
 
     public function testCustomRowSeparatorWithStringRows(): void
@@ -76,13 +76,13 @@ class PaddingFormatterTest extends TestCase
         ];
         $this->formatter->setEolChar('<br>');
         $formattedText = $this->formatter->format($rows, fn ($row) => $row[0]);
-        $this->assertEquals('a  <br>cd <br>fg <br>ijk', $formattedText);
+        $this->assertSame('a  <br>cd <br>fg <br>ijk', $formattedText);
     }
 
     public function testGettingEOLChar(): void
     {
         $this->formatter->setEolChar('foo');
-        $this->assertEquals('foo', $this->formatter->getEolChar());
+        $this->assertSame('foo', $this->formatter->getEolChar());
     }
 
     public function testNormalizingColumns(): void
@@ -114,14 +114,14 @@ class PaddingFormatterTest extends TestCase
         // Format with the padding after the string
         $this->formatter->setPadAfter(true);
         $formattedRows = $this->formatter->format($rows, fn ($row) => $row[0] . '-' . $row[1]);
-        $this->assertEquals(
+        $this->assertSame(
             'a  -b  ' . PHP_EOL . 'cd -ee ' . PHP_EOL . 'fg -hhh' . PHP_EOL . 'ijk-ll ',
             $formattedRows
         );
         // Format with the padding before the string
         $this->formatter->setPadAfter(false);
         $formattedRows = $this->formatter->format($rows, fn ($row) => $row[0] . '-' . $row[1]);
-        $this->assertEquals(
+        $this->assertSame(
             '  a-  b' . PHP_EOL . ' cd- ee' . PHP_EOL . ' fg-hhh' . PHP_EOL . 'ijk- ll',
             $formattedRows
         );
@@ -129,12 +129,12 @@ class PaddingFormatterTest extends TestCase
 
     public function testPaddingEmptyArray(): void
     {
-        $this->assertEquals('', $this->formatter->format([], fn ($row) => $row[0]));
+        $this->assertSame('', $this->formatter->format([], fn ($row) => $row[0]));
     }
 
     public function testPaddingSingleArray(): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             'foo' . PHP_EOL . 'bar',
             $this->formatter->format(['  foo  ', 'bar'], fn ($row) => $row[0])
         );
@@ -142,7 +142,7 @@ class PaddingFormatterTest extends TestCase
 
     public function testPaddingSingleString(): void
     {
-        $this->assertEquals('foo', $this->formatter->format(['  foo  '], fn ($row) => $row[0]));
+        $this->assertSame('foo', $this->formatter->format(['  foo  '], fn ($row) => $row[0]));
     }
 
     public function testPaddingStringRows(): void
@@ -156,10 +156,10 @@ class PaddingFormatterTest extends TestCase
         // Format with the padding after the string
         $this->formatter->setPadAfter(true);
         $formattedRows = $this->formatter->format($rows, fn ($row) => $row[0]);
-        $this->assertEquals('a  ' . PHP_EOL . 'cd ' . PHP_EOL . 'fg ' . PHP_EOL . 'ijk', $formattedRows);
+        $this->assertSame('a  ' . PHP_EOL . 'cd ' . PHP_EOL . 'fg ' . PHP_EOL . 'ijk', $formattedRows);
         // Format with the padding before the string
         $this->formatter->setPadAfter(false);
         $formattedRows = $this->formatter->format($rows, fn ($row) => $row[0]);
-        $this->assertEquals('  a' . PHP_EOL . ' cd' . PHP_EOL . ' fg' . PHP_EOL . 'ijk', $formattedRows);
+        $this->assertSame('  a' . PHP_EOL . ' cd' . PHP_EOL . ' fg' . PHP_EOL . 'ijk', $formattedRows);
     }
 }

--- a/src/Console/tests/Output/Formatters/TableFormatterTest.php
+++ b/src/Console/tests/Output/Formatters/TableFormatterTest.php
@@ -40,7 +40,7 @@ class TableFormatterTest extends TestCase
             '+-----+' . PHP_EOL .
             '| a   |' . PHP_EOL .
             '+-----+';
-        $this->assertEquals($expected, $this->formatter->format($rows, $headers));
+        $this->assertSame($expected, $this->formatter->format($rows, $headers));
     }
 
     public function testFormattingSingleRow(): void
@@ -50,7 +50,7 @@ class TableFormatterTest extends TestCase
             '+---+----+-----+' . PHP_EOL .
             '| a | bb | ccc |' . PHP_EOL .
             '+---+----+-----+';
-        $this->assertEquals($expected, $this->formatter->format($rows));
+        $this->assertSame($expected, $this->formatter->format($rows));
     }
 
     public function testFormattingSingleRowAndColumn(): void
@@ -60,7 +60,7 @@ class TableFormatterTest extends TestCase
             '+---+' . PHP_EOL .
             '| a |' . PHP_EOL .
             '+---+';
-        $this->assertEquals($expected, $this->formatter->format($rows));
+        $this->assertSame($expected, $this->formatter->format($rows));
     }
 
     public function testFormattingTableWithCustomCharacters(): void
@@ -85,7 +85,7 @@ class TableFormatterTest extends TestCase
             'I_ aa_I_ bb_I_   _I<br>' .
             'I_aaa_I_bbb_I_ccc_I<br>' .
             '*=====*=====*=====*';
-        $this->assertEquals($expected, $this->formatter->format($rows, $headers));
+        $this->assertSame($expected, $this->formatter->format($rows, $headers));
     }
 
     public function testFormattingTableWithCustomPaddingString(): void
@@ -96,7 +96,7 @@ class TableFormatterTest extends TestCase
             '+-----+' . PHP_EOL .
             '|__a__|' . PHP_EOL .
             '+-----+';
-        $this->assertEquals($expected, $this->formatter->format($rows));
+        $this->assertSame($expected, $this->formatter->format($rows));
     }
 
     public function testFormattingTableWithHeadersButWithoutRows(): void
@@ -120,7 +120,7 @@ class TableFormatterTest extends TestCase
             '| aa  | bb  |     |      |' . PHP_EOL .
             '| aaa | bbb | ccc |      |' . PHP_EOL .
             '+-----+-----+-----+------+';
-        $this->assertEquals($expected, $this->formatter->format($rows, $headers));
+        $this->assertSame($expected, $this->formatter->format($rows, $headers));
     }
 
     public function testFormattingTableWithMoreRowColumnsThanHeaders(): void
@@ -139,7 +139,7 @@ class TableFormatterTest extends TestCase
             '| aa  | bb  |     |' . PHP_EOL .
             '| aaa | bbb | ccc |' . PHP_EOL .
             '+-----+-----+-----+';
-        $this->assertEquals($expected, $this->formatter->format($rows, $headers));
+        $this->assertSame($expected, $this->formatter->format($rows, $headers));
     }
 
     public function testFormattingTableWithoutHeaders(): void
@@ -155,7 +155,7 @@ class TableFormatterTest extends TestCase
             '| aa  | bb  |     |' . PHP_EOL .
             '| aaa | bbb | ccc |' . PHP_EOL .
             '+-----+-----+-----+';
-        $this->assertEquals($expected, $this->formatter->format($rows));
+        $this->assertSame($expected, $this->formatter->format($rows));
     }
 
     public function testSettingRowsWithNonArrayValues(): void
@@ -165,6 +165,6 @@ class TableFormatterTest extends TestCase
             '| foo |' . PHP_EOL .
             '| bar |' . PHP_EOL .
             '+-----+';
-        $this->assertEquals($expected, $this->formatter->format(['foo', 'bar']));
+        $this->assertSame($expected, $this->formatter->format(['foo', 'bar']));
     }
 }

--- a/src/Console/tests/Output/Lexers/OutputTokenTest.php
+++ b/src/Console/tests/Output/Lexers/OutputTokenTest.php
@@ -21,8 +21,8 @@ class OutputTokenTest extends TestCase
     public function testPropertiesAreSetInConstructor(): void
     {
         $token = new OutputToken(OutputTokenTypes::T_WORD, 'foo', 24);
-        $this->assertEquals(OutputTokenTypes::T_WORD, $token->type);
-        $this->assertEquals('foo', $token->value);
-        $this->assertEquals(24, $token->position);
+        $this->assertSame(OutputTokenTypes::T_WORD, $token->type);
+        $this->assertSame('foo', $token->value);
+        $this->assertSame(24, $token->position);
     }
 }

--- a/src/Console/tests/Output/OutputTest.php
+++ b/src/Console/tests/Output/OutputTest.php
@@ -30,7 +30,7 @@ class OutputTest extends TestCase
     {
         ob_start();
         $this->output->clear();
-        $this->assertEquals(\chr(27) . '[2J' . \chr(27) . '[;H', ob_get_clean());
+        $this->assertSame(\chr(27) . '[2J' . \chr(27) . '[;H', ob_get_clean());
     }
 
     public function testGetDriverReturnsOneSetInConstructor(): void
@@ -44,28 +44,28 @@ class OutputTest extends TestCase
     {
         ob_start();
         $this->output->writeln(['foo', 'bar']);
-        $this->assertEquals('foo' . PHP_EOL . 'bar' . PHP_EOL, ob_get_clean());
+        $this->assertSame('foo' . PHP_EOL . 'bar' . PHP_EOL, ob_get_clean());
     }
 
     public function testWritingMultipleMessagesWithNoNewLines(): void
     {
         ob_start();
         $this->output->write(['foo', 'bar']);
-        $this->assertEquals('foobar', ob_get_clean());
+        $this->assertSame('foobar', ob_get_clean());
     }
 
     public function testWritingSingleMessageWithNewLine(): void
     {
         ob_start();
         $this->output->writeln('foo');
-        $this->assertEquals('foo' . PHP_EOL, ob_get_clean());
+        $this->assertSame('foo' . PHP_EOL, ob_get_clean());
     }
 
     public function testWritingSingleMessageWithNoNewLine(): void
     {
         ob_start();
         $this->output->write('foo');
-        $this->assertEquals('foo', ob_get_clean());
+        $this->assertSame('foo', ob_get_clean());
     }
 
     public function testWritingStyledMessageWithStylingDisabled(): void
@@ -73,6 +73,6 @@ class OutputTest extends TestCase
         ob_start();
         $this->output->includeStyles(false);
         $this->output->write('<b>foo</b>');
-        $this->assertEquals('foo', ob_get_clean());
+        $this->assertSame('foo', ob_get_clean());
     }
 }

--- a/src/Console/tests/Output/Parsers/NodeTest.php
+++ b/src/Console/tests/Output/Parsers/NodeTest.php
@@ -47,6 +47,6 @@ class NodeTest extends TestCase
     public function testGettingValue(): void
     {
         $node = new AstNode('foo');
-        $this->assertEquals('foo', $node->value);
+        $this->assertSame('foo', $node->value);
     }
 }

--- a/src/Console/tests/Output/Prompts/MultipleChoiceTest.php
+++ b/src/Console/tests/Output/Prompts/MultipleChoiceTest.php
@@ -75,19 +75,19 @@ class MultipleChoiceTest extends TestCase
 
     public function testFormattingSingleAnswer(): void
     {
-        $this->assertEquals('foo', $this->indexedChoiceQuestion->formatAnswer(1));
-        $this->assertEquals('bar', $this->indexedChoiceQuestion->formatAnswer(2));
-        $this->assertEquals('baz', $this->indexedChoiceQuestion->formatAnswer(3));
+        $this->assertSame('foo', $this->indexedChoiceQuestion->formatAnswer(1));
+        $this->assertSame('bar', $this->indexedChoiceQuestion->formatAnswer(2));
+        $this->assertSame('baz', $this->indexedChoiceQuestion->formatAnswer(3));
     }
 
     public function testFormattingStringAnswer(): void
     {
-        $this->assertEquals('foo', $this->indexedChoiceQuestion->formatAnswer('1'));
-        $this->assertEquals('bar', $this->indexedChoiceQuestion->formatAnswer('2'));
-        $this->assertEquals('baz', $this->indexedChoiceQuestion->formatAnswer('3'));
-        $this->assertEquals('b', $this->keyedChoiceQuestion->formatAnswer('a'));
-        $this->assertEquals('d', $this->keyedChoiceQuestion->formatAnswer('c'));
-        $this->assertEquals('f', $this->keyedChoiceQuestion->formatAnswer('e'));
+        $this->assertSame('foo', $this->indexedChoiceQuestion->formatAnswer('1'));
+        $this->assertSame('bar', $this->indexedChoiceQuestion->formatAnswer('2'));
+        $this->assertSame('baz', $this->indexedChoiceQuestion->formatAnswer('3'));
+        $this->assertSame('b', $this->keyedChoiceQuestion->formatAnswer('a'));
+        $this->assertSame('d', $this->keyedChoiceQuestion->formatAnswer('c'));
+        $this->assertSame('f', $this->keyedChoiceQuestion->formatAnswer('e'));
     }
 
     public function testGettingAllowsMultipleChoices(): void
@@ -149,7 +149,7 @@ class MultipleChoiceTest extends TestCase
     public function testSettingAnswerLineString(): void
     {
         $this->indexedChoiceQuestion->setAnswerLineString('foo');
-        $this->assertEquals('foo', $this->indexedChoiceQuestion->getAnswerLineString());
+        $this->assertSame('foo', $this->indexedChoiceQuestion->getAnswerLineString());
     }
 
     public function testStringAsAnswerToIndexedChoices(): void

--- a/src/Console/tests/Output/Prompts/PromptTest.php
+++ b/src/Console/tests/Output/Prompts/PromptTest.php
@@ -45,7 +45,7 @@ class PromptTest extends TestCase
         $this->output->method('write')
             ->with("<question>{$question->text}</question>");
         $answer = $this->prompt->ask($question, $this->output);
-        $this->assertEquals('Dave', $answer);
+        $this->assertSame('Dave', $answer);
     }
 
     public function testAskingIndexedMultipleChoiceQuestion(): void
@@ -66,7 +66,7 @@ class PromptTest extends TestCase
             ->method('write')
             ->with('  > ');
         $answer = $this->prompt->ask($question, $this->output);
-        $this->assertEquals('bar', $answer);
+        $this->assertSame('bar', $answer);
     }
 
     public function testAskingKeyedMultipleChoiceQuestion(): void
@@ -87,7 +87,7 @@ class PromptTest extends TestCase
             ->method('write')
             ->with('  > ');
         $answer = $this->prompt->ask($question, $this->output);
-        $this->assertEquals('d', $answer);
+        $this->assertSame('d', $answer);
     }
 
     public function testAskingMultipleChoiceQuestionWithCustomAnswerLineString(): void
@@ -109,7 +109,7 @@ class PromptTest extends TestCase
             ->method('write')
             ->with('  : ');
         $answer = $this->prompt->ask($question, $this->output);
-        $this->assertEquals('foo', $answer);
+        $this->assertSame('foo', $answer);
     }
 
     public function testAskingQuestion(): void
@@ -120,7 +120,7 @@ class PromptTest extends TestCase
         $this->output->method('write')
             ->with("<question>{$question->text}</question>");
         $answer = $this->prompt->ask($question, $this->output);
-        $this->assertEquals('Dave', $answer);
+        $this->assertSame('Dave', $answer);
     }
 
     public function testAskingHiddenAnswerQuestionWillUseDriver(): void
@@ -134,7 +134,7 @@ class PromptTest extends TestCase
             ->method('getDriver')
             ->willReturn($driver);
         $answer = $this->prompt->ask(new Question('Question', null, true), $this->output);
-        $this->assertEquals('foo', $answer);
+        $this->assertSame('foo', $answer);
     }
 
     public function testEmptyDefaultAnswerToIndexedChoices(): void
@@ -177,6 +177,6 @@ class PromptTest extends TestCase
         $this->output->method('write')
             ->with("<question>{$question->text}</question>");
         $answer = $this->prompt->ask($question, $this->output);
-        $this->assertEquals('unknown', $answer);
+        $this->assertSame('unknown', $answer);
     }
 }

--- a/src/Console/tests/Output/Prompts/QuestionTest.php
+++ b/src/Console/tests/Output/Prompts/QuestionTest.php
@@ -26,16 +26,16 @@ class QuestionTest extends TestCase
 
     public function testFormattingAnswer(): void
     {
-        $this->assertEquals('foo', $this->question->formatAnswer('foo'));
+        $this->assertSame('foo', $this->question->formatAnswer('foo'));
     }
 
     public function testGettingDefaultAnswer(): void
     {
-        $this->assertEquals('foo', $this->question->defaultAnswer);
+        $this->assertSame('foo', $this->question->defaultAnswer);
     }
 
     public function testGettingQuestion(): void
     {
-        $this->assertEquals('Dummy question', $this->question->text);
+        $this->assertSame('Dummy question', $this->question->text);
     }
 }

--- a/src/Console/tests/Output/SilentOutputTest.php
+++ b/src/Console/tests/Output/SilentOutputTest.php
@@ -33,7 +33,7 @@ class SilentOutputTest extends TestCase
 
     public function testReadLineReturnsEmptyString(): void
     {
-        $this->assertEquals('', $this->output->readLine());
+        $this->assertSame('', $this->output->readLine());
     }
 
     public function testWrite(): void

--- a/src/Console/tests/Output/StreamOutputTest.php
+++ b/src/Console/tests/Output/StreamOutputTest.php
@@ -54,7 +54,7 @@ class StreamOutputTest extends TestCase
     {
         fwrite($this->inputStream, 'foo');
         rewind($this->inputStream);
-        $this->assertEquals('foo', $this->output->readLine());
+        $this->assertSame('foo', $this->output->readLine());
     }
 
     public function testReadingLineThatIsNotAtEofThrowsException(): void
@@ -71,27 +71,27 @@ class StreamOutputTest extends TestCase
     {
         $this->output->write(['foo', 'bar']);
         rewind($this->output->getOutputStream());
-        $this->assertEquals('foobar', stream_get_contents($this->output->getOutputStream()));
+        $this->assertSame('foobar', stream_get_contents($this->output->getOutputStream()));
     }
 
     public function testWriteOnString(): void
     {
         $this->output->write('foo');
         rewind($this->output->getOutputStream());
-        $this->assertEquals('foo', stream_get_contents($this->output->getOutputStream()));
+        $this->assertSame('foo', stream_get_contents($this->output->getOutputStream()));
     }
 
     public function testWritelnOnArray(): void
     {
         $this->output->writeln(['foo', 'bar']);
         rewind($this->output->getOutputStream());
-        $this->assertEquals('foo' . PHP_EOL . 'bar' . PHP_EOL, stream_get_contents($this->output->getOutputStream()));
+        $this->assertSame('foo' . PHP_EOL . 'bar' . PHP_EOL, stream_get_contents($this->output->getOutputStream()));
     }
 
     public function testWritelnOnString(): void
     {
         $this->output->writeln('foo');
         rewind($this->output->getOutputStream());
-        $this->assertEquals('foo' . PHP_EOL, stream_get_contents($this->output->getOutputStream()));
+        $this->assertSame('foo' . PHP_EOL, stream_get_contents($this->output->getOutputStream()));
     }
 }

--- a/src/ContentNegotiation/tests/AcceptCharsetEncodingMatcherTest.php
+++ b/src/ContentNegotiation/tests/AcceptCharsetEncodingMatcherTest.php
@@ -38,7 +38,7 @@ class AcceptCharsetEncodingMatcherTest extends TestCase
     public function testBestEncodingCanMatchMismatchingCasesInAcceptCharset(): void
     {
         $this->headers->add('Accept-Charset', 'UTF-8');
-        $this->assertEquals('utf-8', $this->matcher->getBestEncodingMatch(['utf-8'], $this->request));
+        $this->assertSame('utf-8', $this->matcher->getBestEncodingMatch(['utf-8'], $this->request));
     }
 
     public function testBestEncodingCanMatchMismatchingCasesInAcceptHeader(): void
@@ -49,7 +49,7 @@ class AcceptCharsetEncodingMatcherTest extends TestCase
             $this->request,
             $this->headerParser->parseAcceptHeader($this->headers)[0]
         );
-        $this->assertEquals('utf-8', $encoding);
+        $this->assertSame('utf-8', $encoding);
     }
 
     public function testBestEncodingComesFromAcceptCharsetHeaderIfItAndAcceptHeaderHaveSupportedEncodings(): void
@@ -61,14 +61,14 @@ class AcceptCharsetEncodingMatcherTest extends TestCase
             $this->request,
             $this->headerParser->parseAcceptHeader($this->headers)[0]
         );
-        $this->assertEquals('utf-16', $encoding);
+        $this->assertSame('utf-16', $encoding);
     }
 
     public function testBestEncodingComesFromAcceptCharsetHeaderIfNoAcceptHeaderIsPresent(): void
     {
         $this->headers->add('Accept-Charset', 'utf-16');
         $encoding = $this->matcher->getBestEncodingMatch(['utf-16'], $this->request);
-        $this->assertEquals('utf-16', $encoding);
+        $this->assertSame('utf-16', $encoding);
     }
 
     public function testBestEncodingComesFromAcceptHeaderIfAcceptCharsetHeaderIsNotPresent(): void
@@ -79,14 +79,14 @@ class AcceptCharsetEncodingMatcherTest extends TestCase
             $this->request,
             $this->headerParser->parseAcceptHeader($this->headers)[0]
         );
-        $this->assertEquals('utf-16', $encoding);
+        $this->assertSame('utf-16', $encoding);
     }
 
     public function testBestEncodingComesFromWildcardInAcceptCharsetHeader(): void
     {
         $this->headers->add('Accept-Charset', '*');
         $encoding = $this->matcher->getBestEncodingMatch(['utf-8'], $this->request);
-        $this->assertEquals('utf-8', $encoding);
+        $this->assertSame('utf-8', $encoding);
     }
 
     public function testBestEncodingComesFromWildcardInContentTypeHeader(): void
@@ -97,7 +97,7 @@ class AcceptCharsetEncodingMatcherTest extends TestCase
             $this->request,
             $this->headerParser->parseContentTypeHeader($this->headers)
         );
-        $this->assertEquals('utf-8', $encoding);
+        $this->assertSame('utf-8', $encoding);
     }
 
     public function testBestEncodingIsChosenInOrderOfQualityScore(): void
@@ -106,7 +106,7 @@ class AcceptCharsetEncodingMatcherTest extends TestCase
         $this->headers->add('Accept-Charset', 'utf-16; q=0.5', true);
         $this->headers->add('Accept-Charset', 'utf-32; q=0.6', true);
         $encoding = $this->matcher->getBestEncodingMatch(['utf-8', 'utf-16', 'utf-32'], $this->request);
-        $this->assertEquals('utf-32', $encoding);
+        $this->assertSame('utf-32', $encoding);
     }
 
     public function testBestEncodingIsFirstSupportedOneIfBothHaveEqualScoresAndAreNotWildcards(): void
@@ -114,7 +114,7 @@ class AcceptCharsetEncodingMatcherTest extends TestCase
         $this->headers->add('Accept-Charset', 'utf-8');
         $this->headers->add('Accept-Charset', 'utf-16', true);
         $encoding = $this->matcher->getBestEncodingMatch(['utf-8', 'utf-16'], $this->request);
-        $this->assertEquals('utf-8', $encoding);
+        $this->assertSame('utf-8', $encoding);
     }
 
     public function testBestEncodingIsFirstSupportedOneIfBothHaveEqualScoresAndAreWildcards(): void
@@ -122,7 +122,7 @@ class AcceptCharsetEncodingMatcherTest extends TestCase
         $this->headers->add('Accept-Charset', '*');
         $this->headers->add('Accept-Charset', '*', true);
         $encoding = $this->matcher->getBestEncodingMatch(['utf-8'], $this->request);
-        $this->assertEquals('utf-8', $encoding);
+        $this->assertSame('utf-8', $encoding);
     }
 
     public function testBestEncodingIsNonWildcardIfBothHaveEqualsScoresAndWildcardIsBeforeNon(): void
@@ -130,7 +130,7 @@ class AcceptCharsetEncodingMatcherTest extends TestCase
         $this->headers->add('Accept-Charset', '*');
         $this->headers->add('Accept-Charset', 'utf-8', true);
         $encoding = $this->matcher->getBestEncodingMatch(['utf-8'], $this->request);
-        $this->assertEquals('utf-8', $encoding);
+        $this->assertSame('utf-8', $encoding);
     }
 
     public function testBestEncodingIsNonWildcardIfBothHaveEqualsScoresAndWildcardisAfterNon(): void
@@ -138,7 +138,7 @@ class AcceptCharsetEncodingMatcherTest extends TestCase
         $this->headers->add('Accept-Charset', 'utf-8');
         $this->headers->add('Accept-Charset', '*', true);
         $encoding = $this->matcher->getBestEncodingMatch(['utf-8'], $this->request);
-        $this->assertEquals('utf-8', $encoding);
+        $this->assertSame('utf-8', $encoding);
     }
 
     public function testBestEncodingIsNullWhenFormatterDoesNotSupportCharsetFromContentTypeHeader(): void

--- a/src/ContentNegotiation/tests/AcceptLanguageMatcherTest.php
+++ b/src/ContentNegotiation/tests/AcceptLanguageMatcherTest.php
@@ -34,7 +34,7 @@ class AcceptLanguageMatcherTest extends TestCase
     {
         $this->headers->add('Accept-Language', '*');
         $this->headers->add('Accept-Language', '*', true);
-        $this->assertEquals('en-US', (new AcceptLanguageMatcher(['en-US', 'en-GB']))->getBestLanguageMatch($this->request));
+        $this->assertSame('en-US', (new AcceptLanguageMatcher(['en-US', 'en-GB']))->getBestLanguageMatch($this->request));
     }
 
     public function testLanguageIsNullWhenNoMatchesAreFound(): void
@@ -48,7 +48,7 @@ class AcceptLanguageMatcherTest extends TestCase
     {
         $this->headers->add('Accept-Language', 'en-US; q=0.1');
         $this->headers->add('Accept-Language', 'en-GB; q=0.5', true);
-        $this->assertEquals('en-GB', (new AcceptLanguageMatcher(['en-US', 'en-GB']))->getBestLanguageMatch($this->request));
+        $this->assertSame('en-GB', (new AcceptLanguageMatcher(['en-US', 'en-GB']))->getBestLanguageMatch($this->request));
     }
 
     public function testLanguageWithWildcardIsRankedAfterLanguagesWithEqualQualityScore(): void
@@ -56,7 +56,7 @@ class AcceptLanguageMatcherTest extends TestCase
         $this->headers->add('Accept-Language', 'en-US; q=1');
         $this->headers->add('Accept-Language', '*; q=1', true);
         $this->headers->add('Accept-Language', 'en-GB; q=1', true);
-        $this->assertEquals('en-US', (new AcceptLanguageMatcher(['en-GB', 'en-US']))->getBestLanguageMatch($this->request));
+        $this->assertSame('en-US', (new AcceptLanguageMatcher(['en-GB', 'en-US']))->getBestLanguageMatch($this->request));
     }
 
     public function testLanguageWithZeroQualityScoreIsExcluded(): void
@@ -69,17 +69,17 @@ class AcceptLanguageMatcherTest extends TestCase
     public function testTruncatedLanguageCanMatchSupportedLanguage(): void
     {
         $this->headers->add('Accept-Language', 'en-US-123; q=1');
-        $this->assertEquals('en-US', (new AcceptLanguageMatcher(['en-US']))->getBestLanguageMatch($this->request));
+        $this->assertSame('en-US', (new AcceptLanguageMatcher(['en-US']))->getBestLanguageMatch($this->request));
 
         // Purposely overwriting the previous Accept-Language header
         $this->headers->add('Accept-Language', 'en-US; q=1');
-        $this->assertEquals('en', (new AcceptLanguageMatcher(['en']))->getBestLanguageMatch($this->request));
+        $this->assertSame('en', (new AcceptLanguageMatcher(['en']))->getBestLanguageMatch($this->request));
     }
 
     public function testWildcardWithHighestScoreMatchesFirstSupportedLanguage(): void
     {
         $this->headers->add('Accept-Language', '*; q=1');
         $this->headers->add('Accept-Language', 'en-GB; q=0.5', true);
-        $this->assertEquals('de-DE', (new AcceptLanguageMatcher(['de-DE']))->getBestLanguageMatch($this->request));
+        $this->assertSame('de-DE', (new AcceptLanguageMatcher(['de-DE']))->getBestLanguageMatch($this->request));
     }
 }

--- a/src/ContentNegotiation/tests/ContentNegotiationResultTest.php
+++ b/src/ContentNegotiation/tests/ContentNegotiationResultTest.php
@@ -23,7 +23,7 @@ class ContentNegotiationResultTest extends TestCase
         /** @var IMediaTypeFormatter $formatter */
         $formatter = $this->createMock(IMediaTypeFormatter::class);
         $results = new ContentNegotiationResult($formatter, 'foo/bar', 'utf-8', null);
-        $this->assertEquals('utf-8', $results->getEncoding());
+        $this->assertSame('utf-8', $results->getEncoding());
     }
 
     public function testGettingFormatterReturnsSameOneInConstructor(): void
@@ -39,7 +39,7 @@ class ContentNegotiationResultTest extends TestCase
         /** @var IMediaTypeFormatter $formatter */
         $formatter = $this->createMock(IMediaTypeFormatter::class);
         $results = new ContentNegotiationResult($formatter, 'foo/bar', 'utf-8', 'en-US');
-        $this->assertEquals('en-US', $results->getLanguage());
+        $this->assertSame('en-US', $results->getLanguage());
     }
 
     public function testGettingMediaTypeReturnsSameOneInConstructor(): void
@@ -47,6 +47,6 @@ class ContentNegotiationResultTest extends TestCase
         /** @var IMediaTypeFormatter $formatter */
         $formatter = $this->createMock(IMediaTypeFormatter::class);
         $results = new ContentNegotiationResult($formatter, 'foo/bar', null, null);
-        $this->assertEquals('foo/bar', $results->getMediaType());
+        $this->assertSame('foo/bar', $results->getMediaType());
     }
 }

--- a/src/ContentNegotiation/tests/ContentNegotiatorTest.php
+++ b/src/ContentNegotiation/tests/ContentNegotiatorTest.php
@@ -146,9 +146,9 @@ class ContentNegotiatorTest extends TestCase
         $negotiator = new ContentNegotiator([$formatter]);
         $result = $negotiator->negotiateRequestContent(User::class, $this->request);
         $this->assertSame($formatter, $result->getFormatter());
-        $this->assertEquals('text/html', $result->getMediaType());
-        $this->assertEquals('utf-16', $result->getEncoding());
-        $this->assertEquals('en-US', $result->getLanguage());
+        $this->assertSame('text/html', $result->getMediaType());
+        $this->assertSame('utf-16', $result->getEncoding());
+        $this->assertSame('en-US', $result->getLanguage());
     }
 
     public function testRequestFormatterIsNullWithNoContentTypeSpecified(): void
@@ -157,7 +157,7 @@ class ContentNegotiatorTest extends TestCase
         $negotiator = new ContentNegotiator([$formatter]);
         $result = $negotiator->negotiateRequestContent(User::class, $this->request);
         $this->assertNull($result->getFormatter());
-        $this->assertEquals('application/octet-stream', $result->getMediaType());
+        $this->assertSame('application/octet-stream', $result->getMediaType());
         $this->assertNull($result->getEncoding());
     }
 
@@ -176,9 +176,9 @@ class ContentNegotiatorTest extends TestCase
         $negotiator = new ContentNegotiator([$formatter]);
         $result = $negotiator->negotiateRequestContent(User::class, $this->request);
         $this->assertSame($formatter, $result->getFormatter());
-        $this->assertEquals('text/html', $result->getMediaType());
-        $this->assertEquals('utf-8', $result->getEncoding());
-        $this->assertEquals('en-US', $result->getLanguage());
+        $this->assertSame('text/html', $result->getMediaType());
+        $this->assertSame('utf-8', $result->getEncoding());
+        $this->assertSame('en-US', $result->getLanguage());
     }
 
     public function testResponseFormatterIsFirstFormatterRegisteredWithNoAcceptSpecified(): void
@@ -196,7 +196,7 @@ class ContentNegotiatorTest extends TestCase
         $result = $negotiator->negotiateResponseContent(User::class, $this->request);
         $this->assertSame($formatter1, $result->getFormatter());
         // Verify it's using the default media type
-        $this->assertEquals('application/json', $result->getMediaType());
+        $this->assertSame('application/json', $result->getMediaType());
         $this->assertNull($result->getEncoding());
     }
 
@@ -219,7 +219,7 @@ class ContentNegotiatorTest extends TestCase
         $result = $negotiator->negotiateResponseContent(User::class, $this->request);
         $this->assertSame($formatter2, $result->getFormatter());
         // Verify it's using the default media type
-        $this->assertEquals('application/json', $result->getMediaType());
+        $this->assertSame('application/json', $result->getMediaType());
         $this->assertNull($result->getEncoding());
     }
 
@@ -256,8 +256,8 @@ class ContentNegotiatorTest extends TestCase
         $negotiator = new ContentNegotiator([$formatter]);
         $result = $negotiator->negotiateResponseContent(User::class, $this->request);
         $this->assertSame($formatter, $result->getFormatter());
-        $this->assertEquals('application/json', $result->getMediaType());
-        $this->assertEquals('utf-16', $result->getEncoding());
+        $this->assertSame('application/json', $result->getMediaType());
+        $this->assertSame('utf-16', $result->getEncoding());
     }
 
     public function testResponseEncodingIsSetFromAcceptCharsetHeaderWhenPresent(): void
@@ -275,7 +275,7 @@ class ContentNegotiatorTest extends TestCase
         $negotiator = new ContentNegotiator([$formatter]);
         $result = $negotiator->negotiateResponseContent(User::class, $this->request);
         $this->assertSame($formatter, $result->getFormatter());
-        $this->assertEquals('utf-8', $result->getEncoding());
+        $this->assertSame('utf-8', $result->getEncoding());
     }
 
     public function testResponseLanguageIsNullWhenNoMatchingSupportedLanguage(): void
@@ -322,9 +322,9 @@ class ContentNegotiatorTest extends TestCase
         $negotiator = new ContentNegotiator([$formatter], null, null, $languageMatcher);
         $result = $negotiator->negotiateResponseContent(User::class, $this->request);
         $this->assertSame($formatter, $result->getFormatter());
-        $this->assertEquals('application/json', $result->getMediaType());
-        $this->assertEquals('utf-8', $result->getEncoding());
-        $this->assertEquals('en-US', $result->getLanguage());
+        $this->assertSame('application/json', $result->getMediaType());
+        $this->assertSame('utf-8', $result->getEncoding());
+        $this->assertSame('en-US', $result->getLanguage());
     }
 
     /**

--- a/src/ContentNegotiation/tests/MediaTypeFormatterMatchTest.php
+++ b/src/ContentNegotiation/tests/MediaTypeFormatterMatchTest.php
@@ -34,7 +34,7 @@ class MediaTypeFormatterMatchTest extends TestCase
         $formatter = $this->createMock(IMediaTypeFormatter::class);
         $mediaTypeHeaderValue = new ContentTypeHeaderValue('foo/bar');
         $match = new MediaTypeFormatterMatch($formatter, 'baz/blah', $mediaTypeHeaderValue);
-        $this->assertEquals('baz/blah', $match->getMediaType());
+        $this->assertSame('baz/blah', $match->getMediaType());
     }
 
     public function testGettingMediaTypeHeaderReturnsSameOneInConstructor(): void

--- a/src/ContentNegotiation/tests/MediaTypeFormatterMatcherTest.php
+++ b/src/ContentNegotiation/tests/MediaTypeFormatterMatcherTest.php
@@ -50,7 +50,7 @@ class MediaTypeFormatterMatcherTest extends TestCase
         $matcher = new MediaTypeFormatterMatcher([$formatter1, $formatter2]);
         $match = $matcher->getBestResponseMediaTypeFormatterMatch(User::class, $this->request);
         $this->assertSame($formatter2, $match->getFormatter());
-        $this->assertEquals('text/html', $match->getMediaType());
+        $this->assertSame('text/html', $match->getMediaType());
     }
 
     public function testBestFormatterCanMatchWithWildcardType(): void
@@ -65,7 +65,7 @@ class MediaTypeFormatterMatcherTest extends TestCase
         $matcher = new MediaTypeFormatterMatcher([$formatter1, $formatter2]);
         $match = $matcher->getBestResponseMediaTypeFormatterMatch(User::class, $this->request);
         $this->assertSame($formatter1, $match->getFormatter());
-        $this->assertEquals('application/json', $match->getMediaType());
+        $this->assertSame('application/json', $match->getMediaType());
     }
 
     public function testBestFormatterIsFirstSupportedWhenAllContentTypesAreEqualScoreAndHaveNoWildcards(): void
@@ -81,7 +81,7 @@ class MediaTypeFormatterMatcherTest extends TestCase
         $this->headers->add('Accept', 'text/json', true);
         $match = $matcher->getBestResponseMediaTypeFormatterMatch(User::class, $this->request);
         $this->assertSame($formatter1, $match->getFormatter());
-        $this->assertEquals('application/json', $match->getMediaType());
+        $this->assertSame('application/json', $match->getMediaType());
     }
 
     public function testBestFormatterIsFirstSupportedWhenAllContentTypesAreEqualScoresAndOneHasWildcardType(): void
@@ -96,7 +96,7 @@ class MediaTypeFormatterMatcherTest extends TestCase
         $this->headers->add('Accept', 'application/*', true);
         $match = $matcher->getBestResponseMediaTypeFormatterMatch(User::class, $this->request);
         $this->assertSame($formatter, $match->getFormatter());
-        $this->assertEquals('application/json', $match->getMediaType());
+        $this->assertSame('application/json', $match->getMediaType());
     }
 
     public function testBestFormatterIsFirstSupportedWhenAllContentTypesAreEqualScoreWildcardSubTypes(): void
@@ -111,7 +111,7 @@ class MediaTypeFormatterMatcherTest extends TestCase
         $this->headers->add('Accept', 'application/*', true);
         $match = $matcher->getBestResponseMediaTypeFormatterMatch(User::class, $this->request);
         $this->assertSame($formatter, $match->getFormatter());
-        $this->assertEquals('application/json', $match->getMediaType());
+        $this->assertSame('application/json', $match->getMediaType());
     }
 
     public function testBestFormatterIsFirstSupportedWhenAllContentTypesAreEqualScoreAndOneHasWilcardSubTypeAndOtherDoesNot(): void
@@ -126,7 +126,7 @@ class MediaTypeFormatterMatcherTest extends TestCase
         $this->headers->add('Accept', 'application/json', true);
         $match = $matcher->getBestResponseMediaTypeFormatterMatch(User::class, $this->request);
         $this->assertSame($formatter, $match->getFormatter());
-        $this->assertEquals('application/json', $match->getMediaType());
+        $this->assertSame('application/json', $match->getMediaType());
     }
 
     public function testBestFormatterIsFirstSupportedWhenAllContentTypesAreEqualScoreWildcardTypes(): void
@@ -141,7 +141,7 @@ class MediaTypeFormatterMatcherTest extends TestCase
         $this->headers->add('Accept', '*/*', true);
         $match = $matcher->getBestResponseMediaTypeFormatterMatch(User::class, $this->request);
         $this->assertSame($formatter, $match->getFormatter());
-        $this->assertEquals('application/json', $match->getMediaType());
+        $this->assertSame('application/json', $match->getMediaType());
     }
 
     public function testBestFormatterIsSelectedByMatchingSupportedMediaTypesInContentTypeHeader(): void
@@ -160,7 +160,7 @@ class MediaTypeFormatterMatcherTest extends TestCase
         $matcher = new MediaTypeFormatterMatcher([$formatter1, $formatter2]);
         $match = $matcher->getBestRequestMediaTypeFormatterMatch(User::class, $this->request);
         $this->assertSame($formatter2, $match->getFormatter());
-        $this->assertEquals('text/html', $match->getMediaType());
+        $this->assertSame('text/html', $match->getMediaType());
     }
 
     public function testBestFormatterMatchesMostSpecificMediaTypeWithEqualQualityMediaTypes(): void
@@ -186,7 +186,7 @@ class MediaTypeFormatterMatcherTest extends TestCase
         $matcher = new MediaTypeFormatterMatcher([$formatter1, $formatter2, $formatter3]);
         $match = $matcher->getBestResponseMediaTypeFormatterMatch(User::class, $this->request);
         $this->assertSame($formatter3, $match->getFormatter());
-        $this->assertEquals('text/html', $match->getMediaType());
+        $this->assertSame('text/html', $match->getMediaType());
     }
 
     public function testBestFormatterMatchesWildcardSubTypeWithHigherQualityScoreThanSpecificMediaType(): void
@@ -201,7 +201,7 @@ class MediaTypeFormatterMatcherTest extends TestCase
         $matcher = new MediaTypeFormatterMatcher([$formatter]);
         $match = $matcher->getBestResponseMediaTypeFormatterMatch(User::class, $this->request);
         $this->assertSame($formatter, $match->getFormatter());
-        $this->assertEquals('text/plain', $match->getMediaType());
+        $this->assertSame('text/plain', $match->getMediaType());
     }
 
     public function testBestFormatterMatchesHigherQualityScoreWhenBothMediaTypesAreFullyQualified(): void
@@ -217,7 +217,7 @@ class MediaTypeFormatterMatcherTest extends TestCase
         $matcher = new MediaTypeFormatterMatcher([$formatter1, $formatter2]);
         $match = $matcher->getBestResponseMediaTypeFormatterMatch(User::class, $this->request);
         $this->assertSame($formatter2, $match->getFormatter());
-        $this->assertEquals('text/json', $match->getMediaType());
+        $this->assertSame('text/json', $match->getMediaType());
     }
 
     public function tesBestFormatterMatchesWildcardTypeWithHigherQualityScoreThanSpecificMediaType(): void
@@ -232,7 +232,7 @@ class MediaTypeFormatterMatcherTest extends TestCase
         $matcher = new MediaTypeFormatterMatcher([$formatter]);
         $match = $matcher->getBestResponseMediaTypeFormatterMatch(User::class, $this->request);
         $this->assertSame($formatter, $match->getFormatter());
-        $this->assertEquals('application/json', $match->getMediaType());
+        $this->assertSame('application/json', $match->getMediaType());
     }
 
     public function testBestFormatterThatMatchesZeroQualityMediaTypeReturnsNullMatch(): void
@@ -291,7 +291,7 @@ class MediaTypeFormatterMatcherTest extends TestCase
         $matcher = new MediaTypeFormatterMatcher([$formatter1, $formatter2]);
         $match = $matcher->getBestRequestMediaTypeFormatterMatch(User::class, $this->request);
         $this->assertSame($formatter2, $match->getFormatter());
-        $this->assertEquals('text/html', $match->getMediaType());
+        $this->assertSame('text/html', $match->getMediaType());
     }
 
     public function testBestResponseFormatterIsSkippedIfItCannotWriteType(): void
@@ -310,7 +310,7 @@ class MediaTypeFormatterMatcherTest extends TestCase
         $matcher = new MediaTypeFormatterMatcher([$formatter1, $formatter2]);
         $match = $matcher->getBestResponseMediaTypeFormatterMatch(User::class, $this->request);
         $this->assertSame($formatter2, $match->getFormatter());
-        $this->assertEquals('text/html', $match->getMediaType());
+        $this->assertSame('text/html', $match->getMediaType());
     }
 
     public function testExceptionIsThrownIfNoMediaTypeFormattersAreSpecified(): void

--- a/src/ContentNegotiation/tests/MediaTypeFormatters/HtmlMediaTypeFormatterTest.php
+++ b/src/ContentNegotiation/tests/MediaTypeFormatters/HtmlMediaTypeFormatterTest.php
@@ -52,12 +52,12 @@ class HtmlMediaTypeFormatterTest extends TestCase
 
     public function testDefaultEncodingReturnsFirstSupportedEncoding(): void
     {
-        $this->assertEquals('utf-8', $this->formatter->getDefaultEncoding());
+        $this->assertSame('utf-8', $this->formatter->getDefaultEncoding());
     }
 
     public function testDefaultMediaTypeReturnsFirstSupportedMediaType(): void
     {
-        $this->assertEquals('text/html', $this->formatter->getDefaultMediaType());
+        $this->assertSame('text/html', $this->formatter->getDefaultMediaType());
     }
 
     public function testReadingAsArrayOfStringsThrowsException(): void
@@ -71,7 +71,7 @@ class HtmlMediaTypeFormatterTest extends TestCase
     {
         $stream = $this->createStreamWithStringBody('foo');
         $value = $this->formatter->readFromStream($stream, 'string');
-        $this->assertEquals('foo', $value);
+        $this->assertSame('foo', $value);
     }
 
     public function testReadingNonStringThrowsException(): void

--- a/src/ContentNegotiation/tests/MediaTypeFormatters/JsonMediaTypeFormatterTest.php
+++ b/src/ContentNegotiation/tests/MediaTypeFormatters/JsonMediaTypeFormatterTest.php
@@ -55,12 +55,12 @@ class JsonMediaTypeFormatterTest extends TestCase
 
     public function testDefaultEncodingReturnsFirstSupportedEncoding(): void
     {
-        $this->assertEquals('utf-8', $this->formatter->getDefaultEncoding());
+        $this->assertSame('utf-8', $this->formatter->getDefaultEncoding());
     }
 
     public function testDefaultMediaTypeReturnsFirstSupportedMediaType(): void
     {
-        $this->assertEquals('application/json', $this->formatter->getDefaultMediaType());
+        $this->assertSame('application/json', $this->formatter->getDefaultMediaType());
     }
 
     public function testReadingFromStreamDeserializesStreamContents(): void

--- a/src/ContentNegotiation/tests/MediaTypeFormatters/PlainTextMediaTypeFormatterTest.php
+++ b/src/ContentNegotiation/tests/MediaTypeFormatters/PlainTextMediaTypeFormatterTest.php
@@ -52,12 +52,12 @@ class PlainTextMediaTypeFormatterTest extends TestCase
 
     public function testDefaultEncodingReturnsFirstSupportedEncoding(): void
     {
-        $this->assertEquals('utf-8', $this->formatter->getDefaultEncoding());
+        $this->assertSame('utf-8', $this->formatter->getDefaultEncoding());
     }
 
     public function testDefaultMediaTypeReturnsFirstSupportedMediaType(): void
     {
-        $this->assertEquals('text/plain', $this->formatter->getDefaultMediaType());
+        $this->assertSame('text/plain', $this->formatter->getDefaultMediaType());
     }
 
     public function testReadingAsArrayOfStringsThrowsException(): void
@@ -71,7 +71,7 @@ class PlainTextMediaTypeFormatterTest extends TestCase
     {
         $stream = $this->createStreamWithStringBody('foo');
         $value = $this->formatter->readFromStream($stream, 'string');
-        $this->assertEquals('foo', $value);
+        $this->assertSame('foo', $value);
     }
 
     public function testReadingNonStringThrowsException(): void

--- a/src/ContentNegotiation/tests/MediaTypeFormatters/XmlMediaTypeFormatterTest.php
+++ b/src/ContentNegotiation/tests/MediaTypeFormatters/XmlMediaTypeFormatterTest.php
@@ -55,12 +55,12 @@ class XmlMediaTypeFormatterTest extends TestCase
 
     public function testDefaultEncodingReturnsFirstSupportedEncoding(): void
     {
-        $this->assertEquals('utf-8', $this->formatter->getDefaultEncoding());
+        $this->assertSame('utf-8', $this->formatter->getDefaultEncoding());
     }
 
     public function testDefaultMediaTypeReturnsFirstSupportedMediaType(): void
     {
-        $this->assertEquals('text/xml', $this->formatter->getDefaultMediaType());
+        $this->assertSame('text/xml', $this->formatter->getDefaultMediaType());
     }
 
     public function testReadingFromStreamDeserializesStreamContents(): void

--- a/src/ContentNegotiation/tests/NegotiatedRequestBuilderTest.php
+++ b/src/ContentNegotiation/tests/NegotiatedRequestBuilderTest.php
@@ -107,7 +107,7 @@ class NegotiatedRequestBuilderTest extends TestCase
             ->withBody($rawBody)
             ->build();
         $this->assertSame($expectedStream, $request->getBody()->readAsStream());
-        $this->assertEquals('application/json', $request->getHeaders()->getFirst('Content-Type'));
+        $this->assertSame('application/json', $request->getHeaders()->getFirst('Content-Type'));
     }
 
     public function testWithBodyWithNullBodySetsBodyToNull(): void

--- a/src/ContentNegotiation/tests/NegotiatedResponseFactoryTest.php
+++ b/src/ContentNegotiation/tests/NegotiatedResponseFactoryTest.php
@@ -98,7 +98,7 @@ class NegotiatedResponseFactoryTest extends TestCase
             ->willReturn(123);
         $request = $this->createRequest('http://foo.com');
         $response = $this->factory->createResponse($request, 200, null, $rawBody);
-        $this->assertEquals(123, $response->getHeaders()->getFirst('Content-Length'));
+        $this->assertSame(123, $response->getHeaders()->getFirst('Content-Length'));
     }
 
     public function testCreatingResponseFromStreamWithUnknownLengthWillNotSetContentLengthHeader(): void
@@ -117,7 +117,7 @@ class NegotiatedResponseFactoryTest extends TestCase
         $rawBody = 'foo';
         $request = $this->createRequest('http://foo.com');
         $response = $this->factory->createResponse($request, 200, null, $rawBody);
-        $this->assertEquals(\mb_strlen($rawBody), $response->getHeaders()->getFirst('Content-Length'));
+        $this->assertSame(\mb_strlen($rawBody), $response->getHeaders()->getFirst('Content-Length'));
     }
 
     public function testCreatingResponseFromStringWithAlreadySetContentLengthHeaderDoesNotOverwriteContentLength(): void
@@ -126,7 +126,7 @@ class NegotiatedResponseFactoryTest extends TestCase
         $headers = new Headers();
         $headers->add('Content-Length', 123);
         $response = $this->factory->createResponse($this->createRequest('http://foo.com'), 200, $headers, $rawBody);
-        $this->assertEquals(123, $response->getHeaders()->getFirst('Content-Length'));
+        $this->assertSame(123, $response->getHeaders()->getFirst('Content-Length'));
     }
 
     public function testCreatingResponseIncludesContentLanguageHeaderIfItIsPresentInContentNegotiationResult(): void
@@ -139,13 +139,13 @@ class NegotiatedResponseFactoryTest extends TestCase
             new ContentNegotiationResult($this->createMock(IMediaTypeFormatter::class), null, 'utf-8', 'en-US')
         );
         $response = $this->factory->createResponse($request, 200, null, $rawBody);
-        $this->assertEquals('en-US', $response->getHeaders()->getFirst('Content-Language'));
+        $this->assertSame('en-US', $response->getHeaders()->getFirst('Content-Language'));
     }
 
     public function testCreatingResponseUsesStatusCode(): void
     {
         $response = $this->factory->createResponse($this->createRequest('http://foo.com'), 202, null, null);
-        $this->assertEquals(202, $response->getStatusCode());
+        $this->assertSame(202, $response->getStatusCode());
     }
 
     public function testCreatingResponseWillSetContentTypeResponseHeaderFromMediaTypeFormatterMediaType(): void
@@ -163,7 +163,7 @@ class NegotiatedResponseFactoryTest extends TestCase
         );
         $rawBody = new User(123, 'foo@bar.com');
         $response = $this->factory->createResponse($request, 200, null, $rawBody);
-        $this->assertEquals('foo/bar', $response->getHeaders()->getFirst('Content-Type'));
+        $this->assertSame('foo/bar', $response->getHeaders()->getFirst('Content-Type'));
     }
 
     public function testCreatingResponseWithHeadersUsesThoseHeaders(): void
@@ -212,9 +212,9 @@ class NegotiatedResponseFactoryTest extends TestCase
             $this->fail('Expected exception to be thrown');
         } catch (HttpException $ex) {
             $response = $ex->getResponse();
-            $this->assertEquals(HttpStatusCodes::HTTP_NOT_ACCEPTABLE, $response->getStatusCode());
-            $this->assertEquals('application/json', $response->getHeaders()->getFirst('Content-Type'));
-            $this->assertEquals('["foo\/bar"]', (string)$response->getBody());
+            $this->assertSame(HttpStatusCodes::HTTP_NOT_ACCEPTABLE, $response->getStatusCode());
+            $this->assertSame('application/json', $response->getHeaders()->getFirst('Content-Type'));
+            $this->assertSame('["foo\/bar"]', (string)$response->getBody());
         }
     }
 
@@ -237,7 +237,7 @@ class NegotiatedResponseFactoryTest extends TestCase
             $this->factory->createResponse($request, 200, null, $rawBody);
             $this->fail('Expected exception to be thrown');
         } catch (HttpException $ex) {
-            $this->assertEquals(HttpStatusCodes::HTTP_INTERNAL_SERVER_ERROR, $ex->getResponse()->getStatusCode());
+            $this->assertSame(HttpStatusCodes::HTTP_INTERNAL_SERVER_ERROR, $ex->getResponse()->getStatusCode());
         }
     }
 
@@ -263,7 +263,7 @@ class NegotiatedResponseFactoryTest extends TestCase
         $rawBody = 'foo';
         $response = $this->factory->createResponse($this->createRequest('http://foo.com'), 200, null, $rawBody);
         $this->assertInstanceOf(StringBody::class, $response->getBody());
-        $this->assertEquals('foo', (string)$response->getBody());
+        $this->assertSame('foo', (string)$response->getBody());
     }
 
     public function testCreatingResponseWithStreamBodyCreatesBodyFromStream(): void

--- a/src/DependencyInjection/tests/Binders/LazyBinderDispatcherTest.php
+++ b/src/DependencyInjection/tests/Binders/LazyBinderDispatcherTest.php
@@ -185,7 +185,7 @@ class LazyBinderDispatcherTest extends TestCase
         /** @var ClassContainerBinding $bindingFromBinder */
         $bindingFromBinder = $this->container->getBinding(IFoo::class);
         $this->assertInstanceOf(ClassContainerBinding::class, $bindingFromBinder);
-        $this->assertEquals(Foo::class, $bindingFromBinder->getConcreteClass());
+        $this->assertSame(Foo::class, $bindingFromBinder->getConcreteClass());
     }
 
     public function testDispatchingWithNoCacheForcesCollectionCreation(): void
@@ -204,7 +204,7 @@ class LazyBinderDispatcherTest extends TestCase
         /** @var ClassContainerBinding $bindingFromBinder */
         $bindingFromBinder = $this->container->getBinding(IFoo::class);
         $this->assertInstanceOf(ClassContainerBinding::class, $bindingFromBinder);
-        $this->assertEquals(Foo::class, $bindingFromBinder->getConcreteClass());
+        $this->assertSame(Foo::class, $bindingFromBinder->getConcreteClass());
     }
 
     /**

--- a/src/DependencyInjection/tests/Binders/Metadata/BoundInterfaceTest.php
+++ b/src/DependencyInjection/tests/Binders/Metadata/BoundInterfaceTest.php
@@ -22,7 +22,7 @@ class BoundInterfaceTest extends TestCase
     public function testGetInterfaceReturnsSetInterface(): void
     {
         $interface = new BoundInterface('foo', new UniversalContext());
-        $this->assertEquals('foo', $interface->getInterface());
+        $this->assertSame('foo', $interface->getInterface());
     }
 
     public function testGetContextReturnsSetContext(): void

--- a/src/DependencyInjection/tests/Binders/Metadata/ContainerBinderMetadataCollectorTest.php
+++ b/src/DependencyInjection/tests/Binders/Metadata/ContainerBinderMetadataCollectorTest.php
@@ -56,8 +56,8 @@ class ContainerBinderMetadataCollectorTest extends TestCase
         $this->assertCount(3, $actualBoundInterfaces);
 
         foreach ($actualBoundInterfaces as $i => $actualBoundInterface) {
-            $this->assertEquals('bar', $actualBoundInterface->getContext()->getTargetClass());
-            $this->assertEquals("foo$i", $actualBoundInterface->getInterface());
+            $this->assertSame('bar', $actualBoundInterface->getContext()->getTargetClass());
+            $this->assertSame("foo$i", $actualBoundInterface->getInterface());
         }
     }
 
@@ -79,7 +79,7 @@ class ContainerBinderMetadataCollectorTest extends TestCase
         $this->assertCount(3, $actualBoundInterfaces);
 
         foreach ($actualBoundInterfaces as $i => $actualBoundInterface) {
-            $this->assertEquals("foo$i", $actualBoundInterface->getInterface());
+            $this->assertSame("foo$i", $actualBoundInterface->getInterface());
             $this->assertFalse($actualBoundInterface->getContext()->isTargeted());
         }
     }
@@ -99,10 +99,10 @@ class ContainerBinderMetadataCollectorTest extends TestCase
         $binderMetadata = $collector->collect($binder);
         $actualBoundInterfaces = $binderMetadata->getBoundInterfaces();
         $this->assertCount(2, $actualBoundInterfaces);
-        $this->assertEquals('bar', $actualBoundInterfaces[0]->getContext()->getTargetClass());
-        $this->assertEquals('foo', $actualBoundInterfaces[0]->getInterface());
+        $this->assertSame('bar', $actualBoundInterfaces[0]->getContext()->getTargetClass());
+        $this->assertSame('foo', $actualBoundInterfaces[0]->getInterface());
         $this->assertFalse($actualBoundInterfaces[1]->getContext()->isTargeted());
-        $this->assertEquals('foo', $actualBoundInterfaces[1]->getInterface());
+        $this->assertSame('foo', $actualBoundInterfaces[1]->getInterface());
     }
 
     public function testBindingSameTargetedInterfaceTwiceReturnsOneBoundInterface(): void
@@ -122,8 +122,8 @@ class ContainerBinderMetadataCollectorTest extends TestCase
         $binderMetadata = $collector->collect($binder);
         $actualBoundInterfaces = $binderMetadata->getBoundInterfaces();
         $this->assertCount(1, $actualBoundInterfaces);
-        $this->assertEquals('bar', $actualBoundInterfaces[0]->getContext()->getTargetClass());
-        $this->assertEquals('foo', $actualBoundInterfaces[0]->getInterface());
+        $this->assertSame('bar', $actualBoundInterfaces[0]->getContext()->getTargetClass());
+        $this->assertSame('foo', $actualBoundInterfaces[0]->getInterface());
     }
 
     public function testBindingSameUniversalInterfaceTwiceReturnsOneBoundInterface(): void
@@ -140,7 +140,7 @@ class ContainerBinderMetadataCollectorTest extends TestCase
         $actualBoundInterfaces = $binderMetadata->getBoundInterfaces();
         $this->assertCount(1, $actualBoundInterfaces);
         $this->assertFalse($actualBoundInterfaces[0]->getContext()->isTargeted());
-        $this->assertEquals('foo', $actualBoundInterfaces[0]->getInterface());
+        $this->assertSame('foo', $actualBoundInterfaces[0]->getInterface());
     }
 
     public function testCallClosurePassesThroughToComposedContainer(): void
@@ -214,7 +214,7 @@ class ContainerBinderMetadataCollectorTest extends TestCase
             $this->fail('Expected to throw exception');
         } catch (FailedBinderMetadataCollectionException $ex) {
             $this->assertCount(1, $ex->getIncompleteBinderMetadata()->getResolvedInterfaces());
-            $this->assertEquals('foo', $ex->getIncompleteBinderMetadata()->getResolvedInterfaces()[0]->getInterface());
+            $this->assertSame('foo', $ex->getIncompleteBinderMetadata()->getResolvedInterfaces()[0]->getInterface());
         } catch (Exception $ex) {
             $this->fail('Expected ' . FailedBinderMetadataCollectionException::class . ' to be thrown');
         }
@@ -242,8 +242,8 @@ class ContainerBinderMetadataCollectorTest extends TestCase
         $this->assertCount(2, $actualResolvedInterfaces);
 
         foreach ($actualResolvedInterfaces as $i => $actualResolvedInterface) {
-            $this->assertEquals('bar', $actualResolvedInterface->getContext()->getTargetClass());
-            $this->assertEquals("foo$i", $actualResolvedInterface->getInterface());
+            $this->assertSame('bar', $actualResolvedInterface->getContext()->getTargetClass());
+            $this->assertSame("foo$i", $actualResolvedInterface->getInterface());
         }
     }
 
@@ -265,7 +265,7 @@ class ContainerBinderMetadataCollectorTest extends TestCase
         $this->assertCount(2, $actualResolvedInterfaces);
 
         foreach ($actualResolvedInterfaces as $i => $actualResolvedInterface) {
-            $this->assertEquals("foo$i", $actualResolvedInterface->getInterface());
+            $this->assertSame("foo$i", $actualResolvedInterface->getInterface());
             $this->assertFalse($actualResolvedInterface->getContext()->isTargeted());
         }
     }
@@ -287,10 +287,10 @@ class ContainerBinderMetadataCollectorTest extends TestCase
         $binderMetadata = $collector->collect($binder);
         $actualResolvedInterfaces = $binderMetadata->getResolvedInterfaces();
         $this->assertCount(2, $actualResolvedInterfaces);
-        $this->assertEquals('bar', $actualResolvedInterfaces[0]->getContext()->getTargetClass());
-        $this->assertEquals('foo', $actualResolvedInterfaces[0]->getInterface());
+        $this->assertSame('bar', $actualResolvedInterfaces[0]->getContext()->getTargetClass());
+        $this->assertSame('foo', $actualResolvedInterfaces[0]->getInterface());
         $this->assertFalse($actualResolvedInterfaces[1]->getContext()->isTargeted());
-        $this->assertEquals('foo', $actualResolvedInterfaces[1]->getInterface());
+        $this->assertSame('foo', $actualResolvedInterfaces[1]->getInterface());
     }
 
     public function testResolvingSameTargetedInterfaceTwiceReturnsOneResolvedInterface(): void
@@ -309,8 +309,8 @@ class ContainerBinderMetadataCollectorTest extends TestCase
         $binderMetadata = $collector->collect($binder);
         $actualResolvedInterfaces = $binderMetadata->getResolvedInterfaces();
         $this->assertCount(1, $actualResolvedInterfaces);
-        $this->assertEquals('bar', $actualResolvedInterfaces[0]->getContext()->getTargetClass());
-        $this->assertEquals('foo', $actualResolvedInterfaces[0]->getInterface());
+        $this->assertSame('bar', $actualResolvedInterfaces[0]->getContext()->getTargetClass());
+        $this->assertSame('foo', $actualResolvedInterfaces[0]->getInterface());
     }
 
     public function testResolvingSameUniversalInterfaceTwiceReturnsOneResolvedInterface(): void
@@ -328,7 +328,7 @@ class ContainerBinderMetadataCollectorTest extends TestCase
         $actualResolvedInterfaces = $binderMetadata->getResolvedInterfaces();
         $this->assertCount(1, $actualResolvedInterfaces);
         $this->assertFalse($actualResolvedInterfaces[0]->getContext()->isTargeted());
-        $this->assertEquals('foo', $actualResolvedInterfaces[0]->getInterface());
+        $this->assertSame('foo', $actualResolvedInterfaces[0]->getInterface());
     }
 
     public function testTryResolveAddsResolvedBindingEventIfResolutionFailed(): void
@@ -342,7 +342,7 @@ class ContainerBinderMetadataCollectorTest extends TestCase
         };
         $collector = new ContainerBinderMetadataCollector($this->container);
         $this->assertCount(1, $collector->collect($binder)->getResolvedInterfaces());
-        $this->assertEquals('foo', $collector->collect($binder)->getResolvedInterfaces()[0]->getInterface());
+        $this->assertSame('foo', $collector->collect($binder)->getResolvedInterfaces()[0]->getInterface());
     }
 
     public function testTryResolveResolvesInterfaceUsingComposedContainer(): void

--- a/src/DependencyInjection/tests/Binders/Metadata/FailedBinderMetadataCollectionExceptionTest.php
+++ b/src/DependencyInjection/tests/Binders/Metadata/FailedBinderMetadataCollectionExceptionTest.php
@@ -33,8 +33,8 @@ class FailedBinderMetadataCollectionExceptionTest extends TestCase
         };
         $binderMetadata = new BinderMetadata($binder, [], [new ResolvedInterface(IFoo::class, new UniversalContext())]);
         $exception = new FailedBinderMetadataCollectionException($binderMetadata, IFoo::class);
-        $this->assertEquals('Failed to collect metadata for ' . \get_class($binder), $exception->getMessage());
+        $this->assertSame('Failed to collect metadata for ' . \get_class($binder), $exception->getMessage());
         $this->assertSame($binderMetadata, $exception->getIncompleteBinderMetadata());
-        $this->assertEquals(IFoo::class, $exception->getFailedInterface());
+        $this->assertSame(IFoo::class, $exception->getFailedInterface());
     }
 }

--- a/src/DependencyInjection/tests/Binders/Metadata/ImpossibleBindingExceptionTest.php
+++ b/src/DependencyInjection/tests/Binders/Metadata/ImpossibleBindingExceptionTest.php
@@ -24,7 +24,7 @@ class ImpossibleBindingExceptionTest extends TestCase
         $binder1 = $this->createBinder();
         $binder2 = $this->createBinder();
         $exception = new ImpossibleBindingException(['foo' => [$binder1, $binder2]]);
-        $this->assertEquals(
+        $this->assertSame(
             'Impossible to resolve following interfaces: foo (attempted to be resolved in ' . \get_class($binder1) . ', ' . \get_class($binder2) . ')',
             $exception->getMessage()
         );
@@ -35,7 +35,7 @@ class ImpossibleBindingExceptionTest extends TestCase
         $binder1 = $this->createBinder();
         $binder2 = $this->createBinder();
         $exception = new ImpossibleBindingException(['foo' => [$binder1], 'bar' => [$binder2]]);
-        $this->assertEquals(
+        $this->assertSame(
             'Impossible to resolve following interfaces: foo (attempted to be resolved in ' . \get_class($binder1) . '), bar (attempted to be resolved in ' . \get_class($binder2) . ')',
             $exception->getMessage()
         );
@@ -45,7 +45,7 @@ class ImpossibleBindingExceptionTest extends TestCase
     {
         $binder = $this->createBinder();
         $exception = new ImpossibleBindingException(['foo' => [$binder]]);
-        $this->assertEquals(
+        $this->assertSame(
             'Impossible to resolve following interfaces: foo (attempted to be resolved in ' . \get_class($binder) . ')',
             $exception->getMessage()
         );

--- a/src/DependencyInjection/tests/Binders/Metadata/ResolvedInterfaceTest.php
+++ b/src/DependencyInjection/tests/Binders/Metadata/ResolvedInterfaceTest.php
@@ -22,7 +22,7 @@ class ResolvedInterfaceTest extends TestCase
     public function testGetInterfaceReturnsSetInterface(): void
     {
         $interface = new ResolvedInterface('foo', new UniversalContext());
-        $this->assertEquals('foo', $interface->getInterface());
+        $this->assertSame('foo', $interface->getInterface());
     }
 
     public function testGetContextReturnsSetContext(): void

--- a/src/DependencyInjection/tests/ClassContainerBindingTest.php
+++ b/src/DependencyInjection/tests/ClassContainerBindingTest.php
@@ -34,7 +34,7 @@ class ClassContainerBindingTest extends TestCase
 
     public function testGettingConcreteClass(): void
     {
-        $this->assertEquals('foo', $this->binding->getConcreteClass());
+        $this->assertSame('foo', $this->binding->getConcreteClass());
     }
 
     public function testGettingConstructorPrimitives(): void

--- a/src/DependencyInjection/tests/ContainerTest.php
+++ b/src/DependencyInjection/tests/ContainerTest.php
@@ -122,7 +122,7 @@ class ContainerTest extends TestCase
         $this->container->callMethod($instance, 'setPrimitive', ['foo']);
         $this->assertSame('foo', $instance->getPrimitive());
         $result = $this->container->callClosure(fn ($primitive) => $primitive, ['foo']);
-        $this->assertEquals('foo', $result);
+        $this->assertSame('foo', $result);
     }
 
     public function testCallingMethodWithPrimitiveTypesWithoutSpecifyingValue(): void
@@ -143,7 +143,7 @@ class ContainerTest extends TestCase
             fn (IFoo $interface, $primitive) => \get_class($interface) . ':' . $primitive,
             ['foo']
         );
-        $this->assertEquals(Bar::class . ':foo', $response);
+        $this->assertSame(Bar::class . ':foo', $response);
     }
 
     public function testCallingClosureWithTypeHints(): void
@@ -153,7 +153,7 @@ class ContainerTest extends TestCase
         $this->container->callMethod($instance, 'setInterface');
         $this->assertInstanceOf(Bar::class, $instance->getInterface());
         $response = $this->container->callClosure(fn (IFoo $interface) => \get_class($interface));
-        $this->assertEquals(Bar::class, $response);
+        $this->assertSame(Bar::class, $response);
     }
 
     public function testCallingClosureWithUnresolvableParametersThrowsException(): void
@@ -413,8 +413,8 @@ class ContainerTest extends TestCase
         $instance2 = $this->container->resolve(ConstructorWithMixOfInterfacesAndPrimitives::class);
         $this->assertInstanceOf(ConstructorWithMixOfInterfacesAndPrimitives::class, $instance1);
         $this->assertSame($instance1, $instance2);
-        $this->assertEquals(23, $instance1->getId());
-        $this->assertEquals(23, $instance2->getId());
+        $this->assertSame(23, $instance1->getId());
+        $this->assertSame(23, $instance2->getId());
     }
 
     public function testForWithInvalidParameterThrowsException(): void
@@ -462,7 +462,7 @@ class ContainerTest extends TestCase
         /** @var ConstructorWithMixOfConcreteClassesAndPrimitives $instance */
         $instance = $this->container->resolve(ConstructorWithMixOfConcreteClassesAndPrimitives::class);
         $this->assertInstanceOf(ConstructorWithMixOfConcreteClassesAndPrimitives::class, $instance);
-        $this->assertEquals(23, $instance->getId());
+        $this->assertSame(23, $instance->getId());
         $this->assertNotSame($instance, $this->container->resolve(ConstructorWithMixOfConcreteClassesAndPrimitives::class));
     }
 
@@ -478,7 +478,7 @@ class ContainerTest extends TestCase
         $instance = $this->container->resolve(ConstructorWithMixOfConcreteClassesAndPrimitives::class);
         /** @var ConstructorWithMixOfConcreteClassesAndPrimitives $newInstance */
         $this->assertInstanceOf(ConstructorWithMixOfConcreteClassesAndPrimitives::class, $instance);
-        $this->assertEquals(23, $instance->getId());
+        $this->assertSame(23, $instance->getId());
         $this->assertSame($instance, $this->container->resolve(ConstructorWithMixOfConcreteClassesAndPrimitives::class));
     }
 
@@ -629,8 +629,8 @@ class ContainerTest extends TestCase
         $instance2 = $this->container->resolve(ConstructorWithMixOfInterfacesAndPrimitives::class);
         $this->assertInstanceOf(ConstructorWithMixOfInterfacesAndPrimitives::class, $instance1);
         $this->assertSame($instance1, $instance2);
-        $this->assertEquals(23, $instance1->getId());
-        $this->assertEquals(23, $instance2->getId());
+        $this->assertSame(23, $instance1->getId());
+        $this->assertSame(23, $instance2->getId());
         $this->assertSame($instance1->getPerson(), $instance2->getPerson());
     }
 

--- a/src/DependencyInjection/tests/ResolutionExceptionTest.php
+++ b/src/DependencyInjection/tests/ResolutionExceptionTest.php
@@ -29,6 +29,6 @@ class ResolutionExceptionTest extends TestCase
     public function testGetInterfaceReturnsInterfaceInjectedInConstructor(): void
     {
         $exception = new ResolutionException('foo', new UniversalContext());
-        $this->assertEquals('foo', $exception->getInterface());
+        $this->assertSame('foo', $exception->getInterface());
     }
 }

--- a/src/DependencyInjection/tests/TargetedContextTest.php
+++ b/src/DependencyInjection/tests/TargetedContextTest.php
@@ -20,7 +20,7 @@ class TargetedContextTest extends TestCase
     public function testMethodsIndicateATargetedContext(): void
     {
         $context = new TargetedContext('foo');
-        $this->assertEquals('foo', $context->getTargetClass());
+        $this->assertSame('foo', $context->getTargetClass());
         $this->assertTrue($context->isTargeted());
         $this->assertFalse($context->isUniversal());
     }

--- a/src/Exceptions/tests/GlobalExceptionHandlerTest.php
+++ b/src/Exceptions/tests/GlobalExceptionHandlerTest.php
@@ -57,8 +57,8 @@ class GlobalExceptionHandlerTest extends TestCase
             $this->globalExceptionHandler->handleError(E_ERROR, 'foo');
             $this->fail('Expected error to be thrown as exception');
         } catch (ErrorException $ex) {
-            $this->assertEquals(E_ERROR, $ex->getSeverity());
-            $this->assertEquals('foo', $ex->getMessage());
+            $this->assertSame(E_ERROR, $ex->getSeverity());
+            $this->assertSame('foo', $ex->getMessage());
         }
     }
 
@@ -118,11 +118,11 @@ class GlobalExceptionHandlerTest extends TestCase
         foreach ($errors as $error) {
             $globalExceptionHandler->handleShutdown($error);
             $this->assertInstanceOf(FatalErrorException::class, $globalExceptionHandler->handledException);
-            $this->assertEquals($error['message'], $globalExceptionHandler->handledException->getMessage());
+            $this->assertSame($error['message'], $globalExceptionHandler->handledException->getMessage());
             $this->assertEquals($error['type'], $globalExceptionHandler->handledException->getCode());
-            $this->assertEquals(0, $globalExceptionHandler->handledException->getSeverity());
-            $this->assertEquals($error['file'], $globalExceptionHandler->handledException->getFile());
-            $this->assertEquals($error['line'], $globalExceptionHandler->handledException->getLine());
+            $this->assertSame(0, $globalExceptionHandler->handledException->getSeverity());
+            $this->assertSame($error['file'], $globalExceptionHandler->handledException->getFile());
+            $this->assertSame($error['line'], $globalExceptionHandler->handledException->getLine());
         }
     }
 }

--- a/src/Exceptions/tests/LogLevelFactoryTest.php
+++ b/src/Exceptions/tests/LogLevelFactoryTest.php
@@ -29,7 +29,7 @@ class LogLevelFactoryTest extends TestCase
     public function testCreatingLogLevelDefaultsToErrorLogLevelIfExceptionHasNoCustomLogLevel(): void
     {
         $exception = new Exception();
-        $this->assertEquals(LogLevel::ERROR, $this->factory->createLogLevel($exception));
+        $this->assertSame(LogLevel::ERROR, $this->factory->createLogLevel($exception));
     }
 
     public function testCreatingLogLevelWithManyCustomErrorLogLevelUsesThem(): void
@@ -38,13 +38,13 @@ class LogLevelFactoryTest extends TestCase
         $this->factory->registerManyLogLevelFactories([
             Exception::class => fn (Exception $ex) => LogLevel::EMERGENCY
         ]);
-        $this->assertEquals(LogLevel::EMERGENCY, $this->factory->createLogLevel($exception));
+        $this->assertSame(LogLevel::EMERGENCY, $this->factory->createLogLevel($exception));
     }
 
     public function testCreatingLogLevelWithSingleCustomErrorLogLevelUsesIt(): void
     {
         $exception = new Exception();
         $this->factory->registerLogLevelFactory(Exception::class, fn (Exception $ex) => LogLevel::EMERGENCY);
-        $this->assertEquals(LogLevel::EMERGENCY, $this->factory->createLogLevel($exception));
+        $this->assertSame(LogLevel::EMERGENCY, $this->factory->createLogLevel($exception));
     }
 }

--- a/src/Framework/tests/Api/Testing/PhpUnit/IntegrationTestCaseTest.php
+++ b/src/Framework/tests/Api/Testing/PhpUnit/IntegrationTestCaseTest.php
@@ -186,7 +186,7 @@ class IntegrationTestCaseTest extends TestCase
     {
         $response = new Response(200);
         $this->integrationTests->assertCookieEquals('bar', $response, 'foo');
-        $this->assertEquals(
+        $this->assertSame(
             'Failed to assert that cookie foo has expected value',
             $this->integrationTests->getFailMessage()
         );
@@ -202,7 +202,7 @@ class IntegrationTestCaseTest extends TestCase
     {
         $response = new Response(200);
         $this->integrationTests->assertHasCookie($response, 'foo');
-        $this->assertEquals(
+        $this->assertSame(
             'Failed to assert that cookie foo is set',
             $this->integrationTests->getFailMessage()
         );
@@ -218,7 +218,7 @@ class IntegrationTestCaseTest extends TestCase
     {
         $response = new Response(200);
         $this->integrationTests->assertHasHeader($response, 'Foo');
-        $this->assertEquals(
+        $this->assertSame(
             'Failed to assert that header Foo is set',
             $this->integrationTests->getFailMessage()
         );
@@ -234,7 +234,7 @@ class IntegrationTestCaseTest extends TestCase
     {
         $response = new Response(200);
         $this->integrationTests->assertHeaderEquals(['bar'], $response, 'Foo');
-        $this->assertEquals(
+        $this->assertSame(
             'No header value for Foo is set',
             $this->integrationTests->getFailMessage()
         );
@@ -250,7 +250,7 @@ class IntegrationTestCaseTest extends TestCase
     {
         $response = new Response(200);
         $this->integrationTests->assertHeaderMatchesRegex('/^bar$/', $response, 'Foo');
-        $this->assertEquals(
+        $this->assertSame(
             'No header value for Foo is set',
             $this->integrationTests->getFailMessage()
         );
@@ -289,7 +289,7 @@ class IntegrationTestCaseTest extends TestCase
             ->willReturn($response);
         $this->integrationTests->send($request);
         $this->integrationTests->assertParsedBodyEquals($this, $response);
-        $this->assertEquals(
+        $this->assertSame(
             'Failed to assert that the response body matches the expected value',
             $this->integrationTests->getFailMessage()
         );
@@ -336,7 +336,7 @@ class IntegrationTestCaseTest extends TestCase
             self::class,
             fn ($parsedBody) => false
         );
-        $this->assertEquals(
+        $this->assertSame(
             'Failed to assert that the response body passes the callback',
             $this->integrationTests->getFailMessage()
         );
@@ -352,7 +352,7 @@ class IntegrationTestCaseTest extends TestCase
     {
         $response = new Response(200);
         $this->integrationTests->assertStatusCodeEquals(500, $response);
-        $this->assertEquals(
+        $this->assertSame(
             'Expected status code 500, got 200',
             $this->integrationTests->getFailMessage()
         );

--- a/src/Framework/tests/Console/Commands/FlushFrameworkCachesCommandTest.php
+++ b/src/Framework/tests/Console/Commands/FlushFrameworkCachesCommandTest.php
@@ -20,7 +20,7 @@ class FlushFrameworkCachesCommandTest extends TestCase
     public function testCorrectValuesAreSetInConstructor(): void
     {
         $command = new FlushFrameworkCachesCommand();
-        $this->assertEquals('framework:flushcaches', $command->name);
-        $this->assertEquals('Flushes all of Aphiria\'s caches', $command->description);
+        $this->assertSame('framework:flushcaches', $command->name);
+        $this->assertSame('Flushes all of Aphiria\'s caches', $command->description);
     }
 }

--- a/src/Framework/tests/Console/Commands/ServeCommandHandlerTest.php
+++ b/src/Framework/tests/Console/Commands/ServeCommandHandlerTest.php
@@ -44,6 +44,6 @@ class ServeCommandHandlerTest extends TestCase
             }
         };
         $handler->handle($input, $output);
-        $this->assertEquals(PHP_BINARY . ' -S localhost.app:443 -t public router', $handler->ranCommand);
+        $this->assertSame(PHP_BINARY . ' -S localhost.app:443 -t public router', $handler->ranCommand);
     }
 }

--- a/src/Framework/tests/Console/Commands/ServeCommandTest.php
+++ b/src/Framework/tests/Console/Commands/ServeCommandTest.php
@@ -29,8 +29,8 @@ class ServeCommandTest extends TestCase
     public function testCorrectValuesAreSetInConstructor(): void
     {
         $command = new ServeCommand('router');
-        $this->assertEquals('app:serve', $command->name);
-        $this->assertEquals('Runs your app locally', $command->description);
+        $this->assertSame('app:serve', $command->name);
+        $this->assertSame('Runs your app locally', $command->description);
         $expectedOptions = [
             new Option('domain', null, OptionTypes::REQUIRED_VALUE, 'The domain to run your app at', 'localhost'),
             new Option('port', null, OptionTypes::REQUIRED_VALUE, 'The port to run your app at', 80),
@@ -47,6 +47,6 @@ class ServeCommandTest extends TestCase
         );
         $command = new ServeCommand();
         $this->assertCount(4, $command->options);
-        $this->assertEquals('/foo', $command->options[3]->defaultValue);
+        $this->assertSame('/foo', $command->options[3]->defaultValue);
     }
 }

--- a/src/Framework/tests/Exceptions/Components/ExceptionHandlerComponentTest.php
+++ b/src/Framework/tests/Exceptions/Components/ExceptionHandlerComponentTest.php
@@ -93,6 +93,6 @@ class ExceptionHandlerComponentTest extends TestCase
         $factory = fn (Exception $ex) => LogLevel::ALERT;
         $this->exceptionHandlerComponent->withLogLevelFactory(Exception::class, $factory);
         $this->exceptionHandlerComponent->build();
-        $this->assertEquals(LogLevel::ALERT, $this->logLevelFactory->createLogLevel($expectedException));
+        $this->assertSame(LogLevel::ALERT, $this->logLevelFactory->createLogLevel($expectedException));
     }
 }

--- a/src/Framework/tests/Routing/Components/RouterComponentTest.php
+++ b/src/Framework/tests/Routing/Components/RouterComponentTest.php
@@ -48,7 +48,7 @@ class RouterComponentTest extends TestCase
         $this->routerComponent->withRoutes(fn (RouteCollectionBuilder $routeBuilders) => $routeBuilders->get('/foo')->mapsToMethod('Foo', 'bar'));
         $this->routerComponent->build();
         $this->assertCount(1, $this->routes->getAll());
-        $this->assertEquals('/foo', $this->routes->getAll()[0]->uriTemplate->pathTemplate);
+        $this->assertSame('/foo', $this->routes->getAll()[0]->uriTemplate->pathTemplate);
     }
 
     public function testBuildWithAnnotationsAddsAnnotationRegistrant(): void

--- a/src/IO/tests/Streams/MultiStreamTest.php
+++ b/src/IO/tests/Streams/MultiStreamTest.php
@@ -54,7 +54,7 @@ class MultiStreamTest extends TestCase
         $this->multiStream->addStream($unseekableStream);
         $this->multiStream->close();
         $this->assertTrue($this->multiStream->isSeekable());
-        $this->assertEquals(0, $this->multiStream->getPosition());
+        $this->assertSame(0, $this->multiStream->getPosition());
     }
 
     public function testClosingStreamUnsetsSubstreamResources(): void
@@ -77,7 +77,7 @@ class MultiStreamTest extends TestCase
         $stream2 = new Stream(fopen('php://temp', 'r+b'));
         $stream2->write('bar');
         $multistream = new MultiStream([$stream1, $stream2]);
-        $this->assertEquals('foobar', (string)$multistream);
+        $this->assertSame('foobar', (string)$multistream);
     }
 
     public function testCopyingToClosedStreamThrowsException(): void
@@ -105,7 +105,7 @@ class MultiStreamTest extends TestCase
         $destinationStream = new Stream(fopen('php://temp', 'r+b'));
         $this->multiStream->copyToStream($destinationStream, 1);
         $destinationStream->rewind();
-        $this->assertEquals('foobar', $destinationStream->readToEnd());
+        $this->assertSame('foobar', $destinationStream->readToEnd());
     }
 
     public function testDestroyingStreamUnsetsSubstreamResources(): void
@@ -176,7 +176,7 @@ class MultiStreamTest extends TestCase
             ->willReturn(20);
         $this->multiStream->addStream($stream1);
         $this->multiStream->addStream($stream2);
-        $this->assertEquals(30, $this->multiStream->getLength());
+        $this->assertSame(30, $this->multiStream->getLength());
     }
 
     public function testGettingLengthWithoutAnySubstreamsReturnsNull(): void
@@ -201,7 +201,7 @@ class MultiStreamTest extends TestCase
 
     public function testReadingEmptyStreamReturnsEmptyString(): void
     {
-        $this->assertEquals('', $this->multiStream->read(123));
+        $this->assertSame('', $this->multiStream->read(123));
     }
 
     public function testReadingFromMultipleStreamsReadsFirstToEofAndRemainderFromSecond(): void
@@ -218,8 +218,8 @@ class MultiStreamTest extends TestCase
             ->willReturn('o');
         $this->multiStream->addStream($stream1);
         $this->multiStream->addStream($stream2);
-        $this->assertEquals('foo', $this->multiStream->read(3));
-        $this->assertEquals(3, $this->multiStream->getPosition());
+        $this->assertSame('foo', $this->multiStream->read(3));
+        $this->assertSame(3, $this->multiStream->getPosition());
     }
 
     public function testReadingFromSingleStreamReadsThatStream(): void
@@ -230,7 +230,7 @@ class MultiStreamTest extends TestCase
             ->with(3)
             ->willReturn('foo');
         $this->multiStream->addStream($stream);
-        $this->assertEquals('foo', $this->multiStream->read(3));
+        $this->assertSame('foo', $this->multiStream->read(3));
     }
 
     public function testReadingToEndWithMultipleStreamsReadsFromCurrentPositionToEnd(): void
@@ -242,16 +242,16 @@ class MultiStreamTest extends TestCase
         $this->multiStream->addStream($stream1);
         $this->multiStream->addStream($stream2);
         $this->multiStream->rewind();
-        $this->assertEquals('abcde', $this->multiStream->readToEnd());
+        $this->assertSame('abcde', $this->multiStream->readToEnd());
         $this->assertTrue($this->multiStream->isEof());
         $this->multiStream->seek(1);
-        $this->assertEquals('bcde', $this->multiStream->readToEnd());
+        $this->assertSame('bcde', $this->multiStream->readToEnd());
         $this->assertTrue($this->multiStream->isEof());
     }
 
     public function testReadingToEndWithNoStreamsReturnsEmptyString(): void
     {
-        $this->assertEquals('', $this->multiStream->readToEnd());
+        $this->assertSame('', $this->multiStream->readToEnd());
     }
 
     public function testReadingToEndWithSingleStreamReadsItToEnd(): void
@@ -260,7 +260,7 @@ class MultiStreamTest extends TestCase
         $stream->write('foo');
         $this->multiStream->addStream($stream);
         $this->multiStream->seek(1);
-        $this->assertEquals('oo', $this->multiStream->readToEnd());
+        $this->assertSame('oo', $this->multiStream->readToEnd());
         $this->assertTrue($this->multiStream->isEof());
     }
 
@@ -288,29 +288,29 @@ class MultiStreamTest extends TestCase
         $this->multiStream->addStream($stream3);
 
         $this->multiStream->seek(1);
-        $this->assertEquals(1, $stream1->getPosition());
-        $this->assertEquals(0, $stream2->getPosition());
-        $this->assertEquals(0, $stream3->getPosition());
+        $this->assertSame(1, $stream1->getPosition());
+        $this->assertSame(0, $stream2->getPosition());
+        $this->assertSame(0, $stream3->getPosition());
 
         $this->multiStream->seek(3);
-        $this->assertEquals(3, $stream1->getPosition());
-        $this->assertEquals(0, $stream2->getPosition());
-        $this->assertEquals(0, $stream3->getPosition());
+        $this->assertSame(3, $stream1->getPosition());
+        $this->assertSame(0, $stream2->getPosition());
+        $this->assertSame(0, $stream3->getPosition());
 
         $this->multiStream->seek(4);
-        $this->assertEquals(3, $stream1->getPosition());
-        $this->assertEquals(1, $stream2->getPosition());
-        $this->assertEquals(0, $stream3->getPosition());
+        $this->assertSame(3, $stream1->getPosition());
+        $this->assertSame(1, $stream2->getPosition());
+        $this->assertSame(0, $stream3->getPosition());
 
         $this->multiStream->seek(5);
-        $this->assertEquals(3, $stream1->getPosition());
-        $this->assertEquals(2, $stream2->getPosition());
-        $this->assertEquals(0, $stream3->getPosition());
+        $this->assertSame(3, $stream1->getPosition());
+        $this->assertSame(2, $stream2->getPosition());
+        $this->assertSame(0, $stream3->getPosition());
 
         $this->multiStream->seek(6);
-        $this->assertEquals(3, $stream1->getPosition());
-        $this->assertEquals(2, $stream2->getPosition());
-        $this->assertEquals(1, $stream3->getPosition());
+        $this->assertSame(3, $stream1->getPosition());
+        $this->assertSame(2, $stream2->getPosition());
+        $this->assertSame(1, $stream3->getPosition());
     }
 
     public function testSeekingWithSingleStreamSeeksToCorrectPosition(): void
@@ -319,11 +319,11 @@ class MultiStreamTest extends TestCase
         $stream->write('foobar');
         $this->multiStream->addStream($stream);
         $this->multiStream->seek(1);
-        $this->assertEquals(1, $stream->getPosition());
+        $this->assertSame(1, $stream->getPosition());
         $this->multiStream->seek(2, SEEK_CUR);
-        $this->assertEquals(3, $stream->getPosition());
+        $this->assertSame(3, $stream->getPosition());
         $this->multiStream->seek(-1, SEEK_END);
-        $this->assertEquals(5, $stream->getPosition());
+        $this->assertSame(5, $stream->getPosition());
     }
 
     public function testSeekingStreamWithUnknownLengthThrowsException(): void
@@ -374,7 +374,7 @@ class MultiStreamTest extends TestCase
         $stream2->seek(1);
         $this->multiStream->addStream($stream1);
         $this->multiStream->addStream($stream2);
-        $this->assertEquals('foobar', (string)$this->multiStream);
+        $this->assertSame('foobar', (string)$this->multiStream);
     }
 
     public function testToStringWithUnseekableStreamReturnsEmptyString(): void

--- a/src/IO/tests/Streams/StreamTest.php
+++ b/src/IO/tests/Streams/StreamTest.php
@@ -35,7 +35,7 @@ class StreamTest extends TestCase
         $stream = new Stream($handle);
         $stream->write('foo');
         $stream->close();
-        $this->assertEquals('', (string)$stream);
+        $this->assertSame('', (string)$stream);
     }
 
     public function testCastingToStringRewindsAndReadsToEnd(): void
@@ -44,7 +44,7 @@ class StreamTest extends TestCase
         $stream = new Stream($handle);
         $stream->write('foo');
         $stream->read(1);
-        $this->assertEquals('foo', (string)$stream);
+        $this->assertSame('foo', (string)$stream);
     }
 
     public function testClosingStreamUnsetsResource(): void
@@ -74,7 +74,7 @@ class StreamTest extends TestCase
         $destinationStream = new Stream(fopen('php://temp', 'r+b'));
         $sourceStream->copyToStream($destinationStream, 1);
         $destinationStream->rewind();
-        $this->assertEquals('foo', $destinationStream->readToEnd());
+        $this->assertSame('foo', $destinationStream->readToEnd());
     }
 
     public function testDestructorUnsetsResource(): void
@@ -162,7 +162,7 @@ class StreamTest extends TestCase
     {
         $handle = fopen('php://temp', 'rb');
         $stream = new Stream($handle, 724);
-        $this->assertEquals(724, $stream->getLength());
+        $this->assertSame(724, $stream->getLength());
     }
 
     public function testNonResourceThrowsException(): void
@@ -176,7 +176,7 @@ class StreamTest extends TestCase
         $handle = fopen('php://temp', 'w+b');
         $stream = new Stream($handle);
         $stream->write('foo');
-        $this->assertEquals(3, $stream->getPosition());
+        $this->assertSame(3, $stream->getPosition());
     }
 
     public function testReadingFromClosedStreamThrowsException(): void
@@ -222,7 +222,7 @@ class StreamTest extends TestCase
         $handle = fopen('php://temp', 'rb');
         $expectedLength = fstat($handle)['size'];
         $stream = new Stream($handle);
-        $this->assertEquals($expectedLength, $stream->getLength());
+        $this->assertSame($expectedLength, $stream->getLength());
     }
 
     public function testRewindSeeksToBeginningOfStream(): void
@@ -230,9 +230,9 @@ class StreamTest extends TestCase
         $handle = fopen('php://temp', 'w+b');
         $stream = new Stream($handle);
         $stream->write('foo');
-        $this->assertEquals('', $stream->readToEnd());
+        $this->assertSame('', $stream->readToEnd());
         $stream->rewind();
-        $this->assertEquals('foo', $stream->readToEnd());
+        $this->assertSame('foo', $stream->readToEnd());
     }
 
     public function testSeekingChangesPosition(): void
@@ -242,10 +242,10 @@ class StreamTest extends TestCase
         $stream->write('foo');
         $stream->rewind();
         $stream->seek(1);
-        $this->assertEquals('oo', $stream->readToEnd());
+        $this->assertSame('oo', $stream->readToEnd());
         $stream->rewind();
         $stream->seek(2);
-        $this->assertEquals('o', $stream->readToEnd());
+        $this->assertSame('o', $stream->readToEnd());
     }
 
     public function testWritingToUnwritableStreamThrowsException(): void
@@ -262,6 +262,6 @@ class StreamTest extends TestCase
         $stream = new Stream($handle);
         $stream->write('foo');
         $stream->rewind();
-        $this->assertEquals('foo', $stream->readToEnd());
+        $this->assertSame('foo', $stream->readToEnd());
     }
 }

--- a/src/Middleware/tests/AttributeMiddlewareTest.php
+++ b/src/Middleware/tests/AttributeMiddlewareTest.php
@@ -27,12 +27,12 @@ class AttributeMiddlewareTest extends TestCase
     public function testGettingAttributeReturnsSameValueInSetter(): void
     {
         $this->middleware->setAttributes(['foo' => 'bar']);
-        $this->assertEquals('bar', $this->middleware->getAttribute('foo'));
+        $this->assertSame('bar', $this->middleware->getAttribute('foo'));
     }
 
     public function testGettingAttributeThatDoesNotExistReturnsDefaultValue(): void
     {
         $this->assertNull($this->middleware->getAttribute('foo'));
-        $this->assertEquals('bar', $this->middleware->getAttribute('foo', 'bar'));
+        $this->assertSame('bar', $this->middleware->getAttribute('foo', 'bar'));
     }
 }

--- a/src/Middleware/tests/MiddlewareBindingTest.php
+++ b/src/Middleware/tests/MiddlewareBindingTest.php
@@ -21,7 +21,7 @@ class MiddlewareBindingTest extends TestCase
     {
         $expectedAttributes = ['bar' => 'baz'];
         $middlewareBinding = new MiddlewareBinding('foo', $expectedAttributes);
-        $this->assertEquals('foo', $middlewareBinding->className);
+        $this->assertSame('foo', $middlewareBinding->className);
         $this->assertSame($expectedAttributes, $middlewareBinding->attributes);
     }
 }

--- a/src/Net/tests/Formatting/UriParserTest.php
+++ b/src/Net/tests/Formatting/UriParserTest.php
@@ -48,12 +48,12 @@ class UriParserTest extends TestCase
     public function testParsingQueryStringParamWithSingleValueReturnsThatValue(): void
     {
         $uri = new Uri('http://host.com?foo=bar');
-        $this->assertEquals('bar', $this->parser->parseQueryString($uri)->get('foo'));
+        $this->assertSame('bar', $this->parser->parseQueryString($uri)->get('foo'));
     }
 
     public function testUrlEncodedValuesAreDecoded(): void
     {
         $uri = new Uri('http://host.com?foo=a%26w');
-        $this->assertEquals('a&w', $this->parser->parseQueryString($uri)->get('foo'));
+        $this->assertSame('a&w', $this->parser->parseQueryString($uri)->get('foo'));
     }
 }

--- a/src/Net/tests/Http/Formatting/BodyParserTest.php
+++ b/src/Net/tests/Http/Formatting/BodyParserTest.php
@@ -36,7 +36,7 @@ class BodyParserTest extends TestCase
         $this->body->expects($this->once())
             ->method('readAsString')
             ->willReturn('foo=bar');
-        $this->assertEquals('bar', $this->parser->readAsFormInput($this->body)->get('foo'));
+        $this->assertSame('bar', $this->parser->readAsFormInput($this->body)->get('foo'));
     }
 
     public function testGettingMimeTypeOfNullBodyReturnsNull(): void
@@ -49,8 +49,8 @@ class BodyParserTest extends TestCase
         $this->body->expects($this->once())
             ->method('readAsString')
             ->willReturn('<?xml version="1.0"?><foo />');
-        $this->assertEquals('text/xml', $this->parser->getMimeType($this->body));
-        $this->assertEquals('text/xml', $this->parser->getMimeType($this->body));
+        $this->assertSame('text/xml', $this->parser->getMimeType($this->body));
+        $this->assertSame('text/xml', $this->parser->getMimeType($this->body));
     }
 
     public function testGettingMimeTypeReturnsCorrectMimeType(): void
@@ -58,7 +58,7 @@ class BodyParserTest extends TestCase
         $this->body->expects($this->once())
             ->method('readAsString')
             ->willReturn('<?xml version="1.0"?><foo />');
-        $this->assertEquals('text/xml', $this->parser->getMimeType($this->body));
+        $this->assertSame('text/xml', $this->parser->getMimeType($this->body));
     }
 
     public function testParsingInputWithFormUrlEncodedBodyThatAlreadyHasBeenCheckedReturnsSameInput(): void
@@ -66,8 +66,8 @@ class BodyParserTest extends TestCase
         $this->body->expects($this->once())
             ->method('readAsString')
             ->willReturn('foo=bar');
-        $this->assertEquals('bar', $this->parser->readAsFormInput($this->body)->get('foo'));
-        $this->assertEquals('bar', $this->parser->readAsFormInput($this->body)->get('foo'));
+        $this->assertSame('bar', $this->parser->readAsFormInput($this->body)->get('foo'));
+        $this->assertSame('bar', $this->parser->readAsFormInput($this->body)->get('foo'));
     }
 
     public function testParsingInputWithFormUrlEncodedBodyReturnsParsedFormData(): void
@@ -75,7 +75,7 @@ class BodyParserTest extends TestCase
         $this->body->expects($this->once())
             ->method('readAsString')
             ->willReturn('foo=bar');
-        $this->assertEquals('bar', $this->parser->readAsFormInput($this->body)->get('foo'));
+        $this->assertSame('bar', $this->parser->readAsFormInput($this->body)->get('foo'));
     }
 
     public function testParsingInputWithNullBodyReturnsEmptyDictionary(): void
@@ -115,8 +115,8 @@ class BodyParserTest extends TestCase
         $this->assertNotNull($multipartBody);
         $bodyParts = $multipartBody->getParts();
         $this->assertCount(1, $bodyParts);
-        $this->assertEquals('bar', $bodyParts[0]->getHeaders()->getFirst('Foo'));
-        $this->assertEquals('blah', $bodyParts[0]->getHeaders()->getFirst('Baz'));
+        $this->assertSame('bar', $bodyParts[0]->getHeaders()->getFirst('Foo'));
+        $this->assertSame('blah', $bodyParts[0]->getHeaders()->getFirst('Baz'));
     }
 
     public function testParsingMultipartRequestWithHeadersExtractsBody(): void
@@ -130,7 +130,7 @@ class BodyParserTest extends TestCase
         $this->assertCount(1, $bodyParts);
         $body = $bodyParts[0]->getBody();
         $this->assertNotNull($body);
-        $this->assertEquals('body', $body->readAsString());
+        $this->assertSame('body', $body->readAsString());
     }
 
     public function testParsingMultipartRequestWithNullBodyReturnsNull(): void
@@ -167,7 +167,7 @@ class BodyParserTest extends TestCase
         $this->assertNotNull($multipartBody);
         $bodyParts = $multipartBody->getParts();
         $this->assertCount(1, $bodyParts);
-        $this->assertEquals(
+        $this->assertSame(
             'multipart/mixed; boundary="boundary2"',
             $bodyParts[0]->getHeaders()->getFirst('Content-Type')
         );
@@ -185,6 +185,6 @@ class BodyParserTest extends TestCase
             '--boundary2--';
         $body = $bodyParts[0]->getBody();
         $this->assertNotNull($body);
-        $this->assertEquals($expectedBodyString, $body->readAsString());
+        $this->assertSame($expectedBodyString, $body->readAsString());
     }
 }

--- a/src/Net/tests/Http/Formatting/HeaderParserTest.php
+++ b/src/Net/tests/Http/Formatting/HeaderParserTest.php
@@ -63,7 +63,7 @@ class HeaderParserTest extends TestCase
         $headers = new Headers();
         $headers->add('Content-Type', 'application/json');
         $value = $this->parser->parseContentTypeHeader($headers);
-        $this->assertEquals('application/json', $value->getMediaType());
+        $this->assertSame('application/json', $value->getMediaType());
     }
 
     public function testParsingParametersForIndexThatDoesNotExistReturnsEmptyDictionary(): void
@@ -79,7 +79,7 @@ class HeaderParserTest extends TestCase
         $headers->add('Foo', 'bar; baz="blah"');
         $values = $this->parser->parseParameters($headers, 'Foo');
         $this->assertNull($values->get('bar'));
-        $this->assertEquals('blah', $values->get('baz'));
+        $this->assertSame('blah', $values->get('baz'));
     }
 
     public function testParsingParametersWithQuotedAndUnquotedValuesReturnsArrayWithUnquotedValue(): void
@@ -87,8 +87,8 @@ class HeaderParserTest extends TestCase
         $headers = new Headers();
         $headers->add('Foo', 'bar=baz');
         $headers->add('Bar', 'bar="baz"');
-        $this->assertEquals('baz', $this->parser->parseParameters($headers, 'Foo')->get('bar'));
-        $this->assertEquals('baz', $this->parser->parseParameters($headers, 'Bar')->get('bar'));
+        $this->assertSame('baz', $this->parser->parseParameters($headers, 'Foo')->get('bar'));
+        $this->assertSame('baz', $this->parser->parseParameters($headers, 'Bar')->get('bar'));
     }
 
     public function testIsJsonForHeadersWithoutContentTypeReturnsFalse(): void

--- a/src/Net/tests/Http/Formatting/RequestHeaderParserTest.php
+++ b/src/Net/tests/Http/Formatting/RequestHeaderParserTest.php
@@ -34,10 +34,10 @@ class RequestHeaderParserTest extends TestCase
         $headers->add('Accept-Charset', 'utf-16', true);
         $headerValues = $this->parser->parseAcceptCharsetHeader($headers);
         $this->assertCount(2, $headerValues);
-        $this->assertEquals('utf-8', $headerValues[0]->getCharset());
-        $this->assertEquals(1.0, $headerValues[0]->getQuality());
-        $this->assertEquals('utf-16', $headerValues[1]->getCharset());
-        $this->assertEquals(1.0, $headerValues[1]->getQuality());
+        $this->assertSame('utf-8', $headerValues[0]->getCharset());
+        $this->assertSame(1.0, $headerValues[0]->getQuality());
+        $this->assertSame('utf-16', $headerValues[1]->getCharset());
+        $this->assertSame(1.0, $headerValues[1]->getQuality());
     }
 
     public function testParsingAcceptCharsetHeaderWithScoresReturnsValuesWithThoseScores(): void
@@ -47,10 +47,10 @@ class RequestHeaderParserTest extends TestCase
         $headers->add('Accept-Charset', 'utf-16; q=0.5', true);
         $headerValues = $this->parser->parseAcceptCharsetHeader($headers);
         $this->assertCount(2, $headerValues);
-        $this->assertEquals('utf-8', $headerValues[0]->getCharset());
-        $this->assertEquals(0.1, $headerValues[0]->getQuality());
-        $this->assertEquals('utf-16', $headerValues[1]->getCharset());
-        $this->assertEquals(0.5, $headerValues[1]->getQuality());
+        $this->assertSame('utf-8', $headerValues[0]->getCharset());
+        $this->assertSame(0.1, $headerValues[0]->getQuality());
+        $this->assertSame('utf-16', $headerValues[1]->getCharset());
+        $this->assertSame(0.5, $headerValues[1]->getQuality());
     }
 
     public function testParsingAcceptHeaderWithCharsetSetsCharsetInHeaderValue(): void
@@ -59,7 +59,7 @@ class RequestHeaderParserTest extends TestCase
         $headers->add('Accept', 'text/html; charset=utf-8', true);
         $headerValues = $this->parser->parseAcceptHeader($headers);
         $this->assertCount(1, $headerValues);
-        $this->assertEquals('utf-8', $headerValues[0]->getCharset());
+        $this->assertSame('utf-8', $headerValues[0]->getCharset());
     }
 
     public function testParsingAcceptHeaderWithNoScoresReturnsValuesWithDefaultScores(): void
@@ -69,11 +69,11 @@ class RequestHeaderParserTest extends TestCase
         $headers->add('Accept', 'application/json', true);
         $headerValues = $this->parser->parseAcceptHeader($headers);
         $this->assertCount(2, $headerValues);
-        $this->assertEquals('text/html', $headerValues[0]->getMediaType());
-        $this->assertEquals(1.0, $headerValues[0]->getQuality());
+        $this->assertSame('text/html', $headerValues[0]->getMediaType());
+        $this->assertSame(1.0, $headerValues[0]->getQuality());
         $this->assertNull($headerValues[0]->getCharset());
-        $this->assertEquals('application/json', $headerValues[1]->getMediaType());
-        $this->assertEquals(1.0, $headerValues[1]->getQuality());
+        $this->assertSame('application/json', $headerValues[1]->getMediaType());
+        $this->assertSame(1.0, $headerValues[1]->getQuality());
         $this->assertNull($headerValues[1]->getCharset());
     }
 
@@ -84,11 +84,11 @@ class RequestHeaderParserTest extends TestCase
         $headers->add('Accept', 'application/json; q=0.5', true);
         $headerValues = $this->parser->parseAcceptHeader($headers);
         $this->assertCount(2, $headerValues);
-        $this->assertEquals('text/html', $headerValues[0]->getMediaType());
-        $this->assertEquals(0.1, $headerValues[0]->getQuality());
+        $this->assertSame('text/html', $headerValues[0]->getMediaType());
+        $this->assertSame(0.1, $headerValues[0]->getQuality());
         $this->assertNull($headerValues[0]->getCharset());
-        $this->assertEquals('application/json', $headerValues[1]->getMediaType());
-        $this->assertEquals(0.5, $headerValues[1]->getQuality());
+        $this->assertSame('application/json', $headerValues[1]->getMediaType());
+        $this->assertSame(0.5, $headerValues[1]->getQuality());
         $this->assertNull($headerValues[1]->getCharset());
     }
 
@@ -99,10 +99,10 @@ class RequestHeaderParserTest extends TestCase
         $headers->add('Accept-Language', 'en-GB', true);
         $headerValues = $this->parser->parseAcceptLanguageHeader($headers);
         $this->assertCount(2, $headerValues);
-        $this->assertEquals('en-US', $headerValues[0]->getLanguage());
-        $this->assertEquals(1.0, $headerValues[0]->getQuality());
-        $this->assertEquals('en-GB', $headerValues[1]->getLanguage());
-        $this->assertEquals(1.0, $headerValues[1]->getQuality());
+        $this->assertSame('en-US', $headerValues[0]->getLanguage());
+        $this->assertSame(1.0, $headerValues[0]->getQuality());
+        $this->assertSame('en-GB', $headerValues[1]->getLanguage());
+        $this->assertSame(1.0, $headerValues[1]->getQuality());
     }
 
     public function testParsingAcceptLanguageHeaderWithScoresReturnsValuesWithThoseScores(): void
@@ -112,10 +112,10 @@ class RequestHeaderParserTest extends TestCase
         $headers->add('Accept-Language', 'en-GB; q=0.5', true);
         $headerValues = $this->parser->parseAcceptLanguageHeader($headers);
         $this->assertCount(2, $headerValues);
-        $this->assertEquals('en-US', $headerValues[0]->getLanguage());
-        $this->assertEquals(0.1, $headerValues[0]->getQuality());
-        $this->assertEquals('en-GB', $headerValues[1]->getLanguage());
-        $this->assertEquals(0.5, $headerValues[1]->getQuality());
+        $this->assertSame('en-US', $headerValues[0]->getLanguage());
+        $this->assertSame(0.1, $headerValues[0]->getQuality());
+        $this->assertSame('en-GB', $headerValues[1]->getLanguage());
+        $this->assertSame(0.5, $headerValues[1]->getQuality());
     }
 
     public function testParsingContentTypeHeaderWithCharsetSetsCharset(): void
@@ -123,8 +123,8 @@ class RequestHeaderParserTest extends TestCase
         $headers = new Headers();
         $headers->add('Content-Type', 'application/json; charset=utf-8');
         $headerValue = $this->parser->parseContentTypeHeader($headers);
-        $this->assertEquals('application/json', $headerValue->getMediaType());
-        $this->assertEquals('utf-8', $headerValue->getCharset());
+        $this->assertSame('application/json', $headerValue->getMediaType());
+        $this->assertSame('utf-8', $headerValue->getCharset());
     }
 
     public function testParsingContentTypeHeaderWithNoCharsetStillSetsMediaType(): void
@@ -132,7 +132,7 @@ class RequestHeaderParserTest extends TestCase
         $headers = new Headers();
         $headers->add('Content-Type', 'application/json');
         $headerValue = $this->parser->parseContentTypeHeader($headers);
-        $this->assertEquals('application/json', $headerValue->getMediaType());
+        $this->assertSame('application/json', $headerValue->getMediaType());
         $this->assertNull($headerValue->getCharset());
     }
 
@@ -140,13 +140,13 @@ class RequestHeaderParserTest extends TestCase
     {
         $this->headers->add('Cookie', 'foo=bar; baz=blah');
         $cookies = $this->parser->parseCookies($this->headers);
-        $this->assertEquals('bar', $cookies->get('foo'));
-        $this->assertEquals('blah', $cookies->get('baz'));
+        $this->assertSame('bar', $cookies->get('foo'));
+        $this->assertSame('blah', $cookies->get('baz'));
     }
 
     public function testParsingCookiesAndNotHavingCookieHeaderReturnsEmptyDictionary(): void
     {
-        $this->assertEquals(0, $this->parser->parseCookies($this->headers)->count());
+        $this->assertSame(0, $this->parser->parseCookies($this->headers)->count());
     }
 
     public function testParsingNonExistentAcceptCharsetHeaderReturnsEmptyArray(): void

--- a/src/Net/tests/Http/Formatting/RequestParserTest.php
+++ b/src/Net/tests/Http/Formatting/RequestParserTest.php
@@ -63,7 +63,7 @@ class RequestParserTest extends TestCase
         $this->body->expects($this->once())
             ->method('readAsString')
             ->willReturn('<?xml version="1.0"?><foo />');
-        $this->assertEquals('text/xml', $this->parser->getActualMimeType($this->request));
+        $this->assertSame('text/xml', $this->parser->getActualMimeType($this->request));
     }
 
     public function testGettingClientIPAddressReturnsNullWhenPropertyIsNotSet(): void
@@ -74,7 +74,7 @@ class RequestParserTest extends TestCase
     public function testGettingClientIPAddressReturnsPropertyValueWhenPropertyIsSet(): void
     {
         $this->properties->add('CLIENT_IP_ADDRESS', '127.0.0.1');
-        $this->assertEquals('127.0.0.1', $this->parser->getClientIPAddress($this->request));
+        $this->assertSame('127.0.0.1', $this->parser->getClientIPAddress($this->request));
     }
 
     public function testGettingClientMimeTypeForMultipartWithContentTypeReturnsCorrectMimeType(): void
@@ -83,7 +83,7 @@ class RequestParserTest extends TestCase
             new Headers([new KeyValuePair('Content-Type', 'image/png')]),
             new StringBody('')
         );
-        $this->assertEquals('image/png', $this->parser->getClientMimeType($bodyPart));
+        $this->assertSame('image/png', $this->parser->getClientMimeType($bodyPart));
     }
 
     public function testGettingClientMimeTypeForMultipartWithoutContentTypeHeaderReturnsNull(): void
@@ -126,7 +126,7 @@ class RequestParserTest extends TestCase
         $this->headers->add('Accept-Charset', 'utf-8; q=0.1');
         $values = $this->parser->parseAcceptCharsetHeader($this->request);
         $this->assertCount(1, $values);
-        $this->assertEquals(0.1, $values[0]->getParameters()->get('q'));
+        $this->assertSame('0.1', $values[0]->getParameters()->get('q'));
     }
 
     public function testParseAcceptHeaderReturnsThem(): void
@@ -134,7 +134,7 @@ class RequestParserTest extends TestCase
         $this->headers->add('Accept', 'tex/plain; q=0.1');
         $values = $this->parser->parseAcceptHeader($this->request);
         $this->assertCount(1, $values);
-        $this->assertEquals(0.1, $values[0]->getParameters()->get('q'));
+        $this->assertSame('0.1', $values[0]->getParameters()->get('q'));
     }
 
     public function testParseAcceptLanguageHeaderReturnsThem(): void
@@ -142,23 +142,23 @@ class RequestParserTest extends TestCase
         $this->headers->add('Accept-language', 'en; q=0.1');
         $values = $this->parser->parseAcceptLanguageHeader($this->request);
         $this->assertCount(1, $values);
-        $this->assertEquals(0.1, $values[0]->getParameters()->get('q'));
+        $this->assertSame('0.1', $values[0]->getParameters()->get('q'));
     }
 
     public function testParseContentTypeReturnsContentTypeHeader(): void
     {
         $this->headers->add('Content-Type', 'application/json; charset=utf-8');
         $header = $this->parser->parseContentTypeHeader($this->request);
-        $this->assertEquals('application/json', $header->getMediaType());
-        $this->assertEquals('utf-8', $header->getCharset());
+        $this->assertSame('application/json', $header->getMediaType());
+        $this->assertSame('utf-8', $header->getCharset());
     }
 
     public function testParsingCookiesReturnsCorrectValuesWithMultipleCookieValues(): void
     {
         $this->headers->add('Cookie', 'foo=bar; baz=blah');
         $cookies = $this->parser->parseCookies($this->request);
-        $this->assertEquals('bar', $cookies->get('foo'));
-        $this->assertEquals('blah', $cookies->get('baz'));
+        $this->assertSame('bar', $cookies->get('foo'));
+        $this->assertSame('blah', $cookies->get('baz'));
     }
 
     public function testParsingMultipartRequestWithoutBoundaryThrowsException(): void
@@ -181,7 +181,7 @@ class RequestParserTest extends TestCase
         $this->headers->add('Foo', 'bar; baz="blah"');
         $values = $this->parser->parseParameters($this->request, 'Foo');
         $this->assertNull($values->get('bar'));
-        $this->assertEquals('blah', $values->get('baz'));
+        $this->assertSame('blah', $values->get('baz'));
     }
 
     public function testParsingQueryStringReturnsDictionaryOfValues(): void
@@ -190,7 +190,7 @@ class RequestParserTest extends TestCase
         $request->expects($this->once())
             ->method('getUri')
             ->willReturn(new Uri('http://host.com?foo=bar'));
-        $this->assertEquals('bar', $this->parser->parseQueryString($request)->get('foo'));
+        $this->assertSame('bar', $this->parser->parseQueryString($request)->get('foo'));
     }
 
     public function testReadAsFormInputReturnsInput(): void
@@ -198,7 +198,7 @@ class RequestParserTest extends TestCase
         $this->body->method('readAsString')
             ->willReturn('foo=bar');
         $value = $this->parser->readAsFormInput($this->request);
-        $this->assertEquals('bar', $value->get('foo'));
+        $this->assertSame('bar', $value->get('foo'));
     }
 
     public function testReadAsJsonReturnsInput(): void
@@ -206,7 +206,7 @@ class RequestParserTest extends TestCase
         $this->body->method('readAsString')
             ->willReturn('{"foo":"bar"}');
         $value = $this->parser->readAsJson($this->request);
-        $this->assertEquals('bar', $value['foo']);
+        $this->assertSame('bar', $value['foo']);
     }
 
     public function testReadingAsMultipartRequestWithHeadersExtractsBody(): void
@@ -221,6 +221,6 @@ class RequestParserTest extends TestCase
         $this->assertCount(1, $bodyParts);
         $body = $bodyParts[0]->getBody();
         $this->assertNotNull($body);
-        $this->assertEquals('body', $body->readAsString());
+        $this->assertSame('body', $body->readAsString());
     }
 }

--- a/src/Net/tests/Http/Formatting/ResponseFormatterTest.php
+++ b/src/Net/tests/Http/Formatting/ResponseFormatterTest.php
@@ -46,13 +46,13 @@ class ResponseFormatterTest extends TestCase
                 return $body instanceof StringBody && $body->readAsString() === json_encode(['foo' => 'bar']);
             }));
         $this->formatter->writeJson($this->response, ['foo' => 'bar']);
-        $this->assertEquals('application/json', $this->response->getHeaders()->getFirst('Content-Type'));
+        $this->assertSame('application/json', $this->response->getHeaders()->getFirst('Content-Type'));
     }
 
     public function testDeletingCookieSetsCookiesToExpire(): void
     {
         $this->formatter->deleteCookie($this->response, 'name', '/path', 'example.com', true, true, 'lax');
-        $this->assertEquals(
+        $this->assertSame(
             'name=; Max-Age=0; Path=%2Fpath; Domain=example.com; Secure; HttpOnly; SameSite=lax',
             $this->headers->getFirst('Set-Cookie')
         );
@@ -64,7 +64,7 @@ class ResponseFormatterTest extends TestCase
             ->method('setStatusCode')
             ->with(301);
         $this->formatter->redirectToUri($this->response, 'http://foo.com', 301);
-        $this->assertEquals('http://foo.com', $this->headers->getFirst('Location'));
+        $this->assertSame('http://foo.com', $this->headers->getFirst('Location'));
     }
 
     public function testRedirectingToUriConvertsUriInstanceToStringAndSetsLocationHeaderAndStatusCode(): void
@@ -73,7 +73,7 @@ class ResponseFormatterTest extends TestCase
             ->method('setStatusCode')
             ->with(301);
         $this->formatter->redirectToUri($this->response, new Uri('http://foo.com'), 301);
-        $this->assertEquals('http://foo.com', $this->headers->getFirst('Location'));
+        $this->assertSame('http://foo.com', $this->headers->getFirst('Location'));
     }
 
     public function testRedirectingToUriThatIsNotUriNorStringThrowsException(): void
@@ -89,7 +89,7 @@ class ResponseFormatterTest extends TestCase
             $this->response,
             new Cookie('name', 'value', 3600, '/path', 'example.com', true, true, 'lax')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'name=value; Max-Age=3600; Path=%2Fpath; Domain=example.com; Secure; HttpOnly; SameSite=lax',
             $this->headers->getFirst('Set-Cookie')
         );
@@ -103,11 +103,11 @@ class ResponseFormatterTest extends TestCase
         );
         $cookies = $this->headers->get('Set-Cookie');
         $this->assertCount(2, $cookies);
-        $this->assertEquals(
+        $this->assertSame(
             'name1=value1; Max-Age=3600; HttpOnly; SameSite=lax',
             $cookies[0]
         );
-        $this->assertEquals(
+        $this->assertSame(
             'name2=value2; Max-Age=7200; HttpOnly; SameSite=lax',
             $cookies[1]
         );

--- a/src/Net/tests/Http/Formatting/ResponseHeaderFormatterTest.php
+++ b/src/Net/tests/Http/Formatting/ResponseHeaderFormatterTest.php
@@ -32,7 +32,7 @@ class ResponseHeaderFormatterTest extends TestCase
     {
         $cookie = new Cookie('foo', '+', null, '/', null, false, false, 'strict');
         $this->formatter->setCookie($this->headers, $cookie);
-        $this->assertEquals(
+        $this->assertSame(
             'foo=' . urlencode('+') . '; Path=' . urlencode('/') . '; SameSite=' . urldecode('strict'),
             $this->headers->getFirst('Set-Cookie')
         );
@@ -42,7 +42,7 @@ class ResponseHeaderFormatterTest extends TestCase
     {
         $cookie = new Cookie('foo', 'bar', null, null, 'foo.com', false, false, null);
         $this->formatter->setCookie($this->headers, $cookie);
-        $this->assertEquals(
+        $this->assertSame(
             'foo=bar; Domain=foo.com',
             $this->headers->getFirst('Set-Cookie')
         );
@@ -53,7 +53,7 @@ class ResponseHeaderFormatterTest extends TestCase
         $maxAge = 3600;
         $cookie = new Cookie('foo', 'bar', $maxAge, null, null, false, false, null);
         $this->formatter->setCookie($this->headers, $cookie);
-        $this->assertEquals(
+        $this->assertSame(
             'foo=bar; Max-Age=3600',
             $this->headers->getFirst('Set-Cookie')
         );
@@ -63,7 +63,7 @@ class ResponseHeaderFormatterTest extends TestCase
     {
         $cookie = new Cookie('foo', 'bar', null, null, null, false, false);
         $this->formatter->setCookie($this->headers, $cookie);
-        $this->assertEquals(
+        $this->assertSame(
             'foo=bar; SameSite=lax',
             $this->headers->getFirst('Set-Cookie')
         );
@@ -73,7 +73,7 @@ class ResponseHeaderFormatterTest extends TestCase
     {
         $cookie = new Cookie('foo', 'bar', null, '/foo', null, false, false, null);
         $this->formatter->setCookie($this->headers, $cookie);
-        $this->assertEquals(
+        $this->assertSame(
             'foo=bar; Path=' . urlencode('/foo'),
             $this->headers->getFirst('Set-Cookie')
         );
@@ -83,7 +83,7 @@ class ResponseHeaderFormatterTest extends TestCase
     {
         $cookie = new Cookie('foo', 'bar', null, null, null, false, false, 'lax');
         $this->formatter->setCookie($this->headers, $cookie);
-        $this->assertEquals(
+        $this->assertSame(
             'foo=bar; SameSite=lax',
             $this->headers->getFirst('Set-Cookie')
         );
@@ -103,39 +103,39 @@ class ResponseHeaderFormatterTest extends TestCase
     public function testDeletingCookieWithSpecificDomain(): void
     {
         $this->formatter->deleteCookie($this->headers, 'foo', null, 'domain.com', false, false, null);
-        $this->assertEquals('foo=; Max-Age=0; Domain=domain.com', $this->headers->getFirst('Set-Cookie'));
+        $this->assertSame('foo=; Max-Age=0; Domain=domain.com', $this->headers->getFirst('Set-Cookie'));
     }
 
     public function testDeletingCookieWithSpecificPath(): void
     {
         $this->formatter->deleteCookie($this->headers, 'foo', '/', null, false, false, null);
-        $this->assertEquals('foo=; Max-Age=0; Path=%2F', $this->headers->getFirst('Set-Cookie'));
+        $this->assertSame('foo=; Max-Age=0; Path=%2F', $this->headers->getFirst('Set-Cookie'));
     }
 
     public function testDeletingCookieWithSecure(): void
     {
         $this->formatter->deleteCookie($this->headers, 'foo', null, null, true, false, null);
-        $this->assertEquals('foo=; Max-Age=0; Secure', $this->headers->getFirst('Set-Cookie'));
+        $this->assertSame('foo=; Max-Age=0; Secure', $this->headers->getFirst('Set-Cookie'));
     }
 
     public function testDeletingCookieWithSameSite(): void
     {
         $this->formatter->deleteCookie($this->headers, 'foo', null, null, false, false, Cookie::SAME_SITE_STRICT);
-        $this->assertEquals('foo=; Max-Age=0; SameSite=strict', $this->headers->getFirst('Set-Cookie'));
+        $this->assertSame('foo=; Max-Age=0; SameSite=strict', $this->headers->getFirst('Set-Cookie'));
     }
 
     public function testHttpOnlyCookieSetsHttpOnlyFlag(): void
     {
         $cookie = new Cookie('foo', 'bar', null, null, null, false, true, null);
         $this->formatter->setCookie($this->headers, $cookie);
-        $this->assertEquals('foo=bar; HttpOnly', $this->headers->getFirst('Set-Cookie'));
+        $this->assertSame('foo=bar; HttpOnly', $this->headers->getFirst('Set-Cookie'));
     }
 
     public function testSecureCookieSetsSecureFlag(): void
     {
         $cookie = new Cookie('foo', 'bar', null, null, null, true, false, null);
         $this->formatter->setCookie($this->headers, $cookie);
-        $this->assertEquals('foo=bar; Secure', $this->headers->getFirst('Set-Cookie'));
+        $this->assertSame('foo=bar; Secure', $this->headers->getFirst('Set-Cookie'));
     }
 
     public function testSettingCookieAppendsToCookieHeader(): void

--- a/src/Net/tests/Http/Headers/AcceptCharsetHeaderValueTest.php
+++ b/src/Net/tests/Http/Headers/AcceptCharsetHeaderValueTest.php
@@ -58,12 +58,12 @@ class AcceptCharsetHeaderValueTest extends TestCase
     {
         $parameters = new ImmutableHashTable([new KeyValuePair('q', '.5')]);
         $value = new AcceptCharsetHeaderValue('utf-8', $parameters);
-        $this->assertEquals(.5, $value->getQuality());
+        $this->assertSame(.5, $value->getQuality());
     }
 
     public function testQualityDefaultsToOne(): void
     {
         $value = new AcceptCharsetHeaderValue('utf-8', null);
-        $this->assertEquals(1, $value->getQuality());
+        $this->assertEquals(1.0, $value->getQuality());
     }
 }

--- a/src/Net/tests/Http/Headers/AcceptLanguageHeaderValueTest.php
+++ b/src/Net/tests/Http/Headers/AcceptLanguageHeaderValueTest.php
@@ -58,12 +58,12 @@ class AcceptLanguageHeaderValueTest extends TestCase
     {
         $parameters = new ImmutableHashTable([new KeyValuePair('q', '.5')]);
         $value = new AcceptLanguageHeaderValue('en-US', $parameters);
-        $this->assertEquals(.5, $value->getQuality());
+        $this->assertSame(.5, $value->getQuality());
     }
 
     public function testQualityDefaultsToOne(): void
     {
         $value = new AcceptLanguageHeaderValue('en-US', null);
-        $this->assertEquals(1, $value->getQuality());
+        $this->assertEquals(1.0, $value->getQuality());
     }
 }

--- a/src/Net/tests/Http/Headers/AcceptMediaTypeHeaderValueTest.php
+++ b/src/Net/tests/Http/Headers/AcceptMediaTypeHeaderValueTest.php
@@ -43,7 +43,7 @@ class AcceptMediaTypeHeaderValueTest extends TestCase
     {
         $parameters = new ImmutableHashTable([new KeyValuePair('q', '.5')]);
         $value = new AcceptMediaTypeHeaderValue('foo/bar', $parameters);
-        $this->assertEquals(.5, $value->getQuality());
+        $this->assertSame(.5, $value->getQuality());
     }
 
     public function testQualityDefaultsToOne(): void
@@ -55,9 +55,9 @@ class AcceptMediaTypeHeaderValueTest extends TestCase
     public function testTypeWithSuffixSetsTypeSubTypeAndSuffixesCorrectly(): void
     {
         $value = new AcceptMediaTypeHeaderValue('application/foo+json', null);
-        $this->assertEquals('application', $value->getType());
-        $this->assertEquals('foo+json', $value->getSubType());
-        $this->assertEquals('foo', $value->getSubTypeWithoutSuffix());
-        $this->assertEquals('json', $value->getSuffix());
+        $this->assertSame('application', $value->getType());
+        $this->assertSame('foo+json', $value->getSubType());
+        $this->assertSame('foo', $value->getSubTypeWithoutSuffix());
+        $this->assertSame('json', $value->getSuffix());
     }
 }

--- a/src/Net/tests/Http/Headers/ContentTypeHeaderValueTest.php
+++ b/src/Net/tests/Http/Headers/ContentTypeHeaderValueTest.php
@@ -25,35 +25,35 @@ class ContentTypeHeaderValueTest extends TestCase
     {
         $parameters = new ImmutableHashTable([new KeyValuePair('charset', 'utf-8')]);
         $value = new ContentTypeHeaderValue('foo/bar', $parameters);
-        $this->assertEquals('utf-8', $value->getCharset());
+        $this->assertSame('utf-8', $value->getCharset());
     }
 
     public function testGettingMediaTypeReturnsOneSetInConstructor(): void
     {
         $parameters = new ImmutableHashTable([new KeyValuePair('charset', 'utf-8')]);
         $value = new ContentTypeHeaderValue('foo/bar', $parameters);
-        $this->assertEquals('foo/bar', $value->getMediaType());
+        $this->assertSame('foo/bar', $value->getMediaType());
     }
 
     public function testGettingSubTypeReturnsCorrectSubtType(): void
     {
         $value = new ContentTypeHeaderValue('foo/bar', $this->createMock(IImmutableDictionary::class));
-        $this->assertEquals('bar', $value->getSubType());
+        $this->assertSame('bar', $value->getSubType());
     }
 
     public function testGettingTypeReturnsCorrectType(): void
     {
         $value = new ContentTypeHeaderValue('foo/bar', $this->createMock(IImmutableDictionary::class));
-        $this->assertEquals('foo', $value->getType());
+        $this->assertSame('foo', $value->getType());
     }
 
     public function testTypeWithSuffixSetsTypeSubTypeAndSuffixesCorrectly(): void
     {
         $value = new ContentTypeHeaderValue('application/foo+json', $this->createMock(IImmutableDictionary::class));
-        $this->assertEquals('application', $value->getType());
-        $this->assertEquals('foo+json', $value->getSubType());
-        $this->assertEquals('foo', $value->getSubTypeWithoutSuffix());
-        $this->assertEquals('json', $value->getSuffix());
+        $this->assertSame('application', $value->getType());
+        $this->assertSame('foo+json', $value->getSubType());
+        $this->assertSame('foo', $value->getSubTypeWithoutSuffix());
+        $this->assertSame('json', $value->getSuffix());
     }
 
     public function incorrectlyFormattedMediaTypeProvider(): array

--- a/src/Net/tests/Http/Headers/CookieTest.php
+++ b/src/Net/tests/Http/Headers/CookieTest.php
@@ -47,14 +47,14 @@ class CookieTest extends TestCase
     {
         $domainName = 'www.domain.com';
         $this->cookie->setDomain($domainName);
-        $this->assertEquals($domainName, $this->cookie->getDomain());
+        $this->assertSame($domainName, $this->cookie->getDomain());
     }
 
     public function testSetPath(): void
     {
         $path = '/';
         $this->cookie->setPath($path);
-        $this->assertEquals($path, $this->cookie->getPath());
+        $this->assertSame($path, $this->cookie->getPath());
     }
 
     public function setValueProvider(): array
@@ -91,32 +91,32 @@ class CookieTest extends TestCase
 
     public function testGettingDomain(): void
     {
-        $this->assertEquals('foo.com', $this->cookie->getDomain());
+        $this->assertSame('foo.com', $this->cookie->getDomain());
     }
 
     public function testGettingMaxAge(): void
     {
-        $this->assertEquals(1234, $this->cookie->getMaxAge());
+        $this->assertSame(1234, $this->cookie->getMaxAge());
     }
 
     public function testGettingName(): void
     {
-        $this->assertEquals('name', $this->cookie->getName());
+        $this->assertSame('name', $this->cookie->getName());
     }
 
     public function testGettingPath(): void
     {
-        $this->assertEquals('/', $this->cookie->getPath());
+        $this->assertSame('/', $this->cookie->getPath());
     }
 
     public function testGettingSameSite(): void
     {
-        $this->assertEquals(Cookie::SAME_SITE_LAX, $this->cookie->getSameSite());
+        $this->assertSame(Cookie::SAME_SITE_LAX, $this->cookie->getSameSite());
     }
 
     public function testGettingValue(): void
     {
-        $this->assertEquals('value', $this->cookie->getValue());
+        $this->assertSame('value', $this->cookie->getValue());
     }
 
     public function testInvalidNameThrowsException(): void
@@ -129,6 +129,6 @@ class CookieTest extends TestCase
     public function testSettingMaxAge(): void
     {
         $this->cookie->setMaxAge(3600);
-        $this->assertEquals(3600, $this->cookie->getMaxAge());
+        $this->assertSame(3600, $this->cookie->getMaxAge());
     }
 }

--- a/src/Net/tests/Http/Headers/MediaTypeHeaderValueTest.php
+++ b/src/Net/tests/Http/Headers/MediaTypeHeaderValueTest.php
@@ -25,14 +25,14 @@ class MediaTypeHeaderValueTest extends TestCase
     {
         $parameters = new ImmutableHashTable([new KeyValuePair('charset', 'utf-8')]);
         $value = new MediaTypeHeaderValue('foo/bar', $parameters);
-        $this->assertEquals('utf-8', $value->getCharset());
+        $this->assertSame('utf-8', $value->getCharset());
     }
 
     public function testGettingMediaTypeReturnsOneSetInConstructor(): void
     {
         $parameters = new ImmutableHashTable([new KeyValuePair('charset', 'utf-8')]);
         $value = new MediaTypeHeaderValue('foo/bar', $parameters);
-        $this->assertEquals('foo/bar', $value->getMediaType());
+        $this->assertSame('foo/bar', $value->getMediaType());
     }
     public function testGettingParametersReturnsOnesSetInConstructor(): void
     {
@@ -44,28 +44,28 @@ class MediaTypeHeaderValueTest extends TestCase
     public function testGettingSubTypeReturnsCorrectSubType(): void
     {
         $value = new MediaTypeHeaderValue('foo/bar', $this->createMock(IImmutableDictionary::class));
-        $this->assertEquals('bar', $value->getSubType());
+        $this->assertSame('bar', $value->getSubType());
     }
 
     public function testGettingSubTypeWithoutSuffixForSubTypeWithoutSuffixReturnsCorrectSubType(): void
     {
         $value = new MediaTypeHeaderValue('foo/bar', $this->createMock(IImmutableDictionary::class));
-        $this->assertEquals('bar', $value->getSubTypeWithoutSuffix());
+        $this->assertSame('bar', $value->getSubTypeWithoutSuffix());
     }
 
     public function testGettingTypeReturnsCorrectType(): void
     {
         $value = new MediaTypeHeaderValue('foo/bar', $this->createMock(IImmutableDictionary::class));
-        $this->assertEquals('foo', $value->getType());
+        $this->assertSame('foo', $value->getType());
     }
 
     public function testTypeWithSuffixSetsTypeSubTypeAndSuffixesCorrectly(): void
     {
         $value = new MediaTypeHeaderValue('application/foo+json', $this->createMock(IImmutableDictionary::class));
-        $this->assertEquals('application', $value->getType());
-        $this->assertEquals('foo+json', $value->getSubType());
-        $this->assertEquals('foo', $value->getSubTypeWithoutSuffix());
-        $this->assertEquals('json', $value->getSuffix());
+        $this->assertSame('application', $value->getType());
+        $this->assertSame('foo+json', $value->getSubType());
+        $this->assertSame('foo', $value->getSubTypeWithoutSuffix());
+        $this->assertSame('json', $value->getSuffix());
     }
 
     public function incorrectlyFormattedMediaTypeProvider(): array

--- a/src/Net/tests/Http/HttpExceptionTest.php
+++ b/src/Net/tests/Http/HttpExceptionTest.php
@@ -23,7 +23,7 @@ class HttpExceptionTest extends TestCase
     public function testCodeIsSameOneSetInConstructor(): void
     {
         $exception = new HttpException(500, '', 4);
-        $this->assertEquals(4, $exception->getCode());
+        $this->assertSame(4, $exception->getCode());
     }
 
     public function testInvalidStatusCodeOrResponseThrowsException(): void
@@ -36,13 +36,13 @@ class HttpExceptionTest extends TestCase
     public function testIntStatusCodeIsSetInResponse(): void
     {
         $exception = new HttpException(500);
-        $this->assertEquals(500, $exception->getResponse()->getStatusCode());
+        $this->assertSame(500, $exception->getResponse()->getStatusCode());
     }
 
     public function testMessageIsSameOneSetInConstructor(): void
     {
         $exception = new HttpException(500, 'foo');
-        $this->assertEquals('foo', $exception->getMessage());
+        $this->assertSame('foo', $exception->getMessage());
     }
 
     public function testPreviousExceptionIsSameOneSetInConstructor(): void

--- a/src/Net/tests/Http/HttpHeadersTest.php
+++ b/src/Net/tests/Http/HttpHeadersTest.php
@@ -49,7 +49,7 @@ class HttpHeadersTest extends TestCase
     public function testGettingFirstValue(): void
     {
         $this->headers->add('foo', ['bar', 'baz']);
-        $this->assertEquals('bar', $this->headers->getFirst('foo'));
+        $this->assertSame('bar', $this->headers->getFirst('foo'));
     }
 
     public function testGettingFirstValueWhenKeyDoesNotExistThrowsException(): void
@@ -64,20 +64,20 @@ class HttpHeadersTest extends TestCase
         // Test lower-case names
         $this->headers->add('foo', 'bar');
         $this->assertEquals(['bar'], $this->headers->get('Foo'));
-        $this->assertEquals('bar', $this->headers->getFirst('foo'));
+        $this->assertSame('bar', $this->headers->getFirst('foo'));
         $this->assertTrue($this->headers->containsKey('foo'));
         $this->headers->removeKey('foo');
         // Test snake-case names
         $this->headers->add('FOO_BAR', 'baz');
         $this->assertEquals(['baz'], $this->headers->get('Foo-Bar'));
-        $this->assertEquals('baz', $this->headers->getFirst('FOO_BAR'));
+        $this->assertSame('baz', $this->headers->getFirst('FOO_BAR'));
         $this->assertTrue($this->headers->containsKey('FOO_BAR'));
         $this->headers->removeKey('FOO_BAR');
         // Test upper-case names
         $this->assertEquals([], $this->headers->toArray());
         $this->headers->add('BAZ', 'blah');
         $this->assertEquals(['blah'], $this->headers->get('Baz'));
-        $this->assertEquals('blah', $this->headers->getFirst('BAZ'));
+        $this->assertSame('blah', $this->headers->getFirst('BAZ'));
         $this->assertTrue($this->headers->containsKey('BAZ'));
         $this->headers->removeKey('BAZ');
         $this->assertEquals([], $this->headers->toArray());
@@ -88,20 +88,20 @@ class HttpHeadersTest extends TestCase
         // Test lower-case names
         $this->headers->addRange([new KeyValuePair('foo', 'bar')]);
         $this->assertEquals(['bar'], $this->headers->get('Foo'));
-        $this->assertEquals('bar', $this->headers->getFirst('foo'));
+        $this->assertSame('bar', $this->headers->getFirst('foo'));
         $this->assertTrue($this->headers->containsKey('foo'));
         $this->headers->removeKey('foo');
         // Test snake-case names
         $this->headers->addRange([new KeyValuePair('FOO_BAR', 'baz')]);
         $this->assertEquals(['baz'], $this->headers->get('Foo-Bar'));
-        $this->assertEquals('baz', $this->headers->getFirst('FOO_BAR'));
+        $this->assertSame('baz', $this->headers->getFirst('FOO_BAR'));
         $this->assertTrue($this->headers->containsKey('FOO_BAR'));
         $this->headers->removeKey('FOO_BAR');
         // Test upper-case names
         $this->assertEquals([], $this->headers->toArray());
         $this->headers->addRange([new KeyValuePair('BAZ', 'blah')]);
         $this->assertEquals(['blah'], $this->headers->get('Baz'));
-        $this->assertEquals('blah', $this->headers->getFirst('BAZ'));
+        $this->assertSame('blah', $this->headers->getFirst('BAZ'));
         $this->assertTrue($this->headers->containsKey('BAZ'));
         $this->headers->removeKey('BAZ');
         $this->assertEquals([], $this->headers->toArray());
@@ -118,14 +118,14 @@ class HttpHeadersTest extends TestCase
     {
         $this->headers->add('Foo', 'bar');
         $this->headers->add('Foo', 'baz', true);
-        $this->assertEquals('Foo: bar, baz', (string)$this->headers);
+        $this->assertSame('Foo: bar, baz', (string)$this->headers);
     }
 
     public function testSerializingSplitsHeadersIntoLines(): void
     {
         $this->headers->add('Foo', 'bar');
         $this->headers->add('Baz', 'blah');
-        $this->assertEquals("Foo: bar\r\nBaz: blah", (string)$this->headers);
+        $this->assertSame("Foo: bar\r\nBaz: blah", (string)$this->headers);
     }
 
     public function testSettingHeaderAndAppendingItAppendsIt(): void
@@ -169,7 +169,7 @@ class HttpHeadersTest extends TestCase
         $this->assertFalse($this->headers->tryGetFirst('foo', $value));
         $this->headers->add('foo', 'bar');
         $this->assertTrue($this->headers->tryGetFirst('foo', $value));
-        $this->assertEquals('bar', $value);
+        $this->assertSame('bar', $value);
     }
 
     public function testAddRangeOnInvalidValue(): void

--- a/src/Net/tests/Http/HttpStatusCodesTest.php
+++ b/src/Net/tests/Http/HttpStatusCodesTest.php
@@ -19,7 +19,7 @@ class HttpStatusCodesTest extends TestCase
 {
     public function testExistingStatusCodeReturnsDefaultStatusText(): void
     {
-        $this->assertEquals('OK', HttpStatusCodes::getDefaultReasonPhrase(200));
+        $this->assertSame('OK', HttpStatusCodes::getDefaultReasonPhrase(200));
     }
 
     public function testNonExistentStatusCodeReturnsNullStatusText(): void

--- a/src/Net/tests/Http/MultipartBodyPartTest.php
+++ b/src/Net/tests/Http/MultipartBodyPartTest.php
@@ -48,6 +48,6 @@ class MultipartBodyPartTest extends TestCase
         $this->body->expects($this->once())
             ->method('__toString')
             ->willReturn('baz');
-        $this->assertEquals("Foo: bar\r\n\r\nbaz", (string)$this->bodyPart);
+        $this->assertSame("Foo: bar\r\n\r\nbaz", (string)$this->bodyPart);
     }
 }

--- a/src/Net/tests/Http/MultipartBodyTest.php
+++ b/src/Net/tests/Http/MultipartBodyTest.php
@@ -26,7 +26,7 @@ class MultipartBodyTest extends TestCase
     public function testGettingBoundaryReturnsBoundarySpecifiedInConstructor(): void
     {
         $body = new MultipartBody([], 'foo');
-        $this->assertEquals('foo', $body->getBoundary());
+        $this->assertSame('foo', $body->getBoundary());
     }
 
     public function testGettingBoundaryReturnsUuidWhenNoneSpecifiedInConstructor(): void
@@ -106,7 +106,7 @@ class MultipartBodyTest extends TestCase
          * stream 2
          * \r\n--{boundary}--
          */
-        $this->assertEquals(5 + 4+ 1+ 7 + 4 + 2 + 9, $body->getLength());
+        $this->assertSame(5 + 4+ 1+ 7 + 4 + 2 + 9, $body->getLength());
     }
 
     public function testGettingPartsReturnsParts(): void
@@ -122,7 +122,7 @@ class MultipartBodyTest extends TestCase
     public function testNoPartsResultsInOnlyHeaderAndFooter(): void
     {
         $body = new MultipartBody([], '123');
-        $this->assertEquals("--123\r\n--123--", (string)$body);
+        $this->assertSame("--123\r\n--123--", (string)$body);
     }
 
     public function testPartsAreWrittenToStreamWithBoundaries(): void
@@ -132,7 +132,7 @@ class MultipartBodyTest extends TestCase
             $this->createMultipartBodyPart(['Oh' => 'hi'], 'mark')
         ];
         $body = new MultipartBody($parts, '123');
-        $this->assertEquals("--123\r\nFoo: bar\r\n\r\nbaz\r\n--123\r\nOh: hi\r\n\r\nmark\r\n--123--", (string)$body);
+        $this->assertSame("--123\r\nFoo: bar\r\n\r\nbaz\r\n--123\r\nOh: hi\r\n\r\nmark\r\n--123--", (string)$body);
     }
 
     public function testReadingAsStreamReturnsAMultiStream(): void
@@ -151,7 +151,7 @@ class MultipartBodyTest extends TestCase
             $this->createMultipartBodyPart(['Foo' => 'bar'], 'baz')
         ];
         $body = new MultipartBody($parts, '123');
-        $this->assertEquals("--123\r\nFoo: bar\r\n\r\nbaz\r\n--123--", (string)$body);
+        $this->assertSame("--123\r\nFoo: bar\r\n\r\nbaz\r\n--123--", (string)$body);
     }
 
     /**

--- a/src/Net/tests/Http/RequestBuilderTest.php
+++ b/src/Net/tests/Http/RequestBuilderTest.php
@@ -58,8 +58,8 @@ class RequestBuilderTest extends TestCase
         $request = $this->requestBuilder->withMethod('GET')
             ->withUri('http://localhost/path')
             ->build();
-        $this->assertEquals('GET /path HTTP/1.1', explode("\r\n", (string)$request)[0]);
-        $this->assertEquals('localhost', $request->getHeaders()->getFirst('Host'));
+        $this->assertSame('GET /path HTTP/1.1', explode("\r\n", (string)$request)[0]);
+        $this->assertSame('localhost', $request->getHeaders()->getFirst('Host'));
     }
 
     public function testWithBodyWithHttpBodyUsesThatBody(): void
@@ -124,7 +124,7 @@ class RequestBuilderTest extends TestCase
             ->withUri('http://localhost')
             ->withProperty('foo', 'bar')
             ->build();
-        $this->assertEquals('bar', $request->getProperties()->get('foo'));
+        $this->assertSame('bar', $request->getProperties()->get('foo'));
     }
 
     public function testWithProtocolVersionSetsProtocolVersion(): void
@@ -133,7 +133,7 @@ class RequestBuilderTest extends TestCase
             ->withUri('http://localhost')
             ->withProtocolVersion('2.0')
             ->build();
-        $this->assertEquals('GET / HTTP/2.0', explode("\r\n", (string)$request)[0]);
+        $this->assertSame('GET / HTTP/2.0', explode("\r\n", (string)$request)[0]);
     }
 
     public function testWithRequestTargetTypeSetsRequestTargetType(): void
@@ -142,7 +142,7 @@ class RequestBuilderTest extends TestCase
             ->withUri('http://localhost')
             ->withRequestTargetType(RequestTargetTypes::ABSOLUTE_FORM)
             ->build();
-        $this->assertEquals('GET http://localhost HTTP/1.1', explode("\r\n", (string)$request)[0]);
+        $this->assertSame('GET http://localhost HTTP/1.1', explode("\r\n", (string)$request)[0]);
     }
 
     public function testWithStringUriSetsRequestUri(): void

--- a/src/Net/tests/Http/RequestFactoryTest.php
+++ b/src/Net/tests/Http/RequestFactoryTest.php
@@ -33,8 +33,8 @@ class RequestFactoryTest extends TestCase
             'PHP_AUTH_PW' => 'pw',
             'HTTP_HOST' => 'foo.com'
         ]);
-        $this->assertEquals('user', $request->getUri()->getUser());
-        $this->assertEquals('pw', $request->getUri()->getPassword());
+        $this->assertSame('user', $request->getUri()->getUser());
+        $this->assertSame('pw', $request->getUri()->getPassword());
     }
 
     public function testBodyIsCreatedFromInputStream(): void
@@ -51,8 +51,8 @@ class RequestFactoryTest extends TestCase
             'HTTP_COOKIE' => '%25',
             'HTTP_HOST' => 'foo.com'
         ]);
-        $this->assertEquals('%25', $request->getHeaders()->getFirst('Foo'));
-        $this->assertEquals('%', $request->getHeaders()->getFirst('Cookie'));
+        $this->assertSame('%25', $request->getHeaders()->getFirst('Foo'));
+        $this->assertSame('%', $request->getHeaders()->getFirst('Cookie'));
     }
 
     public function testClientIPAddressIsSetAsPropertyWhenUsingTrustedProxy(): void
@@ -62,7 +62,7 @@ class RequestFactoryTest extends TestCase
             'REMOTE_ADDR' => '192.168.1.1',
             'HTTP_HOST' => 'foo.com'
         ]);
-        $this->assertEquals('192.168.1.1', $request->getProperties()->get('CLIENT_IP_ADDRESS'));
+        $this->assertSame('192.168.1.1', $request->getProperties()->get('CLIENT_IP_ADDRESS'));
     }
 
     public function clientIPDataProvider(): array
@@ -96,7 +96,7 @@ class RequestFactoryTest extends TestCase
             'HTTP_CLIENT_IP' => '192.168.1.1',
             'HTTP_HOST' => 'foo.com'
         ]);
-        $this->assertEquals('192.168.1.1', $request->getProperties()->get('CLIENT_IP_ADDRESS'));
+        $this->assertSame('192.168.1.1', $request->getProperties()->get('CLIENT_IP_ADDRESS'));
     }
 
     public function testClientPortUsedToDeterminePortWithTrustedProxy(): void
@@ -107,7 +107,7 @@ class RequestFactoryTest extends TestCase
             'HTTP_X_FORWARDED_PORT' => 8080,
             'HTTP_HOST' => 'foo.com'
         ]);
-        $this->assertEquals(8080, $request->getUri()->getPort());
+        $this->assertSame(8080, $request->getUri()->getPort());
     }
 
     public function clientProtoProvider(): array
@@ -142,7 +142,7 @@ class RequestFactoryTest extends TestCase
             'HTTP_X_FORWARDED_PROTO' => 'https',
             'HTTP_HOST' => 'foo.com'
         ]);
-        $this->assertEquals(443, $request->getUri()->getPort());
+        $this->assertSame(443, $request->getUri()->getPort());
     }
 
     public function testCommaInHeaderThatDoesNotPermitMultipleValuesDoesNotSplitHeaderValue(): void
@@ -160,7 +160,7 @@ class RequestFactoryTest extends TestCase
             'HTTP_COOKIE' => 'foo=bar; baz=blah',
             'HTTP_HOST' => 'foo.com'
         ]);
-        $this->assertEquals('foo=bar; baz=blah', $request->getHeaders()->getFirst('Cookie'));
+        $this->assertSame('foo=bar; baz=blah', $request->getHeaders()->getFirst('Cookie'));
     }
 
     public function testExceptionThrownWhenUsingUntrustedProxyHost(): void
@@ -175,13 +175,13 @@ class RequestFactoryTest extends TestCase
         $factory = new RequestFactory(['192.168.2.1']);
         $server = ['REMOTE_ADDR' => '192.168.2.1', 'HTTP_X_FORWARDED_HOST' => 'foo.com, bar.com'];
         $request = $factory->createRequestFromSuperglobals($server);
-        $this->assertEquals('bar.com', $request->getUri()->getHost());
+        $this->assertSame('bar.com', $request->getUri()->getHost());
     }
 
     public function testHostWithPortStripsPortFromHost(): void
     {
         $request = $this->factory->createRequestFromSuperglobals(['HTTP_HOST' => 'foo.com:8080']);
-        $this->assertEquals('foo.com', $request->getUri()->getHost());
+        $this->assertSame('foo.com', $request->getUri()->getHost());
     }
 
     public function httpServerPropertyProvider(): array
@@ -228,7 +228,7 @@ class RequestFactoryTest extends TestCase
             'REQUEST_METHOD' => 'CONNECT',
             'HTTP_HOST' => 'foo.com'
         ]);
-        $this->assertEquals('CONNECT', $request->getMethod());
+        $this->assertSame('CONNECT', $request->getMethod());
     }
 
     public function testInvalidHostCharThrowsException(): void
@@ -245,7 +245,7 @@ class RequestFactoryTest extends TestCase
             'X-HTTP-METHOD-OVERRIDE' => 'PUT',
             'HTTP_HOST' => 'foo.com'
         ]);
-        $this->assertEquals('PUT', $request->getMethod());
+        $this->assertSame('PUT', $request->getMethod());
     }
 
     public function testMultipleHeaderValuesAreAppended(): void
@@ -263,7 +263,7 @@ class RequestFactoryTest extends TestCase
             'REQUEST_URI' => '/foo/bar?baz=blah',
             'HTTP_HOST' => 'foo.com'
         ]);
-        $this->assertEquals('/foo/bar', $request->getUri()->getPath());
+        $this->assertSame('/foo/bar', $request->getUri()->getPath());
     }
 
     public function testPortHeaderSetsPortOnUri(): void
@@ -272,7 +272,7 @@ class RequestFactoryTest extends TestCase
             'SERVER_PORT' => 8080,
             'HTTP_HOST' => 'foo.com'
         ]);
-        $this->assertEquals(8080, $request->getUri()->getPort());
+        $this->assertSame(8080, $request->getUri()->getPort());
     }
 
     public function testQueryStringServerPropertyIsUsedBeforeRequestUriQueryString(): void
@@ -282,7 +282,7 @@ class RequestFactoryTest extends TestCase
             'REQUEST_URI' => '/baz?blah=dave',
             'HTTP_HOST' => 'foo.com'
         ]);
-        $this->assertEquals('foo=bar', $request->getUri()->getQueryString());
+        $this->assertSame('foo=bar', $request->getUri()->getQueryString());
     }
 
     public function testQuotedCommaInHeaderRemainsIntact(): void
@@ -300,7 +300,7 @@ class RequestFactoryTest extends TestCase
             'REMOTE_ADDR' => '192.168.2.1',
             'HTTP_HOST' => 'foo.com'
         ]);
-        $this->assertEquals('192.168.2.1', $request->getProperties()->get('CLIENT_IP_ADDRESS'));
+        $this->assertSame('192.168.2.1', $request->getProperties()->get('CLIENT_IP_ADDRESS'));
     }
 
     public function testRequestUriQueryStringIsUsedIfQueryStringServerPropertyDoesNotExist(): void
@@ -309,7 +309,7 @@ class RequestFactoryTest extends TestCase
             'REQUEST_URI' => '/foo?bar=baz',
             'HTTP_HOST' => 'foo.com'
         ]);
-        $this->assertEquals('bar=baz', $request->getUri()->getQueryString());
+        $this->assertSame('bar=baz', $request->getUri()->getQueryString());
     }
 
     public function testSpecialCaseHeadersAreAddedToRequestHeaders(): void

--- a/src/Net/tests/Http/RequestTest.php
+++ b/src/Net/tests/Http/RequestTest.php
@@ -71,7 +71,7 @@ class RequestTest extends TestCase
 
     public function testGettingProtocolVersion(): void
     {
-        $this->assertEquals('2.0', $this->request->getProtocolVersion());
+        $this->assertSame('2.0', $this->request->getProtocolVersion());
     }
 
     public function testGettingUri(): void
@@ -84,7 +84,7 @@ class RequestTest extends TestCase
         $headers = new Headers();
         $headers->add('Host', 'foo.com');
         $request = new Request('GET', new Uri('https://bar.com'), $headers);
-        $this->assertEquals('foo.com', $request->getHeaders()->getFirst('Host'));
+        $this->assertSame('foo.com', $request->getHeaders()->getFirst('Host'));
     }
 
     public function testInvalidRequestTargetTypeThrowsException(): void
@@ -99,7 +99,7 @@ class RequestTest extends TestCase
         $request = new Request('GET', new Uri('https://example.com'));
         $request->getHeaders()->add('Foo', 'bar');
         $request->getHeaders()->add('Foo', 'baz', true);
-        $this->assertEquals("GET / HTTP/1.1\r\nHost: example.com\r\nFoo: bar, baz\r\n\r\n", (string)$request);
+        $this->assertSame("GET / HTTP/1.1\r\nHost: example.com\r\nFoo: bar, baz\r\n\r\n", (string)$request);
     }
 
     public function testRequestTargetTypeAbsoluteFormIncludesEntireUri(): void
@@ -113,7 +113,7 @@ class RequestTest extends TestCase
             '1.1',
             RequestTargetTypes::ABSOLUTE_FORM
         );
-        $this->assertEquals(
+        $this->assertSame(
             "GET https://example.com:4343/foo?bar HTTP/1.1\r\nHost: example.com:4343\r\n\r\n",
             (string)$request
         );
@@ -130,7 +130,7 @@ class RequestTest extends TestCase
             '1.1',
             RequestTargetTypes::ASTERISK_FORM
         );
-        $this->assertEquals("GET * HTTP/1.1\r\nHost: example.com\r\n\r\n", (string)$request);
+        $this->assertSame("GET * HTTP/1.1\r\nHost: example.com\r\n\r\n", (string)$request);
     }
 
     public function testRequestTargetTypeAuthorityFormIncludeUriAuthorityWithoutUserInfo(): void
@@ -144,7 +144,7 @@ class RequestTest extends TestCase
             '1.1',
             RequestTargetTypes::AUTHORITY_FORM
         );
-        $this->assertEquals("GET www.example.com:4343 HTTP/1.1\r\n\r\n", (string)$request);
+        $this->assertSame("GET www.example.com:4343 HTTP/1.1\r\n\r\n", (string)$request);
     }
 
     public function requestTargetQueryStringProvider(): array
@@ -169,20 +169,20 @@ class RequestTest extends TestCase
     {
         $request = new Request('GET', new Uri('https://example.com'), new Headers(), new StringBody('foo'));
         $request->getHeaders()->add('Foo', 'bar');
-        $this->assertEquals("GET / HTTP/1.1\r\nHost: example.com\r\nFoo: bar\r\n\r\nfoo", (string)$request);
+        $this->assertSame("GET / HTTP/1.1\r\nHost: example.com\r\nFoo: bar\r\n\r\nfoo", (string)$request);
     }
 
     public function testRequestWithHeadersButNoBodyEndsWithBlankLine(): void
     {
         $request = new Request('GET', new Uri('https://example.com'));
         $request->getHeaders()->add('Foo', 'bar');
-        $this->assertEquals("GET / HTTP/1.1\r\nHost: example.com\r\nFoo: bar\r\n\r\n", (string)$request);
+        $this->assertSame("GET / HTTP/1.1\r\nHost: example.com\r\nFoo: bar\r\n\r\n", (string)$request);
     }
 
     public function testRequestWithNoHeadersOrBodyEndsWithBlankLine(): void
     {
         $request = new Request('GET', new Uri('https://example.com'));
-        $this->assertEquals("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n", (string)$request);
+        $this->assertSame("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n", (string)$request);
     }
 
     public function testSettingBody(): void

--- a/src/Net/tests/Http/ResponseTest.php
+++ b/src/Net/tests/Http/ResponseTest.php
@@ -42,9 +42,9 @@ class ResponseTest extends TestCase
     public function testGettingAndSettingStatusCode(): void
     {
         $response = new Response(201);
-        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertSame(201, $response->getStatusCode());
         $response->setStatusCode(202);
-        $this->assertEquals(202, $response->getStatusCode());
+        $this->assertSame(202, $response->getStatusCode());
     }
 
     public function testGettingHeaders(): void
@@ -57,7 +57,7 @@ class ResponseTest extends TestCase
     public function testGettingProtocolVersion(): void
     {
         $response = new Response(200, null, null, '2.0');
-        $this->assertEquals('2.0', $response->getProtocolVersion());
+        $this->assertSame('2.0', $response->getProtocolVersion());
     }
 
     public function testMultipleHeaderValuesAreConcatenatedWithCommas(): void
@@ -65,33 +65,33 @@ class ResponseTest extends TestCase
         $response = new Response();
         $response->getHeaders()->add('Foo', 'bar');
         $response->getHeaders()->add('Foo', 'baz', true);
-        $this->assertEquals("HTTP/1.1 200 OK\r\nFoo: bar, baz\r\n\r\n", (string)$response);
+        $this->assertSame("HTTP/1.1 200 OK\r\nFoo: bar, baz\r\n\r\n", (string)$response);
     }
 
     public function testReasonPhraseIsIncludedOnlyIfDefined(): void
     {
         $response = new Response();
         $response->setStatusCode(200, 'OK');
-        $this->assertEquals("HTTP/1.1 200 OK\r\n\r\n", (string)$response);
+        $this->assertSame("HTTP/1.1 200 OK\r\n\r\n", (string)$response);
     }
 
     public function testResponseWithHeadersAndBodyEndsWithBody(): void
     {
         $response = new Response(200, new Headers(), new StringBody('foo'));
         $response->getHeaders()->add('Foo', 'bar');
-        $this->assertEquals("HTTP/1.1 200 OK\r\nFoo: bar\r\n\r\nfoo", (string)$response);
+        $this->assertSame("HTTP/1.1 200 OK\r\nFoo: bar\r\n\r\nfoo", (string)$response);
     }
 
     public function testResponseWithHeadersButNoBodyEndsWithBlankLine(): void
     {
         $response = new Response();
         $response->getHeaders()->add('Foo', 'bar');
-        $this->assertEquals("HTTP/1.1 200 OK\r\nFoo: bar\r\n\r\n", (string)$response);
+        $this->assertSame("HTTP/1.1 200 OK\r\nFoo: bar\r\n\r\n", (string)$response);
     }
 
     public function testResponseWithNoHeadersOrBodyEndsWithBlankLine(): void
     {
         $response = new Response();
-        $this->assertEquals("HTTP/1.1 200 OK\r\n\r\n", (string)$response);
+        $this->assertSame("HTTP/1.1 200 OK\r\n\r\n", (string)$response);
     }
 }

--- a/src/Net/tests/Http/StreamBodyTest.php
+++ b/src/Net/tests/Http/StreamBodyTest.php
@@ -27,7 +27,7 @@ class StreamBodyTest extends TestCase
             ->method('__toString')
             ->willReturn('foo');
         $body = new StreamBody($stream);
-        $this->assertEquals('foo', (string)$body);
+        $this->assertSame('foo', (string)$body);
     }
 
     public function testGettingLengthReturnsUnderlyingStreamLength(): void
@@ -43,7 +43,7 @@ class StreamBodyTest extends TestCase
             ->method('getLength')
             ->willReturn(1);
         $definedLengthBody = new StreamBody($definedLengthStream);
-        $this->assertEquals(1, $definedLengthBody->getLength());
+        $this->assertSame(1, $definedLengthBody->getLength());
     }
 
     public function testReadingAsStreamReturnsUnderlyingStream(): void
@@ -65,7 +65,7 @@ class StreamBodyTest extends TestCase
             ->method('__toString')
             ->willReturn('foo');
         $body = new StreamBody($stream);
-        $this->assertEquals('foo', $body->readAsString());
+        $this->assertSame('foo', $body->readAsString());
     }
 
     /**

--- a/src/Net/tests/Http/StringBodyTest.php
+++ b/src/Net/tests/Http/StringBodyTest.php
@@ -22,13 +22,13 @@ class StringBodyTest extends TestCase
     public function testCastingToStringReturnsContents(): void
     {
         $body = new StringBody('foo');
-        $this->assertEquals('foo', (string)$body);
+        $this->assertSame('foo', (string)$body);
     }
 
     public function testGettingLengthReturnsStringLength(): void
     {
         $body = new StringBody('foo');
-        $this->assertEquals(3, $body->getLength());
+        $this->assertSame(3, $body->getLength());
     }
 
     public function testReadingAsStreamReturnsSameStreamInstanceEveryTime(): void
@@ -42,13 +42,13 @@ class StringBodyTest extends TestCase
     {
         $body = new StringBody('foo');
         $stream = $body->readAsStream();
-        $this->assertEquals('foo', $stream->readToEnd());
+        $this->assertSame('foo', $stream->readToEnd());
     }
 
     public function testReadingAsStringReturnsContents(): void
     {
         $body = new StringBody('foo');
-        $this->assertEquals('foo', $body->readAsString());
+        $this->assertSame('foo', $body->readAsString());
     }
 
     public function testWritingToStreamActuallyWritesContentsToStream(): void

--- a/src/Net/tests/UriTest.php
+++ b/src/Net/tests/UriTest.php
@@ -28,8 +28,8 @@ class UriTest extends TestCase
     public function testAbsolutePathUriReturnsPathAndQueryString(): void
     {
         $uri = new Uri('/foo?bar=baz');
-        $this->assertEquals('/foo', $uri->getPath());
-        $this->assertEquals('bar=baz', $uri->getQueryString());
+        $this->assertSame('/foo', $uri->getPath());
+        $this->assertSame('bar=baz', $uri->getQueryString());
     }
 
     public function testDoubleSlashPathWithoutAuthorityThrowsException(): void
@@ -42,7 +42,7 @@ class UriTest extends TestCase
     public function testFragmentReservedCharsAreEncoded(): void
     {
         $uri = new Uri('#dave=%young');
-        $this->assertEquals('dave=%25young', $uri->getFragment());
+        $this->assertSame('dave=%25young', $uri->getFragment());
     }
 
     public function authorityWithNoUserPasswordProvider(): array
@@ -83,53 +83,53 @@ class UriTest extends TestCase
     {
         $uriWithUserAndPassword = new Uri($uri);
         $this->assertEquals($expectedUri, $uriWithUserAndPassword->getAuthority());
-        $this->assertEquals('host', $uriWithUserAndPassword->getAuthority(false));
+        $this->assertSame('host', $uriWithUserAndPassword->getAuthority(false));
     }
 
     public function testGettingFragment(): void
     {
-        $this->assertEquals('fragment', $this->uri->getFragment());
+        $this->assertSame('fragment', $this->uri->getFragment());
     }
 
     public function testGettingHost(): void
     {
-        $this->assertEquals('host', $this->uri->getHost());
+        $this->assertSame('host', $this->uri->getHost());
     }
 
     public function testGettingPassword(): void
     {
-        $this->assertEquals('password', $this->uri->getPassword());
+        $this->assertSame('password', $this->uri->getPassword());
     }
 
     public function testGettingPath(): void
     {
-        $this->assertEquals('/path', $this->uri->getPath());
+        $this->assertSame('/path', $this->uri->getPath());
     }
 
     public function testGettingPort(): void
     {
-        $this->assertEquals(80, $this->uri->getPort());
+        $this->assertSame(80, $this->uri->getPort());
     }
 
     public function testGettingQueryString(): void
     {
-        $this->assertEquals('query', $this->uri->getQueryString());
+        $this->assertSame('query', $this->uri->getQueryString());
     }
 
     public function testGettingScheme(): void
     {
-        $this->assertEquals('http', $this->uri->getScheme());
+        $this->assertSame('http', $this->uri->getScheme());
     }
 
     public function testGettingUser(): void
     {
-        $this->assertEquals('user', $this->uri->getUser());
+        $this->assertSame('user', $this->uri->getUser());
     }
 
     public function testHostIsLowerCased(): void
     {
         $uri = new Uri('http://FOO.COM');
-        $this->assertEquals('foo.com', $uri->getHost());
+        $this->assertSame('foo.com', $uri->getHost());
     }
 
     public function testInvalidSchemeThrowsException(): void
@@ -167,31 +167,31 @@ class UriTest extends TestCase
     public function testPathReservedCharsAreEncoded(): void
     {
         $uri = new Uri('/%path');
-        $this->assertEquals('/%25path', $uri->getPath());
+        $this->assertSame('/%25path', $uri->getPath());
     }
 
     public function testQueryStringReservedCharsAreEncoded(): void
     {
         $uri = new Uri('?dave=%young');
-        $this->assertEquals('dave=%25young', $uri->getQueryString());
+        $this->assertSame('dave=%25young', $uri->getQueryString());
     }
 
     public function testSchemeIsLowerCased(): void
     {
         $uri = new Uri('HTTP://foo.com');
-        $this->assertEquals('http', $uri->getScheme());
+        $this->assertSame('http', $uri->getScheme());
     }
 
     public function testToStringWithAllPartsIsCreatedCorrectly(): void
     {
         $uri = new Uri('http://user:password@host:8080/path?query#fragment');
-        $this->assertEquals('http://user:password@host:8080/path?query#fragment', (string)$uri);
+        $this->assertSame('http://user:password@host:8080/path?query#fragment', (string)$uri);
     }
 
     public function testToStringWithFragmentStringIncludesFragment(): void
     {
         $uri = new Uri('http://host#fragment');
-        $this->assertEquals('http://host#fragment', (string)$uri);
+        $this->assertSame('http://host#fragment', (string)$uri);
     }
 
     public function httpUriProvider(): array
@@ -214,30 +214,30 @@ class UriTest extends TestCase
     public function testToStringWithNoSchemedDoesNotIncludeThatValue(): void
     {
         $uri = new Uri('host');
-        $this->assertEquals('host', (string)$uri);
+        $this->assertSame('host', (string)$uri);
     }
 
     public function testToStringWithNoUserPasswordDoesNotIncludeThoseValues(): void
     {
         $uri = new Uri('http://host');
-        $this->assertEquals('http://host', (string)$uri);
+        $this->assertSame('http://host', (string)$uri);
     }
 
     public function testToStringWithQueryStringIncludesQueryString(): void
     {
         $uri = new Uri('http://host?query');
-        $this->assertEquals('http://host?query', (string)$uri);
+        $this->assertSame('http://host?query', (string)$uri);
     }
 
     public function testToStringWithUserPasswordIncludesThoseValues(): void
     {
         $uri = new Uri('http://user:password@host');
-        $this->assertEquals('http://user:password@host', (string)$uri);
+        $this->assertSame('http://user:password@host', (string)$uri);
     }
 
     public function testToStringWithUserButNoPasswordOnlyIncludesUser(): void
     {
         $uri = new Uri('http://user@host');
-        $this->assertEquals('http://user@host', (string)$uri);
+        $this->assertSame('http://user@host', (string)$uri);
     }
 }

--- a/src/PsrAdapters/tests/Psr7/Psr7FactoryTest.php
+++ b/src/PsrAdapters/tests/Psr7/Psr7FactoryTest.php
@@ -53,7 +53,7 @@ class Psr7FactoryTest extends TestCase
         $psr7Body = Psr7Stream::create('foo');
         $psr7Request = new Psr7Request('GET', 'https://example.com', [], $psr7Body);
         $aphiriaRequest = $this->psr7Factory->createAphiriaRequest($psr7Request);
-        $this->assertEquals('foo', $aphiriaRequest->getBody()->readAsString());
+        $this->assertSame('foo', $aphiriaRequest->getBody()->readAsString());
     }
 
     public function testCreateAphiriaRequestSetsParsedBody(): void
@@ -79,15 +79,15 @@ class Psr7FactoryTest extends TestCase
             ->withAttribute('foo', 'bar')
             ->withAttribute('baz', 'blah');
         $aphiriaRequest = $this->psr7Factory->createAphiriaRequest($psr7Request);
-        $this->assertEquals('bar', $aphiriaRequest->getProperties()->get('foo'));
-        $this->assertEquals('blah', $aphiriaRequest->getProperties()->get('baz'));
+        $this->assertSame('bar', $aphiriaRequest->getProperties()->get('foo'));
+        $this->assertSame('blah', $aphiriaRequest->getProperties()->get('baz'));
     }
 
     public function testCreateAphiriaRequestSetsSameUri(): void
     {
         $psr7Request = new Psr7Request('GET', 'https://dave:abc123@example.com?foo=bar#baz=blah');
         $aphiriaRequest = $this->psr7Factory->createAphiriaRequest($psr7Request);
-        $this->assertEquals('https://dave:abc123@example.com?foo=bar#baz=blah', (string)$aphiriaRequest->getUri());
+        $this->assertSame('https://dave:abc123@example.com?foo=bar#baz=blah', (string)$aphiriaRequest->getUri());
     }
 
     public function testCreateAphiriaRequestWithFileUploadsCreatesMultipartRequest(): void
@@ -105,21 +105,21 @@ class Psr7FactoryTest extends TestCase
         $aphiriaMultipartBody = (new RequestParser())->readAsMultipart($aphiriaRequest);
         $aphiriaMultipartBodyParts = $aphiriaMultipartBody->getParts();
         $this->assertCount(3, $aphiriaMultipartBodyParts);
-        $this->assertEquals('foo', $aphiriaMultipartBodyParts[0]->getBody()->readAsString());
-        $this->assertEquals('image/png', $aphiriaMultipartBodyParts[0]->getHeaders()->getFirst('Content-Type'));
-        $this->assertEquals(
+        $this->assertSame('foo', $aphiriaMultipartBodyParts[0]->getBody()->readAsString());
+        $this->assertSame('image/png', $aphiriaMultipartBodyParts[0]->getHeaders()->getFirst('Content-Type'));
+        $this->assertSame(
             'name=foo; filename=foo.png',
             $aphiriaMultipartBodyParts[0]->getHeaders()->getFirst('Content-Disposition')
         );
-        $this->assertEquals('bar', $aphiriaMultipartBodyParts[1]->getBody()->readAsString());
+        $this->assertSame('bar', $aphiriaMultipartBodyParts[1]->getBody()->readAsString());
         $this->assertFalse($aphiriaMultipartBodyParts[1]->getHeaders()->containsKey('Content-Type'));
-        $this->assertEquals(
+        $this->assertSame(
             'name=bar; filename=bar.png',
             $aphiriaMultipartBodyParts[1]->getHeaders()->getFirst('Content-Disposition')
         );
-        $this->assertEquals('baz', $aphiriaMultipartBodyParts[2]->getBody()->readAsString());
+        $this->assertSame('baz', $aphiriaMultipartBodyParts[2]->getBody()->readAsString());
         $this->assertFalse($aphiriaMultipartBodyParts[2]->getHeaders()->containsKey('Content-Type'));
-        $this->assertEquals(
+        $this->assertSame(
             'name=baz',
             $aphiriaMultipartBodyParts[2]->getHeaders()->getFirst('Content-Disposition')
         );
@@ -130,7 +130,7 @@ class Psr7FactoryTest extends TestCase
         $psr7Body = Psr7Stream::create('foo');
         $psr7Response = new Psr7Response(200, [], $psr7Body);
         $aphiriaResponse = $this->psr7Factory->createAphiriaResponse($psr7Response);
-        $this->assertEquals('foo', $aphiriaResponse->getBody()->readAsString());
+        $this->assertSame('foo', $aphiriaResponse->getBody()->readAsString());
     }
 
     public function testCreateAphiriaResponseSetsSameHeaders(): void
@@ -145,27 +145,27 @@ class Psr7FactoryTest extends TestCase
     {
         $psr7Response = new Psr7Response(200);
         $aphiriaResponse = $this->psr7Factory->createAphiriaResponse($psr7Response);
-        $this->assertEquals(1.1, $aphiriaResponse->getProtocolVersion());
+        $this->assertSame('1.1', $aphiriaResponse->getProtocolVersion());
     }
 
     public function testCreateAphiriaResponseSetsSameReasonPhrase(): void
     {
         $psr7Response = new Psr7Response(200);
         $aphiriaResponse = $this->psr7Factory->createAphiriaResponse($psr7Response);
-        $this->assertEquals('OK', $aphiriaResponse->getReasonPhrase());
+        $this->assertSame('OK', $aphiriaResponse->getReasonPhrase());
     }
 
     public function testCreateAphiriaResponseSetsSameStatusCode(): void
     {
         $psr7Response = new Psr7Response(200);
         $aphiriaResponse = $this->psr7Factory->createAphiriaResponse($psr7Response);
-        $this->assertEquals(200, $aphiriaResponse->getStatusCode());
+        $this->assertSame(200, $aphiriaResponse->getStatusCode());
     }
 
     public function testCreateAphiriaStreamCreatesStreamWithSameContents(): void
     {
         $psr7Stream = Psr7Stream::create('foo');
-        $this->assertEquals('foo', (string)$this->psr7Factory->createAphiriaStream($psr7Stream));
+        $this->assertSame('foo', (string)$this->psr7Factory->createAphiriaStream($psr7Stream));
     }
 
     public function testCreateAphiriaUriCreatesUriWithAllProperties(): void
@@ -173,7 +173,7 @@ class Psr7FactoryTest extends TestCase
         $expectedUri = 'https://dave:abc123@example.com/path?foo=bar#baz=blah';
         $psr7Uri = new Psr7Uri($expectedUri);
         $aphiriaUri = $this->psr7Factory->createAphiriaUri($psr7Uri);
-        $this->assertEquals($expectedUri, (string)$aphiriaUri);
+        $this->assertSame($expectedUri, (string)$aphiriaUri);
     }
 
     public function testCreatePsr7RequestForMultipartRequestSetsSameUploadedFiles(): void
@@ -203,14 +203,14 @@ class Psr7FactoryTest extends TestCase
         /** @var UploadedFileInterface[] $psr7UploadedFiles */
         $psr7UploadedFiles = $psr7Request->getUploadedFiles();
         $this->assertCount(2, $psr7UploadedFiles);
-        $this->assertEquals('file1contents', (string)$psr7UploadedFiles['file1']->getStream());
-        $this->assertEquals('foo.png', $psr7UploadedFiles['file1']->getClientFilename());
-        $this->assertEquals('image/png', $psr7UploadedFiles['file1']->getClientMediaType());
-        $this->assertEquals(\UPLOAD_ERR_OK, $psr7UploadedFiles['file1']->getError());
-        $this->assertEquals('file2contents', (string)$psr7UploadedFiles['file2']->getStream());
-        $this->assertEquals('bar.png', $psr7UploadedFiles['file2']->getClientFilename());
-        $this->assertEquals('image/png', $psr7UploadedFiles['file2']->getClientMediaType());
-        $this->assertEquals(\UPLOAD_ERR_OK, $psr7UploadedFiles['file2']->getError());
+        $this->assertSame('file1contents', (string)$psr7UploadedFiles['file1']->getStream());
+        $this->assertSame('foo.png', $psr7UploadedFiles['file1']->getClientFilename());
+        $this->assertSame('image/png', $psr7UploadedFiles['file1']->getClientMediaType());
+        $this->assertSame(\UPLOAD_ERR_OK, $psr7UploadedFiles['file1']->getError());
+        $this->assertSame('file2contents', (string)$psr7UploadedFiles['file2']->getStream());
+        $this->assertSame('bar.png', $psr7UploadedFiles['file2']->getClientFilename());
+        $this->assertSame('image/png', $psr7UploadedFiles['file2']->getClientMediaType());
+        $this->assertSame(\UPLOAD_ERR_OK, $psr7UploadedFiles['file2']->getError());
     }
 
     public function testCreatePsr7RequestForMultipartRequestWithoutNameDefaultsToUsingIndex(): void
@@ -233,10 +233,10 @@ class Psr7FactoryTest extends TestCase
         /** @var UploadedFileInterface[] $psr7UploadedFiles */
         $psr7UploadedFiles = $psr7Request->getUploadedFiles();
         $this->assertCount(1, $psr7UploadedFiles);
-        $this->assertEquals('filecontents', (string)$psr7UploadedFiles['0']->getStream());
-        $this->assertEquals('foo.png', $psr7UploadedFiles['0']->getClientFilename());
-        $this->assertEquals('image/png', $psr7UploadedFiles['0']->getClientMediaType());
-        $this->assertEquals(\UPLOAD_ERR_OK, $psr7UploadedFiles['0']->getError());
+        $this->assertSame('filecontents', (string)$psr7UploadedFiles['0']->getStream());
+        $this->assertSame('foo.png', $psr7UploadedFiles['0']->getClientFilename());
+        $this->assertSame('image/png', $psr7UploadedFiles['0']->getClientMediaType());
+        $this->assertSame(\UPLOAD_ERR_OK, $psr7UploadedFiles['0']->getError());
     }
 
     public function testCreatePsr7RequestSetsParsedBodyIfOneIsPresent(): void
@@ -252,7 +252,7 @@ class Psr7FactoryTest extends TestCase
         $aphiriaBody = new StringBody('foo');
         $aphiriaRequest = new Request('GET', new Uri('https://example.com'), null, $aphiriaBody);
         $psr7Request = $this->psr7Factory->createPsr7Request($aphiriaRequest);
-        $this->assertEquals('foo', (string)$psr7Request->getBody());
+        $this->assertSame('foo', (string)$psr7Request->getBody());
     }
 
     public function testCreatePsr7RequestSetsSameCookies(): void
@@ -280,7 +280,7 @@ class Psr7FactoryTest extends TestCase
     {
         $aphiriaRequest = new Request('GET', new Uri('https://example.com'));
         $psr7Request = $this->psr7Factory->createPsr7Request($aphiriaRequest);
-        $this->assertEquals('GET', $psr7Request->getMethod());
+        $this->assertSame('GET', $psr7Request->getMethod());
     }
 
     public function testCreatePsr7RequestSetsSameProperties(): void
@@ -303,7 +303,7 @@ class Psr7FactoryTest extends TestCase
     {
         $aphiriaRequest = new Request('GET', new Uri('https://example.com'));
         $psr7Request = $this->psr7Factory->createPsr7Request($aphiriaRequest);
-        $this->assertEquals('https://example.com', (string)$psr7Request->getUri());
+        $this->assertSame('https://example.com', (string)$psr7Request->getUri());
     }
 
     public function testCreatePsr7ResponseSetsSameBody(): void
@@ -311,7 +311,7 @@ class Psr7FactoryTest extends TestCase
         $aphiriaBody = new StringBody('foo');
         $aphiriaResponse = new Response(200, null, $aphiriaBody);
         $psr7Response = $this->psr7Factory->createPsr7Response($aphiriaResponse);
-        $this->assertEquals('foo', (string)$psr7Response->getBody());
+        $this->assertSame('foo', (string)$psr7Response->getBody());
     }
 
     public function testCreatePsr7ResponseSetsSameHeaders(): void
@@ -329,21 +329,21 @@ class Psr7FactoryTest extends TestCase
     {
         $aphiriaResponse = new Response(200);
         $psr7Response = $this->psr7Factory->createPsr7Response($aphiriaResponse);
-        $this->assertEquals(1.1, $psr7Response->getProtocolVersion());
+        $this->assertSame('1.1', $psr7Response->getProtocolVersion());
     }
 
     public function testCreatePsr7ResponseSetsSameReasonPhrase(): void
     {
         $aphiriaResponse = new Response(200);
         $psr7Response = $this->psr7Factory->createPsr7Response($aphiriaResponse);
-        $this->assertEquals('OK', $psr7Response->getReasonPhrase());
+        $this->assertSame('OK', $psr7Response->getReasonPhrase());
     }
 
     public function testCreatePsr7ResponseSetsSameStatusCode(): void
     {
         $aphiriaResponse = new Response(200);
         $psr7Response = $this->psr7Factory->createPsr7Response($aphiriaResponse);
-        $this->assertEquals(200, $psr7Response->getStatusCode());
+        $this->assertSame(200, $psr7Response->getStatusCode());
     }
 
     public function testCreatePsr7StreamCreatesWorkingStream(): void
@@ -352,8 +352,8 @@ class Psr7FactoryTest extends TestCase
         $aphiriaStream->write('foo');
         $psr7Stream = $this->psr7Factory->createPsr7Stream($aphiriaStream);
         $psr7Stream->rewind();
-        $this->assertEquals(3, $psr7Stream->getSize());
-        $this->assertEquals('foo', $psr7Stream->getContents());
+        $this->assertSame(3, $psr7Stream->getSize());
+        $this->assertSame('foo', $psr7Stream->getContents());
     }
 
     public function testCreatePsr7UploadedFilesForMultipartRequestCreatesUploadedFiles(): void
@@ -381,14 +381,14 @@ class Psr7FactoryTest extends TestCase
         );
         $psr7UploadedFiles = $this->psr7Factory->createPsr7UploadedFiles($aphiriaRequest);
         $this->assertCount(2, $psr7UploadedFiles);
-        $this->assertEquals('file1contents', (string)$psr7UploadedFiles['file1']->getStream());
-        $this->assertEquals('foo.png', $psr7UploadedFiles['file1']->getClientFilename());
-        $this->assertEquals('image/png', $psr7UploadedFiles['file1']->getClientMediaType());
-        $this->assertEquals(\UPLOAD_ERR_OK, $psr7UploadedFiles['file1']->getError());
-        $this->assertEquals('file2contents', (string)$psr7UploadedFiles['file2']->getStream());
-        $this->assertEquals('bar.png', $psr7UploadedFiles['file2']->getClientFilename());
-        $this->assertEquals('image/png', $psr7UploadedFiles['file2']->getClientMediaType());
-        $this->assertEquals(\UPLOAD_ERR_OK, $psr7UploadedFiles['file2']->getError());
+        $this->assertSame('file1contents', (string)$psr7UploadedFiles['file1']->getStream());
+        $this->assertSame('foo.png', $psr7UploadedFiles['file1']->getClientFilename());
+        $this->assertSame('image/png', $psr7UploadedFiles['file1']->getClientMediaType());
+        $this->assertSame(\UPLOAD_ERR_OK, $psr7UploadedFiles['file1']->getError());
+        $this->assertSame('file2contents', (string)$psr7UploadedFiles['file2']->getStream());
+        $this->assertSame('bar.png', $psr7UploadedFiles['file2']->getClientFilename());
+        $this->assertSame('image/png', $psr7UploadedFiles['file2']->getClientMediaType());
+        $this->assertSame(\UPLOAD_ERR_OK, $psr7UploadedFiles['file2']->getError());
     }
 
     public function testCreatePsr7UploadedFilesForMultipartRequestWithPartThatHasEmptyBodyGetsSkipped(): void
@@ -442,6 +442,6 @@ class Psr7FactoryTest extends TestCase
         $expectedUri = 'https://dave:abc123@example.com/path?foo=bar#baz=blah';
         $aphiriaUri = new Uri($expectedUri);
         $psr7Uri = $this->psr7Factory->createPsr7Uri($aphiriaUri);
-        $this->assertEquals($expectedUri, (string)$psr7Uri);
+        $this->assertSame($expectedUri, (string)$psr7Uri);
     }
 }

--- a/src/Reflection/tests/TypeResolverTest.php
+++ b/src/Reflection/tests/TypeResolverTest.php
@@ -32,12 +32,12 @@ class TypeResolverTest extends TestCase
 
     public function testResolvingEmptyArrayReturnsArrayType(): void
     {
-        $this->assertEquals('array', TypeResolver::resolveType([]));
+        $this->assertSame('array', TypeResolver::resolveType([]));
     }
 
     public function testResolvingNonEmptyArrayReturnsTypeOfFirstValue(): void
     {
-        $this->assertEquals('string[]', TypeResolver::resolveType(['foo', 'bar']));
+        $this->assertSame('string[]', TypeResolver::resolveType(['foo', 'bar']));
     }
 
     public function testResolvingTypeForObjectUsesObjectsClassName(): void
@@ -47,10 +47,10 @@ class TypeResolverTest extends TestCase
 
     public function testResolvingTypeForScalarUsesScalarType(): void
     {
-        $this->assertEquals('boolean', TypeResolver::resolveType(true));
-        $this->assertEquals('integer', TypeResolver::resolveType(1));
-        $this->assertEquals('double', TypeResolver::resolveType(1.5));
-        $this->assertEquals('string', TypeResolver::resolveType('foo'));
+        $this->assertSame('boolean', TypeResolver::resolveType(true));
+        $this->assertSame('integer', TypeResolver::resolveType(1));
+        $this->assertSame('double', TypeResolver::resolveType(1.5));
+        $this->assertSame('string', TypeResolver::resolveType('foo'));
     }
 
     public function testTypeIsArrayReturnsTrueOnlyForArraysOfTypes(): void

--- a/src/Router/tests/Annotations/AnnotationRouteRegistrantTest.php
+++ b/src/Router/tests/Annotations/AnnotationRouteRegistrantTest.php
@@ -63,8 +63,8 @@ class AnnotationRouteRegistrantTest extends TestCase
         $routeArr = $routes->getAll();
         $this->assertCount(1, $routeArr);
         $route = $routeArr[0];
-        $this->assertEquals('/foo', $route->uriTemplate->pathTemplate);
-        $this->assertEquals('example.com', $route->uriTemplate->hostTemplate);
+        $this->assertSame('/foo', $route->uriTemplate->pathTemplate);
+        $this->assertSame('example.com', $route->uriTemplate->hostTemplate);
         $this->assertTrue($route->uriTemplate->isHttpsOnly);
         $this->assertEquals(['foo' => 'bar'], $route->attributes);
         $this->assertCount(2, $route->constraints);
@@ -94,7 +94,7 @@ class AnnotationRouteRegistrantTest extends TestCase
         $this->assertCount(1, $routeArr);
         $route = $routeArr[0];
         $this->assertCount(1, $route->middlewareBindings);
-        $this->assertEquals(DummyMiddleware::class, $route->middlewareBindings[0]->className);
+        $this->assertSame(DummyMiddleware::class, $route->middlewareBindings[0]->className);
         $this->assertEquals(['foo' => 'bar'], $route->middlewareBindings[0]->attributes);
     }
 
@@ -123,9 +123,9 @@ class AnnotationRouteRegistrantTest extends TestCase
         $this->assertCount(1, $routeArr);
         $route = $routeArr[0];
         $this->assertCount(2, $route->middlewareBindings);
-        $this->assertEquals(DummyMiddleware::class, $route->middlewareBindings[0]->className);
+        $this->assertSame(DummyMiddleware::class, $route->middlewareBindings[0]->className);
         $this->assertEquals(['foo' => 'bar'], $route->middlewareBindings[0]->attributes);
-        $this->assertEquals(DummyMiddleware::class, $route->middlewareBindings[1]->className);
+        $this->assertSame(DummyMiddleware::class, $route->middlewareBindings[1]->className);
         $this->assertEquals(['baz' => 'blah'], $route->middlewareBindings[1]->attributes);
     }
 
@@ -152,9 +152,9 @@ class AnnotationRouteRegistrantTest extends TestCase
         $this->assertCount(1, $routeArr);
         $route = $routeArr[0];
         $this->assertCount(2, $route->middlewareBindings);
-        $this->assertEquals(DummyMiddleware::class, $route->middlewareBindings[0]->className);
+        $this->assertSame(DummyMiddleware::class, $route->middlewareBindings[0]->className);
         $this->assertEquals(['foo' => 'bar'], $route->middlewareBindings[0]->attributes);
-        $this->assertEquals(DummyMiddleware::class, $route->middlewareBindings[1]->className);
+        $this->assertSame(DummyMiddleware::class, $route->middlewareBindings[1]->className);
         $this->assertEquals(['baz' => 'blah'], $route->middlewareBindings[1]->attributes);
     }
 
@@ -181,7 +181,7 @@ class AnnotationRouteRegistrantTest extends TestCase
         $routeArr = $routes->getAll();
         $this->assertCount(1, $routeArr);
         $route = $routeArr[0];
-        $this->assertEquals('/foo', $route->uriTemplate->pathTemplate);
+        $this->assertSame('/foo', $route->uriTemplate->pathTemplate);
     }
 
     public function testRegisteringRoutesWithRouteGroupWithPathPrependsPathToRoutePaths(): void
@@ -207,7 +207,7 @@ class AnnotationRouteRegistrantTest extends TestCase
         $routeArr = $routes->getAll();
         $this->assertCount(1, $routeArr);
         $route = $routeArr[0];
-        $this->assertEquals('/foo/bar', $route->uriTemplate->pathTemplate);
+        $this->assertSame('/foo/bar', $route->uriTemplate->pathTemplate);
     }
 
     public function testRegisteringRoutesWithRouteGroupWithHostAppendsHostToRouteHost(): void
@@ -233,7 +233,7 @@ class AnnotationRouteRegistrantTest extends TestCase
         $routeArr = $routes->getAll();
         $this->assertCount(1, $routeArr);
         $route = $routeArr[0];
-        $this->assertEquals('api.example.com', $route->uriTemplate->hostTemplate);
+        $this->assertSame('api.example.com', $route->uriTemplate->hostTemplate);
     }
 
     public function testRegisteringRoutesWithRouteGroupThatIsHttpsOnlyMakesChildRoutesHttpsOnly(): void

--- a/src/Router/tests/Annotations/MiddlewareTest.php
+++ b/src/Router/tests/Annotations/MiddlewareTest.php
@@ -31,12 +31,12 @@ class MiddlewareTest extends TestCase
 
     public function testClassNameCanBeSetFromClassName(): void
     {
-        $this->assertEquals('foo', (new Middleware(['className' => 'foo']))->className);
+        $this->assertSame('foo', (new Middleware(['className' => 'foo']))->className);
     }
 
     public function testClassNameCanBeSetFromValue(): void
     {
-        $this->assertEquals('foo', (new Middleware(['value' => 'foo']))->className);
+        $this->assertSame('foo', (new Middleware(['value' => 'foo']))->className);
     }
 
     public function testEmptyClassNameThrowsException(): void

--- a/src/Router/tests/Annotations/RouteConstraintTest.php
+++ b/src/Router/tests/Annotations/RouteConstraintTest.php
@@ -31,12 +31,12 @@ class RouteConstraintTest extends TestCase
 
     public function testClassNameCanBeSetFromClassName(): void
     {
-        $this->assertEquals('foo', (new RouteConstraint(['className' => 'foo']))->className);
+        $this->assertSame('foo', (new RouteConstraint(['className' => 'foo']))->className);
     }
 
     public function testClassNameCanBeSetFromValue(): void
     {
-        $this->assertEquals('foo', (new RouteConstraint(['value' => 'foo']))->className);
+        $this->assertSame('foo', (new RouteConstraint(['value' => 'foo']))->className);
     }
 
     public function testEmptyClassNameThrowsException(): void

--- a/src/Router/tests/Annotations/RouteGroupTest.php
+++ b/src/Router/tests/Annotations/RouteGroupTest.php
@@ -21,7 +21,7 @@ class RouteGroupTest extends TestCase
     public function testDefaultValuesOfRoutePropertiesAreSet(): void
     {
         $routeGroup = new RouteGroup([]);
-        $this->assertEquals('', $routeGroup->path);
+        $this->assertSame('', $routeGroup->path);
         $this->assertNull($routeGroup->host);
         $this->assertFalse($routeGroup->isHttpsOnly);
         $this->assertEquals([], $routeGroup->attributes);
@@ -31,13 +31,13 @@ class RouteGroupTest extends TestCase
     public function testPathCanBeSetViaPath(): void
     {
         $routeGroup = new RouteGroup(['path' => '/foo']);
-        $this->assertEquals('/foo', $routeGroup->path);
+        $this->assertSame('/foo', $routeGroup->path);
     }
 
     public function testPathCanBeSetViaValue(): void
     {
         $routeGroup = new RouteGroup(['value' => '/foo']);
-        $this->assertEquals('/foo', $routeGroup->path);
+        $this->assertSame('/foo', $routeGroup->path);
     }
 
     public function testPropertiesAreSetViaConstructor(): void
@@ -49,12 +49,12 @@ class RouteGroupTest extends TestCase
             'attributes' => ['attr' => 'val'],
             'constraints' => [new RouteConstraint(['className' => 'constraintClass', 'constructorParams' => ['param']])]
         ]);
-        $this->assertEquals('/foo', $routeGroup->path);
-        $this->assertEquals('example.com', $routeGroup->host);
+        $this->assertSame('/foo', $routeGroup->path);
+        $this->assertSame('example.com', $routeGroup->host);
         $this->assertTrue($routeGroup->isHttpsOnly);
         $this->assertEquals(['attr' => 'val'], $routeGroup->attributes);
         $this->assertCount(1, $routeGroup->constraints);
-        $this->assertEquals('constraintClass', $routeGroup->constraints[0]->className);
+        $this->assertSame('constraintClass', $routeGroup->constraints[0]->className);
         $this->assertEquals(['param'], $routeGroup->constraints[0]->constructorParams);
     }
 }

--- a/src/Router/tests/Annotations/RouteTest.php
+++ b/src/Router/tests/Annotations/RouteTest.php
@@ -21,7 +21,7 @@ class RouteTest extends TestCase
     public function testDefaultValuesOfRoutePropertiesAreSet(): void
     {
         $route = new Route([]);
-        $this->assertEquals('', $route->path);
+        $this->assertSame('', $route->path);
         $this->assertEquals([], $route->httpMethods);
         $this->assertNull($route->host);
         $this->assertNull($route->name);
@@ -33,13 +33,13 @@ class RouteTest extends TestCase
     public function testPathCanBeSetViaPath(): void
     {
         $route = new Route(['path' => '/foo']);
-        $this->assertEquals('/foo', $route->path);
+        $this->assertSame('/foo', $route->path);
     }
 
     public function testPathCanBeSetViaValue(): void
     {
         $route = new Route(['value' => '/foo']);
-        $this->assertEquals('/foo', $route->path);
+        $this->assertSame('/foo', $route->path);
     }
 
     public function testPropertiesAreSetViaConstructor(): void
@@ -53,14 +53,14 @@ class RouteTest extends TestCase
             'attributes' => ['attr' => 'val'],
             'constraints' => [new RouteConstraint(['className' => 'constraintClass', 'constructorParams' => ['param']])]
         ]);
-        $this->assertEquals('/foo', $route->path);
+        $this->assertSame('/foo', $route->path);
         $this->assertEquals(['GET'], $route->httpMethods);
-        $this->assertEquals('example.com', $route->host);
-        $this->assertEquals('dave', $route->name);
+        $this->assertSame('example.com', $route->host);
+        $this->assertSame('dave', $route->name);
         $this->assertTrue($route->isHttpsOnly);
         $this->assertEquals(['attr' => 'val'], $route->attributes);
         $this->assertCount(1, $route->constraints);
-        $this->assertEquals('constraintClass', $route->constraints[0]->className);
+        $this->assertSame('constraintClass', $route->constraints[0]->className);
         $this->assertEquals(['param'], $route->constraints[0]->constructorParams);
     }
 }

--- a/src/Router/tests/Builders/RouteBuilderTest.php
+++ b/src/Router/tests/Builders/RouteBuilderTest.php
@@ -91,8 +91,8 @@ class RouteBuilderTest extends TestCase
         $this->assertCount(2, $route->middlewareBindings);
         $this->assertInstanceOf(MiddlewareBinding::class, $route->middlewareBindings[0]);
         $this->assertInstanceOf(MiddlewareBinding::class, $route->middlewareBindings[1]);
-        $this->assertEquals('foo', $route->middlewareBindings[0]->className);
-        $this->assertEquals('dave', $route->middlewareBindings[1]->className);
+        $this->assertSame('foo', $route->middlewareBindings[0]->className);
+        $this->assertSame('dave', $route->middlewareBindings[1]->className);
         $this->assertEquals(['bar' => 'baz'], $route->middlewareBindings[0]->attributes);
         $this->assertEquals(['young' => 'cool'], $route->middlewareBindings[1]->attributes);
     }
@@ -114,8 +114,8 @@ class RouteBuilderTest extends TestCase
         $this->assertCount(2, $route->middlewareBindings);
         $this->assertInstanceOf(MiddlewareBinding::class, $route->middlewareBindings[0]);
         $this->assertInstanceOf(MiddlewareBinding::class, $route->middlewareBindings[1]);
-        $this->assertEquals('foo', $route->middlewareBindings[0]->className);
-        $this->assertEquals('bar', $route->middlewareBindings[1]->className);
+        $this->assertSame('foo', $route->middlewareBindings[0]->className);
+        $this->assertSame('bar', $route->middlewareBindings[1]->className);
         $this->assertEquals([], $route->middlewareBindings[0]->attributes);
         $this->assertEquals([], $route->middlewareBindings[1]->attributes);
     }
@@ -135,7 +135,7 @@ class RouteBuilderTest extends TestCase
         $route = $this->routeBuilder->build();
         $this->assertCount(1, $route->middlewareBindings);
         $this->assertInstanceOf(MiddlewareBinding::class, $route->middlewareBindings[0]);
-        $this->assertEquals('foo', $route->middlewareBindings[0]->className);
+        $this->assertSame('foo', $route->middlewareBindings[0]->className);
         $this->assertEquals(['bar' => 'baz'], $route->middlewareBindings[0]->attributes);
     }
 
@@ -144,7 +144,7 @@ class RouteBuilderTest extends TestCase
         $route = $this->routeBuilder->mapsToMethod('class', 'method')
             ->withName('foo')
             ->build();
-        $this->assertEquals('foo', $route->name);
+        $this->assertSame('foo', $route->name);
     }
 
     public function testUriTemplateIsSet(): void

--- a/src/Router/tests/Builders/RouteCollectionBuilderTest.php
+++ b/src/Router/tests/Builders/RouteCollectionBuilderTest.php
@@ -72,7 +72,7 @@ class RouteCollectionBuilderTest extends TestCase
         });
         $routes = $this->builder->build()->getAll();
         $this->assertCount(1, $routes);
-        $this->assertEquals('bar.baz', $routes[0]->uriTemplate->hostTemplate);
+        $this->assertSame('bar.baz', $routes[0]->uriTemplate->hostTemplate);
     }
 
     public function testGroupOptionsDoNotApplyToRoutesAddedOutsideGroup(): void
@@ -86,8 +86,8 @@ class RouteCollectionBuilderTest extends TestCase
             ->mapsToMethod('c2', 'm2');
         $routes = $this->builder->build()->getAll();
         $this->assertCount(2, $routes);
-        $this->assertEquals('/gp/rp1', $routes[0]->uriTemplate->pathTemplate);
-        $this->assertEquals('/rp2', $routes[1]->uriTemplate->pathTemplate);
+        $this->assertSame('/gp/rp1', $routes[0]->uriTemplate->pathTemplate);
+        $this->assertSame('/rp2', $routes[1]->uriTemplate->pathTemplate);
     }
 
     public function testGroupMiddlewareAreMergedWithRouteMiddleware(): void
@@ -117,7 +117,7 @@ class RouteCollectionBuilderTest extends TestCase
         });
         $routes = $registry->build()->getAll();
         $this->assertCount(1, $routes);
-        $this->assertEquals('bar.foo.example.com', $routes[0]->uriTemplate->hostTemplate);
+        $this->assertSame('bar.foo.example.com', $routes[0]->uriTemplate->hostTemplate);
     }
 
     public function testGroupHostWithNoDotAndRouteHostWithTrailingDotHasDotBetweenThem(): void
@@ -129,7 +129,7 @@ class RouteCollectionBuilderTest extends TestCase
         });
         $routes = $registry->build()->getAll();
         $this->assertCount(1, $routes);
-        $this->assertEquals('foo.example.com', $routes[0]->uriTemplate->hostTemplate);
+        $this->assertSame('foo.example.com', $routes[0]->uriTemplate->hostTemplate);
     }
 
     public function testGroupHostWithNoDotAndRouteHostWithNoDosHasDotBetweenThem(): void
@@ -141,7 +141,7 @@ class RouteCollectionBuilderTest extends TestCase
         });
         $routes = $registry->build()->getAll();
         $this->assertCount(1, $routes);
-        $this->assertEquals('foo.example.com', $routes[0]->uriTemplate->hostTemplate);
+        $this->assertSame('foo.example.com', $routes[0]->uriTemplate->hostTemplate);
     }
 
     public function testGroupPathWithNoSlashAndRoutePathWithLeadingSlashHaveSlashBetweenThem(): void
@@ -153,7 +153,7 @@ class RouteCollectionBuilderTest extends TestCase
         });
         $routes = $registry->build()->getAll();
         $this->assertCount(1, $routes);
-        $this->assertEquals('/foo/bar', $routes[0]->uriTemplate->pathTemplate);
+        $this->assertSame('/foo/bar', $routes[0]->uriTemplate->pathTemplate);
     }
 
     public function testGroupPathWithNoSlashAndRoutePathWithNoSlashHaveSlashBetweenThem(): void
@@ -165,7 +165,7 @@ class RouteCollectionBuilderTest extends TestCase
         });
         $routes = $registry->build()->getAll();
         $this->assertCount(1, $routes);
-        $this->assertEquals('/foo/bar', $routes[0]->uriTemplate->pathTemplate);
+        $this->assertSame('/foo/bar', $routes[0]->uriTemplate->pathTemplate);
     }
 
     public function testHttpsOnlyGroupOverridesHttpsSettingInRoutes(): void
@@ -220,7 +220,7 @@ class RouteCollectionBuilderTest extends TestCase
         );
         $routes = $this->builder->build()->getAll();
         $this->assertCount(1, $routes);
-        $this->assertEquals('/op/ip/rp', $routes[0]->uriTemplate->pathTemplate);
+        $this->assertSame('/op/ip/rp', $routes[0]->uriTemplate->pathTemplate);
         $this->assertContains($outerConstraints[0], $routes[0]->constraints);
         $this->assertContains($innerConstraints[0], $routes[0]->constraints);
         $expectedMiddlewareBindings = [
@@ -240,7 +240,7 @@ class RouteCollectionBuilderTest extends TestCase
         });
         $routes = $this->builder->build()->getAll();
         $this->assertCount(1, $routes);
-        $this->assertEquals('/foo/bar', $routes[0]->uriTemplate->pathTemplate);
+        $this->assertSame('/foo/bar', $routes[0]->uriTemplate->pathTemplate);
     }
 
     public function testRouteAddsLeadingSlashToPath(): void
@@ -249,7 +249,7 @@ class RouteCollectionBuilderTest extends TestCase
             ->mapsToMethod('Foo', 'bar');
         $routes = $this->builder->build()->getAll();
         $this->assertCount(1, $routes);
-        $this->assertEquals('/foo', $routes[0]->uriTemplate->pathTemplate);
+        $this->assertSame('/foo', $routes[0]->uriTemplate->pathTemplate);
     }
 
     public function testRouteBuilderIsCreatedWithAttributesToMatchParameter(): void

--- a/src/Router/tests/Builders/RouteGroupOptionsTest.php
+++ b/src/Router/tests/Builders/RouteGroupOptionsTest.php
@@ -51,7 +51,7 @@ class RouteGroupOptionsTest extends TestCase
 
     public function testCorrectHostIsReturned(): void
     {
-        $this->assertEquals('host', $this->routeGroupOptions->hostTemplate);
+        $this->assertSame('host', $this->routeGroupOptions->hostTemplate);
     }
 
     public function testCorrectHttpsOnlyIsReturned(): void
@@ -66,6 +66,6 @@ class RouteGroupOptionsTest extends TestCase
 
     public function testCorrectPathIsReturned(): void
     {
-        $this->assertEquals('path', $this->routeGroupOptions->pathTemplate);
+        $this->assertSame('path', $this->routeGroupOptions->pathTemplate);
     }
 }

--- a/src/Router/tests/Middleware/MiddlewareBindingTest.php
+++ b/src/Router/tests/Middleware/MiddlewareBindingTest.php
@@ -21,7 +21,7 @@ class MiddlewareBindingTest extends TestCase
     {
         $expectedAttributes = ['bar' => 'baz'];
         $middlewareBinding = new MiddlewareBinding('foo', $expectedAttributes);
-        $this->assertEquals('foo', $middlewareBinding->className);
+        $this->assertSame('foo', $middlewareBinding->className);
         $this->assertSame($expectedAttributes, $middlewareBinding->attributes);
     }
 }

--- a/src/Router/tests/RouteActionTest.php
+++ b/src/Router/tests/RouteActionTest.php
@@ -20,7 +20,7 @@ class RouteActionTest extends TestCase
     public function testClassAndMethodNamesAreSetInConstructor(): void
     {
         $action = new RouteAction('Foo', 'bar');
-        $this->assertEquals('Foo', $action->className);
-        $this->assertEquals('bar', $action->methodName);
+        $this->assertSame('Foo', $action->className);
+        $this->assertSame('bar', $action->methodName);
     }
 }

--- a/src/Router/tests/RouteTest.php
+++ b/src/Router/tests/RouteTest.php
@@ -53,7 +53,7 @@ class RouteTest extends TestCase
         $this->assertSame($this->routeAction, $this->route->action);
         $this->assertSame($this->constraints, $this->route->constraints);
         $this->assertSame($this->middlewareBindings, $this->route->middlewareBindings);
-        $this->assertEquals('name', $this->route->name);
+        $this->assertSame('name', $this->route->name);
         $this->assertSame($this->attributes, $this->route->attributes);
     }
 }

--- a/src/Router/tests/UriTemplateTest.php
+++ b/src/Router/tests/UriTemplateTest.php
@@ -51,8 +51,8 @@ class UriTemplateTest extends TestCase
     public function testPropertiesAreSetInConstructor(): void
     {
         $uriTemplate = new UriTemplate('/foo', 'example.com', false);
-        $this->assertEquals('/foo', $uriTemplate->pathTemplate);
-        $this->assertEquals('example.com', $uriTemplate->hostTemplate);
+        $this->assertSame('/foo', $uriTemplate->pathTemplate);
+        $this->assertSame('example.com', $uriTemplate->hostTemplate);
         $this->assertFalse($uriTemplate->isHttpsOnly);
         $this->assertTrue($uriTemplate->isAbsoluteUri);
     }
@@ -60,18 +60,18 @@ class UriTemplateTest extends TestCase
     public function testToStringIgnoresHostIfItIsNull(): void
     {
         $uriTemplate = new UriTemplate('/foo');
-        $this->assertEquals('/foo', (string)$uriTemplate);
+        $this->assertSame('/foo', (string)$uriTemplate);
     }
 
     public function testToStringIncludesHostIfItIsDefined(): void
     {
         $uriTemplate = new UriTemplate('/foo', 'example.com');
-        $this->assertEquals('example.com/foo', (string)$uriTemplate);
+        $this->assertSame('example.com/foo', (string)$uriTemplate);
     }
 
     public function testTrailingSlashIsStrippedFromHost(): void
     {
         $uriTemplate = new UriTemplate('foo', 'example.com/');
-        $this->assertEquals('example.com', $uriTemplate->hostTemplate);
+        $this->assertSame('example.com', $uriTemplate->hostTemplate);
     }
 }

--- a/src/Router/tests/UriTemplates/AstRouteUriFactoryTest.php
+++ b/src/Router/tests/UriTemplates/AstRouteUriFactoryTest.php
@@ -74,19 +74,19 @@ class AstRouteUriFactoryTest extends TestCase
     public function testCreatingUriWithHostAndEmptyPathStripsTrailingSlash(): void
     {
         $this->addRouteWithUriTemplate('foo', 'example.com', '');
-        $this->assertEquals('https://example.com', $this->uriFactory->createRouteUri('foo'));
+        $this->assertSame('https://example.com', $this->uriFactory->createRouteUri('foo'));
     }
 
     public function testCreatingUriWithHttpsOnlyHostUsesHttpsPrefix(): void
     {
         $this->addRouteWithUriTemplate('foo', 'example.com', '/foo');
-        $this->assertEquals('https://example.com/foo', $this->uriFactory->createRouteUri('foo'));
+        $this->assertSame('https://example.com/foo', $this->uriFactory->createRouteUri('foo'));
     }
 
     public function testCreatingUriWithMultipleHostVarsPopulatesThemFromArgs(): void
     {
         $this->addRouteWithUriTemplate('foo', ':foo.:bar.example.com', '');
-        $this->assertEquals(
+        $this->assertSame(
             'https://dave.young.example.com',
             $this->uriFactory->createRouteUri('foo', ['foo' => 'dave', 'bar' => 'young'])
         );
@@ -95,7 +95,7 @@ class AstRouteUriFactoryTest extends TestCase
     public function testCreatingUriWithMultiplePathVarsPopulatesThemFromArgs(): void
     {
         $this->addRouteWithUriTemplate('foo', null, '/:foo/:bar');
-        $this->assertEquals(
+        $this->assertSame(
             '/dave/young',
             $this->uriFactory->createRouteUri('foo', ['foo' => 'dave', 'bar' => 'young'])
         );
@@ -104,28 +104,28 @@ class AstRouteUriFactoryTest extends TestCase
     public function testCreatingUriWithNonHttpsOnlyHostUsesHttpPrefix(): void
     {
         $this->addRouteWithUriTemplate('foo', 'example.com', '/foo', false);
-        $this->assertEquals('http://example.com/foo', $this->uriFactory->createRouteUri('foo'));
+        $this->assertSame('http://example.com/foo', $this->uriFactory->createRouteUri('foo'));
     }
 
     public function testCreatingUriWithOptionalHostWithTextOnlyInOptionalPartIncludesThatText(): void
     {
         $this->addRouteWithUriTemplate('foo', '[foo.]example.com', '');
-        $this->assertEquals('https://foo.example.com', $this->uriFactory->createRouteUri('foo'));
+        $this->assertSame('https://foo.example.com', $this->uriFactory->createRouteUri('foo'));
     }
 
     public function testCreatingUriWithOptionalHostVarDoesNotSetItIfValueDoesNotExist(): void
     {
         $this->addRouteWithUriTemplate('foo', '[:foo.]example.com', '');
-        $this->assertEquals('https://example.com', $this->uriFactory->createRouteUri('foo'));
+        $this->assertSame('https://example.com', $this->uriFactory->createRouteUri('foo'));
 
         $this->addRouteWithUriTemplate('bar', '[:foo.[:bar.]]example.com', '');
-        $this->assertEquals('https://example.com', $this->uriFactory->createRouteUri('bar'));
+        $this->assertSame('https://example.com', $this->uriFactory->createRouteUri('bar'));
     }
 
     public function testCreatingUriWithOptionalHostVarSetsItIfValueExists(): void
     {
         $this->addRouteWithUriTemplate('foo', '[:foo.]example.com', '');
-        $this->assertEquals(
+        $this->assertSame(
             'https://bar.example.com',
             $this->uriFactory->createRouteUri('foo', ['foo' => 'bar'])
         );
@@ -134,17 +134,17 @@ class AstRouteUriFactoryTest extends TestCase
     public function testCreatingUriWithOptionalNestedHostsDoesNotIncludeOuterPartIfInnerPartIsSpecified(): void
     {
         $this->addRouteWithUriTemplate('foo', '[[:foo.]:bar.]example.com', '');
-        $this->assertEquals('https://example.com', $this->uriFactory->createRouteUri('foo', ['foo' => '1']));
+        $this->assertSame('https://example.com', $this->uriFactory->createRouteUri('foo', ['foo' => '1']));
     }
 
     public function testCreatingUriWithOptionalNestedHostsWithDefinedVarsIncludesThem(): void
     {
         $this->addRouteWithUriTemplate('foo', '[[:foo.]:bar.]example.com', '');
-        $this->assertEquals(
+        $this->assertSame(
             'https://1.example.com',
             $this->uriFactory->createRouteUri('foo', ['bar' => '1'])
         );
-        $this->assertEquals(
+        $this->assertSame(
             'https://2.1.example.com',
             $this->uriFactory->createRouteUri('foo', ['bar' => '1', 'foo' => '2'])
         );
@@ -153,17 +153,17 @@ class AstRouteUriFactoryTest extends TestCase
     public function testCreatingUriWithOptionalNestedPathsDoesNotIncludeOuterPartIfInnerPartIsSpecified(): void
     {
         $this->addRouteWithUriTemplate('foo', 'example.com', '/foo[/:bar[/:baz]]');
-        $this->assertEquals('https://example.com/foo', $this->uriFactory->createRouteUri('foo', ['baz' => '1']));
+        $this->assertSame('https://example.com/foo', $this->uriFactory->createRouteUri('foo', ['baz' => '1']));
     }
 
     public function testCreatingUriWithOptionalNestedPathsWithDefinedVarsIncludesThem(): void
     {
         $this->addRouteWithUriTemplate('foo', 'example.com', 'foo[/:bar[/:baz]]');
-        $this->assertEquals(
+        $this->assertSame(
             'https://example.com/foo/1',
             $this->uriFactory->createRouteUri('foo', ['bar' => '1'])
         );
-        $this->assertEquals(
+        $this->assertSame(
             'https://example.com/foo/1/2',
             $this->uriFactory->createRouteUri('foo', ['bar' => '1', 'baz' => '2'])
         );
@@ -172,22 +172,22 @@ class AstRouteUriFactoryTest extends TestCase
     public function testCreatingUriWithOptionalPathWithTextOnlyInOptionalPartIncludesThatText(): void
     {
         $this->addRouteWithUriTemplate('foo', 'example.com', 'foo[/bar]');
-        $this->assertEquals('https://example.com/foo/bar', $this->uriFactory->createRouteUri('foo'));
+        $this->assertSame('https://example.com/foo/bar', $this->uriFactory->createRouteUri('foo'));
     }
 
     public function testCreatingUriWithOptionalPathVarDoesNotSetItIfValueDoesNotExist(): void
     {
         $this->addRouteWithUriTemplate('foo', 'example.com', '/foo[/:bar]');
-        $this->assertEquals('https://example.com/foo', $this->uriFactory->createRouteUri('foo'));
+        $this->assertSame('https://example.com/foo', $this->uriFactory->createRouteUri('foo'));
 
         $this->addRouteWithUriTemplate('bar', 'example.com', '/foo[/:bar[/:baz]]');
-        $this->assertEquals('https://example.com/foo', $this->uriFactory->createRouteUri('bar'));
+        $this->assertSame('https://example.com/foo', $this->uriFactory->createRouteUri('bar'));
     }
 
     public function testCreatingUriWithOptionalPathVarIncludesItIfSet(): void
     {
         $this->addRouteWithUriTemplate('foo', 'example.com', '/foo[/:bar]');
-        $this->assertEquals(
+        $this->assertSame(
             'https://example.com/foo/baz',
             $this->uriFactory->createRouteUri('foo', ['bar' => 'baz'])
         );
@@ -212,7 +212,7 @@ class AstRouteUriFactoryTest extends TestCase
     public function testCreatingUriWithRelativePathHasLeadingSlash(): void
     {
         $this->addRouteWithUriTemplate('foo', null, '/foo/bar');
-        $this->assertEquals('/foo/bar', $this->uriFactory->createRouteUri('foo'));
+        $this->assertSame('/foo/bar', $this->uriFactory->createRouteUri('foo'));
     }
 
     /**

--- a/src/Router/tests/UriTemplates/Compilers/Tries/LiteralTrieNodeTest.php
+++ b/src/Router/tests/UriTemplates/Compilers/Tries/LiteralTrieNodeTest.php
@@ -47,7 +47,7 @@ class LiteralTrieNodeTest extends TestCase
         $expectedRoutes = [new Route(new UriTemplate(''), new RouteAction('Foo', 'bar'), [])];
         $expectedHostTrie = $this->createMockNode();
         $node = new LiteralTrieNode('foo', $expectedChildren, $expectedRoutes, $expectedHostTrie);
-        $this->assertEquals('foo', $node->value);
+        $this->assertSame('foo', $node->value);
         $this->assertSame($expectedChildren, $node->getAllChildren());
         $this->assertSame($expectedRoutes, $node->routes);
         $this->assertSame($expectedHostTrie, $node->hostTrie);

--- a/src/Router/tests/UriTemplates/Compilers/Tries/RouteVariableTest.php
+++ b/src/Router/tests/UriTemplates/Compilers/Tries/RouteVariableTest.php
@@ -22,7 +22,7 @@ class RouteVariableTest extends TestCase
     {
         $expectedConstraints = [$this->createMock(IRouteVariableConstraint::class)];
         $routeVariable = new RouteVariable('foo', $expectedConstraints);
-        $this->assertEquals('foo', $routeVariable->name);
+        $this->assertSame('foo', $routeVariable->name);
         $this->assertSame($expectedConstraints, $routeVariable->constraints);
     }
 }

--- a/src/Router/tests/UriTemplates/Constraints/AlphaConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/AlphaConstraintTest.php
@@ -26,7 +26,7 @@ class AlphaConstraintTest extends TestCase
 
     public function testCorrectSlugIsReturned(): void
     {
-        $this->assertEquals('alpha', AlphaConstraint::getSlug());
+        $this->assertSame('alpha', AlphaConstraint::getSlug());
     }
 
     public function testNonAlphaCharsFail(): void

--- a/src/Router/tests/UriTemplates/Constraints/AlphanumericConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/AlphanumericConstraintTest.php
@@ -28,7 +28,7 @@ class AlphanumericConstraintTest extends TestCase
 
     public function testCorrectSlugIsReturned(): void
     {
-        $this->assertEquals('alphanumeric', AlphanumericConstraint::getSlug());
+        $this->assertSame('alphanumeric', AlphanumericConstraint::getSlug());
     }
 
     public function testNonAlphanumericCharsFail(): void

--- a/src/Router/tests/UriTemplates/Constraints/BetweenConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/BetweenConstraintTest.php
@@ -20,7 +20,7 @@ class BetweenConstraintTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void
     {
-        $this->assertEquals('between', BetweenConstraint::getSlug());
+        $this->assertSame('between', BetweenConstraint::getSlug());
     }
 
     public function testInclusiveFlagsAreRespected(): void

--- a/src/Router/tests/UriTemplates/Constraints/DateConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/DateConstraintTest.php
@@ -21,7 +21,7 @@ class DateConstraintTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void
     {
-        $this->assertEquals('date', DateConstraint::getSlug());
+        $this->assertSame('date', DateConstraint::getSlug());
     }
 
     public function testFailingSingleFormat(): void

--- a/src/Router/tests/UriTemplates/Constraints/InConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/InConstraintTest.php
@@ -19,7 +19,7 @@ class InConstraintTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void
     {
-        $this->assertEquals('in', InConstraint::getSlug());
+        $this->assertSame('in', InConstraint::getSlug());
     }
 
     public function testValueInArrayPasses(): void

--- a/src/Router/tests/UriTemplates/Constraints/IntegerConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/IntegerConstraintTest.php
@@ -19,7 +19,7 @@ class IntegerConstraintTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void
     {
-        $this->assertEquals('int', IntegerConstraint::getSlug());
+        $this->assertSame('int', IntegerConstraint::getSlug());
     }
 
     public function testFailingValue(): void

--- a/src/Router/tests/UriTemplates/Constraints/NotInConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/NotInConstraintTest.php
@@ -19,7 +19,7 @@ class NotInConstraintTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void
     {
-        $this->assertEquals('notIn', NotInConstraint::getSlug());
+        $this->assertSame('notIn', NotInConstraint::getSlug());
     }
 
     public function testValueInArrayFails(): void

--- a/src/Router/tests/UriTemplates/Constraints/NumericConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/NumericConstraintTest.php
@@ -28,7 +28,7 @@ class NumericConstraintTest extends TestCase
 
     public function testCorrectSlugIsReturned(): void
     {
-        $this->assertEquals('numeric', NumericConstraint::getSlug());
+        $this->assertSame('numeric', NumericConstraint::getSlug());
     }
 
     public function testNonAlphaCharsFail(): void

--- a/src/Router/tests/UriTemplates/Constraints/RegexConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/RegexConstraintTest.php
@@ -19,7 +19,7 @@ class RegexConstraintTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void
     {
-        $this->assertEquals('regex', RegexConstraint::getSlug());
+        $this->assertSame('regex', RegexConstraint::getSlug());
     }
 
     public function testMatchingStringsPass(): void

--- a/src/Router/tests/UriTemplates/Constraints/RouteVariableConstraintFactoryTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/RouteVariableConstraintFactoryTest.php
@@ -57,8 +57,8 @@ class RouteVariableConstraintFactoryTest extends TestCase
     {
         $expectedConstraint = $this->createMock(IRouteVariableConstraint::class);
         $factory = function ($foo, $bar) use ($expectedConstraint) {
-            $this->assertEquals(1, $foo);
-            $this->assertEquals(2, $bar);
+            $this->assertSame(1, $foo);
+            $this->assertSame(2, $bar);
 
             return $expectedConstraint;
         };

--- a/src/Router/tests/UriTemplates/Constraints/UuidV4ConstraintTest.php
+++ b/src/Router/tests/UriTemplates/Constraints/UuidV4ConstraintTest.php
@@ -19,7 +19,7 @@ class UuidV4ConstraintTest extends TestCase
 {
     public function testCorrectSlugIsReturned(): void
     {
-        $this->assertEquals('uuidv4', UuidV4Constraint::getSlug());
+        $this->assertSame('uuidv4', UuidV4Constraint::getSlug());
     }
 
     public function testMatchingStringsPass(): void

--- a/src/Router/tests/UriTemplates/Lexers/TokenStreamTest.php
+++ b/src/Router/tests/UriTemplates/Lexers/TokenStreamTest.php
@@ -94,8 +94,8 @@ class TokenStreamTest extends TestCase
 
     public function testLengthReturnsCountOfTokens(): void
     {
-        $this->assertEquals(1, (new TokenStream([new Token('foo', 'bar')]))->length);
-        $this->assertEquals(2, (new TokenStream([new Token('foo', 'bar'), new Token('baz', 'blah')]))->length);
+        $this->assertSame(1, (new TokenStream([new Token('foo', 'bar')]))->length);
+        $this->assertSame(2, (new TokenStream([new Token('foo', 'bar'), new Token('baz', 'blah')]))->length);
     }
 
     public function testPeekingAlwaysReturnsNextToken(): void

--- a/src/Router/tests/UriTemplates/Lexers/TokenTest.php
+++ b/src/Router/tests/UriTemplates/Lexers/TokenTest.php
@@ -21,7 +21,7 @@ class TokenTest extends TestCase
     public function testPropertiesAreSetInConstructor(): void
     {
         $token = new Token(TokenTypes::T_TEXT, 'foo');
-        $this->assertEquals(TokenTypes::T_TEXT, $token->type);
-        $this->assertEquals('foo', $token->value);
+        $this->assertSame(TokenTypes::T_TEXT, $token->type);
+        $this->assertSame('foo', $token->value);
     }
 }

--- a/src/Router/tests/UriTemplates/Parsers/AstNodeTest.php
+++ b/src/Router/tests/UriTemplates/Parsers/AstNodeTest.php
@@ -37,13 +37,13 @@ class AstNodeTest extends TestCase
     public function testGettingTypeReturnsCorrectValue(): void
     {
         $expectedType = AstNodeTypes::VARIABLE;
-        $this->assertEquals($expectedType, (new AstNode($expectedType, 'foo'))->type);
+        $this->assertSame($expectedType, (new AstNode($expectedType, 'foo'))->type);
     }
 
     public function testGettingValueReturnsCorrectValue(): void
     {
         $expectedValue = 'bar';
-        $this->assertEquals($expectedValue, (new AstNode('foo', $expectedValue))->value);
+        $this->assertSame($expectedValue, (new AstNode('foo', $expectedValue))->value);
     }
 
     public function testNodeIsRootOnlyIfItHasNoParent(): void

--- a/src/Sessions/tests/Handlers/ArraySessionDriverTest.php
+++ b/src/Sessions/tests/Handlers/ArraySessionDriverTest.php
@@ -38,7 +38,7 @@ class ArraySessionDriverTest extends TestCase
     {
         $this->driver->set('foo', 'bar');
         $this->driver->gc(0);
-        $this->assertEquals('bar', $this->driver->get('foo'));
+        $this->assertSame('bar', $this->driver->get('foo'));
     }
 
     public function testGettingNonExistentSessionThrowsException(): void
@@ -51,6 +51,6 @@ class ArraySessionDriverTest extends TestCase
     public function testSettingDataMakesItGettable(): void
     {
         $this->driver->set('foo', 'bar');
-        $this->assertEquals('bar', $this->driver->get('foo'));
+        $this->assertSame('bar', $this->driver->get('foo'));
     }
 }

--- a/src/Sessions/tests/Handlers/DriverSessionHandlerTest.php
+++ b/src/Sessions/tests/Handlers/DriverSessionHandlerTest.php
@@ -69,7 +69,7 @@ class DriverSessionHandlerTest extends TestCase
         $encrypter->method('decrypt')
             ->with('bar')
             ->willReturn('baz');
-        $this->assertEquals('baz', $sessionHandlerWithEncrypter->read('foo'));
+        $this->assertSame('baz', $sessionHandlerWithEncrypter->read('foo'));
     }
 
     public function testReadingWithEncrypterThatThrowsExceptionReturnsEmptyString(): void
@@ -84,7 +84,7 @@ class DriverSessionHandlerTest extends TestCase
         $encrypter->method('decrypt')
             ->with('bar')
             ->willThrowException(new SessionEncryptionException());
-        $this->assertEquals('', $sessionHandlerWithEncrypter->read('foo'));
+        $this->assertSame('', $sessionHandlerWithEncrypter->read('foo'));
     }
 
     public function testReadingWithoutEncrypterPassesThroughDriverValue(): void
@@ -93,7 +93,7 @@ class DriverSessionHandlerTest extends TestCase
             ->method('get')
             ->with('foo')
             ->willReturn('bar');
-        $this->assertEquals('bar', $this->sessionHandler->read('foo'));
+        $this->assertSame('bar', $this->sessionHandler->read('foo'));
     }
 
     public function testWritingWithEncrypterEncryptsValueBeforeSettingItInDriver(): void

--- a/src/Sessions/tests/Handlers/FileSessionDriverTest.php
+++ b/src/Sessions/tests/Handlers/FileSessionDriverTest.php
@@ -69,12 +69,12 @@ class FileSessionDriverTest extends TestCase
     public function testGettingReturnsDataWrittenToFile(): void
     {
         \file_put_contents(self::BASE_PATH . '/foo', 'bar');
-        $this->assertEquals('bar', $this->driver->get('foo'));
+        $this->assertSame('bar', $this->driver->get('foo'));
     }
 
     public function testSettingDataWritesItToFile(): void
     {
         $this->driver->set('foo', 'bar');
-        $this->assertEquals('bar', \file_get_contents(self::BASE_PATH . '/foo'));
+        $this->assertSame('bar', \file_get_contents(self::BASE_PATH . '/foo'));
     }
 }

--- a/src/Sessions/tests/Middleware/SessionTest.php
+++ b/src/Sessions/tests/Middleware/SessionTest.php
@@ -126,7 +126,7 @@ class SessionTest extends TestCase
             0
         );
         $actualResponse = $middleware->handle($this->request, $this->next);
-        $this->assertEquals(
+        $this->assertSame(
             'session=foo; Max-Age=3600; Path=%2Fpath; Domain=example.com; Secure; HttpOnly; SameSite=lax',
             $actualResponse->getHeaders()->getFirst('Set-Cookie')
         );

--- a/src/Sessions/tests/SessionTest.php
+++ b/src/Sessions/tests/SessionTest.php
@@ -32,7 +32,7 @@ class SessionTest extends TestCase
             $session->getAll()
         );
         $session->ageFlashData();
-        $this->assertEquals('bar', $session->get('foo'));
+        $this->assertSame('bar', $session->get('foo'));
         $this->assertTrue($session->containsKey('foo'));
         $this->assertEquals(
             [
@@ -46,7 +46,7 @@ class SessionTest extends TestCase
         $session->ageFlashData();
         $this->assertNull($session->get('foo'));
         $this->assertFalse($session->containsKey('foo'));
-        $this->assertEquals('blah', $session->get('baz'));
+        $this->assertSame('blah', $session->get('baz'));
         $this->assertEquals(
             [
                 'baz' => 'blah',
@@ -76,7 +76,7 @@ class SessionTest extends TestCase
         $session->flash('foo', 'baz');
         $session->ageFlashData();
         $this->assertTrue($session->containsKey('foo'));
-        $this->assertEquals('baz', $session->get('foo'));
+        $this->assertSame('baz', $session->get('foo'));
         $this->assertEquals(
             [
                 'foo' => 'baz',
@@ -121,7 +121,7 @@ class SessionTest extends TestCase
         $session = new Session();
         $session->flash('foo', 'bar');
         $this->assertTrue($session->containsKey('foo'));
-        $this->assertEquals('bar', $session->get('foo'));
+        $this->assertSame('bar', $session->get('foo'));
         $this->assertEquals(
             [
                 'foo' => 'bar',
@@ -157,7 +157,7 @@ class SessionTest extends TestCase
         $session = new Session($constructorId, $idGenerator);
         $setterId = str_repeat('2', IIdGenerator::MIN_LENGTH);
         $session->setId($setterId);
-        $this->assertEquals($setterId, $session->getId());
+        $this->assertSame($setterId, $session->getId());
     }
 
     public function testGettingIdUsesIdGeneratorValue(): void
@@ -166,7 +166,7 @@ class SessionTest extends TestCase
         $idGenerator = $this->createMock(IIdGenerator::class);
         $idGenerator->method('idIsValid')->willReturn(true);
         $session = new Session($id, $idGenerator);
-        $this->assertEquals($id, $session->getId());
+        $this->assertSame($id, $session->getId());
     }
 
     public function testGettingNonExistentKeyReturnsNull(): void
@@ -179,7 +179,7 @@ class SessionTest extends TestCase
     public function testGettingNonExistentKeyWithDefaultValueReturnsThatValue(): void
     {
         $session = new Session();
-        $this->assertEquals('bar', $session->get('foo', 'bar'));
+        $this->assertSame('bar', $session->get('foo', 'bar'));
     }
 
     public function testReflashingKeepsTheDataInSessionUntilItIsAgedAgain(): void
@@ -189,7 +189,7 @@ class SessionTest extends TestCase
         $session->ageFlashData();
         $session->reflash();
         $this->assertTrue($session->containsKey('foo'));
-        $this->assertEquals('bar', $session->get('foo'));
+        $this->assertSame('bar', $session->get('foo'));
         $this->assertEquals(
             [
                 'foo' => 'bar',
@@ -200,7 +200,7 @@ class SessionTest extends TestCase
         );
         $session->ageFlashData();
         $this->assertTrue($session->containsKey('foo'));
-        $this->assertEquals('bar', $session->get('foo'));
+        $this->assertSame('bar', $session->get('foo'));
         $this->assertEquals(
             [
                 'foo' => 'bar',
@@ -231,7 +231,7 @@ class SessionTest extends TestCase
         $idGenerator->method('generate')->willReturn($generatedId);
         $session = new Session(null, $idGenerator);
         $session->regenerateId();
-        $this->assertEquals($generatedId, $session->getId());
+        $this->assertSame($generatedId, $session->getId());
     }
 
     public function testRegeneratingIdWithDefaultIdGeneratorCreatesANewId(): void
@@ -276,8 +276,8 @@ class SessionTest extends TestCase
     {
         $session = new Session();
         $session['foo'] = 'bar';
-        $this->assertEquals('bar', $session['foo']);
-        $this->assertEquals('bar', $session->get('foo'));
+        $this->assertSame('bar', $session['foo']);
+        $this->assertSame('bar', $session->get('foo'));
         $this->assertEquals(['foo' => 'bar'], $session->getAll());
     }
 
@@ -285,7 +285,7 @@ class SessionTest extends TestCase
     {
         $session = new Session();
         $session->set('foo', 'bar');
-        $this->assertEquals('bar', $session->get('foo'));
+        $this->assertSame('bar', $session->get('foo'));
         $this->assertEquals(['foo' => 'bar'], $session->getAll());
     }
 

--- a/src/Validation/tests/Builders/ObjectConstraintsBuilderTest.php
+++ b/src/Validation/tests/Builders/ObjectConstraintsBuilderTest.php
@@ -27,7 +27,7 @@ class ObjectConstraintsBuilderTest extends TestCase
 
     public function testBuiltConstraintsHasCorrectClassName(): void
     {
-        $this->assertEquals('foo', $this->builder->build()->getClassName());
+        $this->assertSame('foo', $this->builder->build()->getClassName());
     }
 
     public function testHasMethodConstraintsWithMultipleConstraintsAddsThemToRegistry(): void

--- a/src/Validation/tests/Builders/ObjectConstraintsRegistryBuilderTest.php
+++ b/src/Validation/tests/Builders/ObjectConstraintsRegistryBuilderTest.php
@@ -69,6 +69,6 @@ class ObjectConstraintsRegistryBuilderTest extends TestCase
     public function testClassCreatesBuilderWithCorrectClassName(): void
     {
         $actualConstraintsBuilder = $this->builder->class('foo');
-        $this->assertEquals('foo', $actualConstraintsBuilder->build()->getClassName());
+        $this->assertSame('foo', $actualConstraintsBuilder->build()->getClassName());
     }
 }

--- a/src/Validation/tests/ConstraintViolationTest.php
+++ b/src/Validation/tests/ConstraintViolationTest.php
@@ -21,7 +21,7 @@ class ConstraintViolationTest extends TestCase
     public function testGettingErrorMessageReturnsOneSetInConstructor(): void
     {
         $violation = new ConstraintViolation('error', $this->createMock(IConstraint::class), 'foo', 'bar');
-        $this->assertEquals('error', $violation->getErrorMessage());
+        $this->assertSame('error', $violation->getErrorMessage());
     }
 
     public function testGetInvalidValueReturnsOneSetInConstructor(): void
@@ -32,7 +32,7 @@ class ConstraintViolationTest extends TestCase
             'foo',
             'bar'
         );
-        $this->assertEquals('foo', $violation->getInvalidValue());
+        $this->assertSame('foo', $violation->getInvalidValue());
     }
 
     public function testGetMethodNameReturnsOneSetInConstructor(): void
@@ -45,7 +45,7 @@ class ConstraintViolationTest extends TestCase
             null,
             'method'
         );
-        $this->assertEquals('method', $violation->getMethodName());
+        $this->assertSame('method', $violation->getMethodName());
     }
 
     public function testGetPropertyNameReturnsOneSetInConstructor(): void
@@ -57,7 +57,7 @@ class ConstraintViolationTest extends TestCase
             'bar',
             'prop'
         );
-        $this->assertEquals('prop', $violation->getPropertyName());
+        $this->assertSame('prop', $violation->getPropertyName());
     }
 
     public function testGetRootValueReturnsOneSetInConstructor(): void
@@ -68,7 +68,7 @@ class ConstraintViolationTest extends TestCase
             'foo',
             'bar'
         );
-        $this->assertEquals('bar', $violation->getRootValue());
+        $this->assertSame('bar', $violation->getRootValue());
     }
 
     public function testGetConstraintReturnsOneSetInConstructor(): void

--- a/src/Validation/tests/Constraints/AlphaConstraintTest.php
+++ b/src/Validation/tests/Constraints/AlphaConstraintTest.php
@@ -28,7 +28,7 @@ class AlphaConstraintTest extends TestCase
     public function testGettingErrorMessageId(): void
     {
         $constraint = new AlphaConstraint('foo');
-        $this->assertEquals('foo', $constraint->getErrorMessageId());
+        $this->assertSame('foo', $constraint->getErrorMessageId());
     }
 
     public function testGettingErrorMessagePlaceholdersIncludesValue(): void

--- a/src/Validation/tests/Constraints/AlphanumericConstraintTest.php
+++ b/src/Validation/tests/Constraints/AlphanumericConstraintTest.php
@@ -28,7 +28,7 @@ class AlphanumericConstraintTest extends TestCase
     public function testGettingErrorMessageId(): void
     {
         $constraint = new AlphanumericConstraint('foo');
-        $this->assertEquals('foo', $constraint->getErrorMessageId());
+        $this->assertSame('foo', $constraint->getErrorMessageId());
     }
 
     public function testGettingErrorMessagePlaceholdersIncludesValue(): void

--- a/src/Validation/tests/Constraints/Annotations/AlphaTest.php
+++ b/src/Validation/tests/Constraints/Annotations/AlphaTest.php
@@ -34,7 +34,7 @@ class AlphaTest extends TestCase
     public function testCreatingConstraintUsesErrorMessageIdIfSpecified(): void
     {
         $annotation = new Alpha(['errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
+        $this->assertSame('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
     }
 
     public function testCreatingWithEmptyArrayCreatesInstance(): void
@@ -48,6 +48,6 @@ class AlphaTest extends TestCase
     public function testSettingErrorMessageId(): void
     {
         $annotation = new Alpha(['errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->errorMessageId);
+        $this->assertSame('foo', $annotation->errorMessageId);
     }
 }

--- a/src/Validation/tests/Constraints/Annotations/AlphanumericTest.php
+++ b/src/Validation/tests/Constraints/Annotations/AlphanumericTest.php
@@ -34,7 +34,7 @@ class AlphanumericTest extends TestCase
     public function testCreatingConstraintUsesErrorMessageIdIfSpecified(): void
     {
         $annotation = new Alphanumeric(['errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
+        $this->assertSame('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
     }
 
     public function testCreatingWithEmptyArrayCreatesInstance(): void
@@ -48,6 +48,6 @@ class AlphanumericTest extends TestCase
     public function testSettingErrorMessageId(): void
     {
         $annotation = new Alphanumeric(['errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->errorMessageId);
+        $this->assertSame('foo', $annotation->errorMessageId);
     }
 }

--- a/src/Validation/tests/Constraints/Annotations/BetweenTest.php
+++ b/src/Validation/tests/Constraints/Annotations/BetweenTest.php
@@ -35,7 +35,7 @@ class BetweenTest extends TestCase
     public function testCreatingConstraintUsesErrorMessageIdIfSpecified(): void
     {
         $annotation = new Between(['min' => 2, 'max' => 2, 'errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
+        $this->assertSame('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
     }
 
     public function testMaxIsInclusiveCanBeSetViaConstructor(): void
@@ -53,7 +53,7 @@ class BetweenTest extends TestCase
     public function testMaxIsSetViaConstructor(): void
     {
         $annotation = new Between(['min' => 1, 'max' => 2]);
-        $this->assertEquals(2, $annotation->max);
+        $this->assertSame(2, $annotation->max);
     }
 
     public function testMinIsInclusiveCanBeSetViaConstructor(): void
@@ -71,7 +71,7 @@ class BetweenTest extends TestCase
     public function testMinIsSetViaConstructor(): void
     {
         $annotation = new Between(['min' => 1, 'max' => 2]);
-        $this->assertEquals(1, $annotation->min);
+        $this->assertSame(1, $annotation->min);
     }
 
     public function testNotSettingMaxThrowsException(): void
@@ -105,6 +105,6 @@ class BetweenTest extends TestCase
     public function testSettingErrorMessageId(): void
     {
         $annotation = new Between(['min' => 1, 'max' => 2, 'errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->errorMessageId);
+        $this->assertSame('foo', $annotation->errorMessageId);
     }
 }

--- a/src/Validation/tests/Constraints/Annotations/DateTest.php
+++ b/src/Validation/tests/Constraints/Annotations/DateTest.php
@@ -35,7 +35,7 @@ class DateTest extends TestCase
     public function testCreatingConstraintUsesErrorMessageIdIfSpecified(): void
     {
         $annotation = new Date(['value' => ['Ymd'], 'errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
+        $this->assertSame('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
     }
 
     public function testNotSettingArrayOfAcceptableFormatsThrowsException(): void
@@ -55,7 +55,7 @@ class DateTest extends TestCase
     public function testSettingErrorMessageId(): void
     {
         $annotation = new Date(['value' => 'Ymd', 'errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->errorMessageId);
+        $this->assertSame('foo', $annotation->errorMessageId);
     }
 
     public function testSettingStringAcceptableFormatIsAccepted(): void

--- a/src/Validation/tests/Constraints/Annotations/EachTest.php
+++ b/src/Validation/tests/Constraints/Annotations/EachTest.php
@@ -37,7 +37,7 @@ class EachTest extends TestCase
     public function testCreatingConstraintUsesErrorMessageIdIfSpecified(): void
     {
         $annotation = new Each(['value' => $this->createMock(IConstraintAnnotation::class), 'errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
+        $this->assertSame('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
     }
 
     public function testNotSettingArrayOfConstraintsThrowsException(): void
@@ -60,7 +60,7 @@ class EachTest extends TestCase
             'value' => [$this->createMock(IConstraintAnnotation::class)],
             'errorMessageId' => 'foo'
         ]);
-        $this->assertEquals('foo', $annotation->errorMessageId);
+        $this->assertSame('foo', $annotation->errorMessageId);
     }
 
     public function testSettingSingleConstraintIsAccepted(): void

--- a/src/Validation/tests/Constraints/Annotations/EmailTest.php
+++ b/src/Validation/tests/Constraints/Annotations/EmailTest.php
@@ -34,7 +34,7 @@ class EmailTest extends TestCase
     public function testCreatingConstraintUsesErrorMessageIdIfSpecified(): void
     {
         $annotation = new Email(['errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
+        $this->assertSame('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
     }
 
     public function testCreatingWithEmptyArrayCreatesInstance(): void
@@ -48,6 +48,6 @@ class EmailTest extends TestCase
     public function testSettingErrorMessageId(): void
     {
         $annotation = new Email(['errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->errorMessageId);
+        $this->assertSame('foo', $annotation->errorMessageId);
     }
 }

--- a/src/Validation/tests/Constraints/Annotations/EqualsTest.php
+++ b/src/Validation/tests/Constraints/Annotations/EqualsTest.php
@@ -35,7 +35,7 @@ class EqualsTest extends TestCase
     public function testCreatingConstraintUsesErrorMessageIdIfSpecified(): void
     {
         $annotation = new Equals(['value' => 'val', 'errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
+        $this->assertSame('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
     }
 
     public function testNotSettingValueThrowsException(): void
@@ -48,7 +48,7 @@ class EqualsTest extends TestCase
     public function testSettingErrorMessageId(): void
     {
         $annotation = new Equals(['value' => 'val', 'errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->errorMessageId);
+        $this->assertSame('foo', $annotation->errorMessageId);
     }
 
     public function testSettingNullValueIsAccepted(): void
@@ -60,6 +60,6 @@ class EqualsTest extends TestCase
     public function testSettingStringValueIsAccepted(): void
     {
         $annotation = new Equals(['value' => 'foo']);
-        $this->assertEquals('foo', $annotation->value);
+        $this->assertSame('foo', $annotation->value);
     }
 }

--- a/src/Validation/tests/Constraints/Annotations/IPAddressTest.php
+++ b/src/Validation/tests/Constraints/Annotations/IPAddressTest.php
@@ -34,7 +34,7 @@ class IPAddressTest extends TestCase
     public function testCreatingConstraintUsesErrorMessageIdIfSpecified(): void
     {
         $annotation = new IPAddress(['errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
+        $this->assertSame('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
     }
 
     public function testCreatingWithEmptyArrayCreatesInstance(): void
@@ -48,6 +48,6 @@ class IPAddressTest extends TestCase
     public function testSettingErrorMessageId(): void
     {
         $annotation = new IPAddress(['errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->errorMessageId);
+        $this->assertSame('foo', $annotation->errorMessageId);
     }
 }

--- a/src/Validation/tests/Constraints/Annotations/InTest.php
+++ b/src/Validation/tests/Constraints/Annotations/InTest.php
@@ -35,7 +35,7 @@ class InTest extends TestCase
     public function testCreatingConstraintUsesErrorMessageIdIfSpecified(): void
     {
         $annotation = new In(['value' => [1], 'errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
+        $this->assertSame('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
     }
 
     public function testNotSettingArrayValuesThrowsException(): void
@@ -48,7 +48,7 @@ class InTest extends TestCase
     public function testSettingErrorMessageId(): void
     {
         $annotation = new In(['value' => [123], 'errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->errorMessageId);
+        $this->assertSame('foo', $annotation->errorMessageId);
     }
 
     public function testValuesCanBeSetViaValue(): void

--- a/src/Validation/tests/Constraints/Annotations/IntegerTest.php
+++ b/src/Validation/tests/Constraints/Annotations/IntegerTest.php
@@ -34,7 +34,7 @@ class IntegerTest extends TestCase
     public function testCreatingConstraintUsesErrorMessageIdIfSpecified(): void
     {
         $annotation = new Integer(['errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
+        $this->assertSame('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
     }
 
     public function testCreatingWithEmptyArrayCreatesInstance(): void
@@ -48,6 +48,6 @@ class IntegerTest extends TestCase
     public function testSettingErrorMessageId(): void
     {
         $annotation = new Integer(['errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->errorMessageId);
+        $this->assertSame('foo', $annotation->errorMessageId);
     }
 }

--- a/src/Validation/tests/Constraints/Annotations/MaxTest.php
+++ b/src/Validation/tests/Constraints/Annotations/MaxTest.php
@@ -35,7 +35,7 @@ class MaxTest extends TestCase
     public function testCreatingConstraintUsesErrorMessageIdIfSpecified(): void
     {
         $annotation = new Max(['value' => 1, 'errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
+        $this->assertSame('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
     }
 
     public function testIsInclusiveCanBeSetViaConstructor(): void
@@ -53,13 +53,13 @@ class MaxTest extends TestCase
     public function testMaxCanBeSetViaMax(): void
     {
         $annotation = new Max(['max' => 2]);
-        $this->assertEquals(2, $annotation->max);
+        $this->assertSame(2, $annotation->max);
     }
 
     public function testMaxCanBeSetViaValue(): void
     {
         $annotation = new Max(['value' => 2]);
-        $this->assertEquals(2, $annotation->max);
+        $this->assertSame(2, $annotation->max);
     }
 
     public function testNotSettingMaxThrowsException(): void
@@ -79,6 +79,6 @@ class MaxTest extends TestCase
     public function testSettingErrorMessageId(): void
     {
         $annotation = new Max(['value' => 1, 'errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->errorMessageId);
+        $this->assertSame('foo', $annotation->errorMessageId);
     }
 }

--- a/src/Validation/tests/Constraints/Annotations/MinTest.php
+++ b/src/Validation/tests/Constraints/Annotations/MinTest.php
@@ -35,7 +35,7 @@ class MinTest extends TestCase
     public function testCreatingConstraintUsesErrorMessageIdIfSpecified(): void
     {
         $annotation = new Min(['value' => 1, 'errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
+        $this->assertSame('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
     }
 
     public function testIsInclusiveCanBeSetViaConstructor(): void
@@ -53,13 +53,13 @@ class MinTest extends TestCase
     public function testMaxCanBeSetViaMax(): void
     {
         $annotation = new Min(['min' => 2]);
-        $this->assertEquals(2, $annotation->min);
+        $this->assertSame(2, $annotation->min);
     }
 
     public function testMaxCanBeSetViaValue(): void
     {
         $annotation = new Min(['value' => 2]);
-        $this->assertEquals(2, $annotation->min);
+        $this->assertSame(2, $annotation->min);
     }
 
     public function testNotSettingMaxThrowsException(): void
@@ -79,6 +79,6 @@ class MinTest extends TestCase
     public function testSettingErrorMessageId(): void
     {
         $annotation = new Min(['value' => 1, 'errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->errorMessageId);
+        $this->assertSame('foo', $annotation->errorMessageId);
     }
 }

--- a/src/Validation/tests/Constraints/Annotations/NotInTest.php
+++ b/src/Validation/tests/Constraints/Annotations/NotInTest.php
@@ -35,7 +35,7 @@ class NotInTest extends TestCase
     public function testCreatingConstraintUsesErrorMessageIdIfSpecified(): void
     {
         $annotation = new NotIn(['value' => ['val'], 'errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
+        $this->assertSame('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
     }
 
     public function testNotSettingArrayValuesThrowsException(): void
@@ -48,7 +48,7 @@ class NotInTest extends TestCase
     public function testSettingErrorMessageId(): void
     {
         $annotation = new NotIn(['value' => ['val'], 'errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->errorMessageId);
+        $this->assertSame('foo', $annotation->errorMessageId);
     }
 
     public function testValuesCanBeSetViaValue(): void

--- a/src/Validation/tests/Constraints/Annotations/NumericTest.php
+++ b/src/Validation/tests/Constraints/Annotations/NumericTest.php
@@ -34,7 +34,7 @@ class NumericTest extends TestCase
     public function testCreatingConstraintUsesErrorMessageIdIfSpecified(): void
     {
         $annotation = new Numeric(['errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
+        $this->assertSame('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
     }
 
     public function testCreatingWithEmptyArrayCreatesInstance(): void
@@ -48,6 +48,6 @@ class NumericTest extends TestCase
     public function testSettingErrorMessageId(): void
     {
         $annotation = new Numeric(['errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->errorMessageId);
+        $this->assertSame('foo', $annotation->errorMessageId);
     }
 }

--- a/src/Validation/tests/Constraints/Annotations/RegexTest.php
+++ b/src/Validation/tests/Constraints/Annotations/RegexTest.php
@@ -35,7 +35,7 @@ class RegexTest extends TestCase
     public function testCreatingConstraintUsesErrorMessageIdIfSpecified(): void
     {
         $annotation = new Regex(['value' => 'regex', 'errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
+        $this->assertSame('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
     }
 
     public function testNotSettingValueThrowsException(): void
@@ -48,7 +48,7 @@ class RegexTest extends TestCase
     public function testSettingErrorMessageId(): void
     {
         $annotation = new Regex(['value' => 'regex', 'errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->errorMessageId);
+        $this->assertSame('foo', $annotation->errorMessageId);
     }
 
     public function testSettingInvalidValueThrowsException(): void
@@ -61,6 +61,6 @@ class RegexTest extends TestCase
     public function testSettingValueSetsRegex(): void
     {
         $annotation = new Regex(['value' => 'foo']);
-        $this->assertEquals('foo', $annotation->regex);
+        $this->assertSame('foo', $annotation->regex);
     }
 }

--- a/src/Validation/tests/Constraints/Annotations/RequiredTest.php
+++ b/src/Validation/tests/Constraints/Annotations/RequiredTest.php
@@ -34,7 +34,7 @@ class RequiredTest extends TestCase
     public function testCreatingConstraintUsesErrorMessageIdIfSpecified(): void
     {
         $annotation = new Required(['errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
+        $this->assertSame('foo', $annotation->createConstraintFromAnnotation()->getErrorMessageId());
     }
 
     public function testCreatingWithEmptyArrayCreatesInstance(): void
@@ -48,6 +48,6 @@ class RequiredTest extends TestCase
     public function testSettingErrorMessageId(): void
     {
         $annotation = new Required(['errorMessageId' => 'foo']);
-        $this->assertEquals('foo', $annotation->errorMessageId);
+        $this->assertSame('foo', $annotation->errorMessageId);
     }
 }

--- a/src/Validation/tests/Constraints/BetweenConstraintTest.php
+++ b/src/Validation/tests/Constraints/BetweenConstraintTest.php
@@ -28,7 +28,7 @@ class BetweenConstraintTest extends TestCase
     public function testGettingErrorMessageId(): void
     {
         $constraint = new BetweenConstraint(1, 2, true, true, 'foo');
-        $this->assertEquals('foo', $constraint->getErrorMessageId());
+        $this->assertSame('foo', $constraint->getErrorMessageId());
     }
 
     public function testGettingErrorPlaceholders(): void

--- a/src/Validation/tests/Constraints/CallbackConstraintTest.php
+++ b/src/Validation/tests/Constraints/CallbackConstraintTest.php
@@ -47,7 +47,7 @@ class CallbackConstraintTest extends TestCase
     public function testGettingErrorMessageId(): void
     {
         $constraint = new CallbackConstraint(fn () => true, 'foo');
-        $this->assertEquals('foo', $constraint->getErrorMessageId());
+        $this->assertSame('foo', $constraint->getErrorMessageId());
     }
 
     public function testGettingErrorMessagePlaceholdersIncludesValue(): void

--- a/src/Validation/tests/Constraints/DateConstraintTest.php
+++ b/src/Validation/tests/Constraints/DateConstraintTest.php
@@ -38,7 +38,7 @@ class DateConstraintTest extends TestCase
     public function testGettingErrorMessageId(): void
     {
         $constraint = new DateConstraint(['Ymd'], 'foo');
-        $this->assertEquals('foo', $constraint->getErrorMessageId());
+        $this->assertSame('foo', $constraint->getErrorMessageId());
     }
 
     public function testGettingErrorMessagePlaceholdersIncludesValue(): void

--- a/src/Validation/tests/Constraints/EmailConstraintTest.php
+++ b/src/Validation/tests/Constraints/EmailConstraintTest.php
@@ -20,7 +20,7 @@ class EmailConstraintTest extends TestCase
     public function testGettingErrorMessageId(): void
     {
         $constraint = new EmailConstraint('foo');
-        $this->assertEquals('foo', $constraint->getErrorMessageId());
+        $this->assertSame('foo', $constraint->getErrorMessageId());
     }
 
     public function testGettingErrorMessagePlaceholdersIncludesValue(): void

--- a/src/Validation/tests/Constraints/EqualsConstraintTest.php
+++ b/src/Validation/tests/Constraints/EqualsConstraintTest.php
@@ -26,7 +26,7 @@ class EqualsConstraintTest extends TestCase
     public function testGettingErrorMessageId(): void
     {
         $constraint = new EqualsConstraint('foo', 'bar');
-        $this->assertEquals('bar', $constraint->getErrorMessageId());
+        $this->assertSame('bar', $constraint->getErrorMessageId());
     }
 
     public function testGettingErrorMessagePlaceholdersIncludesValue(): void

--- a/src/Validation/tests/Constraints/IPAddressConstraintTest.php
+++ b/src/Validation/tests/Constraints/IPAddressConstraintTest.php
@@ -27,7 +27,7 @@ class IPAddressConstraintTest extends TestCase
     public function testGettingErrorMessageId(): void
     {
         $constraint = new IPAddressConstraint('foo');
-        $this->assertEquals('foo', $constraint->getErrorMessageId());
+        $this->assertSame('foo', $constraint->getErrorMessageId());
     }
 
     public function testGettingErrorMessagePlaceholdersIncludesValue(): void

--- a/src/Validation/tests/Constraints/InConstraintTest.php
+++ b/src/Validation/tests/Constraints/InConstraintTest.php
@@ -20,7 +20,7 @@ class InConstraintTest extends TestCase
     public function testGettingErrorMessageId(): void
     {
         $constraint = new InConstraint([], 'foo');
-        $this->assertEquals('foo', $constraint->getErrorMessageId());
+        $this->assertSame('foo', $constraint->getErrorMessageId());
     }
 
     public function testGettingErrorMessagePlaceholdersIncludesValue(): void

--- a/src/Validation/tests/Constraints/IntegerConstraintTest.php
+++ b/src/Validation/tests/Constraints/IntegerConstraintTest.php
@@ -29,7 +29,7 @@ class IntegerConstraintTest extends TestCase
     public function testGettingErrorMessageId(): void
     {
         $constraint = new IntegerConstraint('foo');
-        $this->assertEquals('foo', $constraint->getErrorMessageId());
+        $this->assertSame('foo', $constraint->getErrorMessageId());
     }
 
     public function testGettingErrorMessagePlaceholdersIncludesValue(): void

--- a/src/Validation/tests/Constraints/MaxConstraintTest.php
+++ b/src/Validation/tests/Constraints/MaxConstraintTest.php
@@ -28,7 +28,7 @@ class MaxConstraintTest extends TestCase
     public function testGettingErrorMessageId(): void
     {
         $constraint = new MaxConstraint(1, true, 'foo');
-        $this->assertEquals('foo', $constraint->getErrorMessageId());
+        $this->assertSame('foo', $constraint->getErrorMessageId());
     }
 
     public function testGettingErrorPlaceholders(): void

--- a/src/Validation/tests/Constraints/MinConstraintTest.php
+++ b/src/Validation/tests/Constraints/MinConstraintTest.php
@@ -28,7 +28,7 @@ class MinConstraintTest extends TestCase
     public function testGettingErrorMessageId(): void
     {
         $constraint = new MinConstraint(1, true, 'foo');
-        $this->assertEquals('foo', $constraint->getErrorMessageId());
+        $this->assertSame('foo', $constraint->getErrorMessageId());
     }
 
     public function testGettingErrorPlaceholders(): void

--- a/src/Validation/tests/Constraints/NotInConstraintTest.php
+++ b/src/Validation/tests/Constraints/NotInConstraintTest.php
@@ -20,7 +20,7 @@ class NotInConstraintTest extends TestCase
     public function testGettingErrorMessageId(): void
     {
         $constraint = new NotInConstraint([], 'foo');
-        $this->assertEquals('foo', $constraint->getErrorMessageId());
+        $this->assertSame('foo', $constraint->getErrorMessageId());
     }
 
     public function testGettingErrorMessagePlaceholdersIncludesValue(): void

--- a/src/Validation/tests/Constraints/NumericConstraintTest.php
+++ b/src/Validation/tests/Constraints/NumericConstraintTest.php
@@ -27,7 +27,7 @@ class NumericConstraintTest extends TestCase
     public function testGettingErrorMessageId(): void
     {
         $constraint = new NumericConstraint('foo');
-        $this->assertEquals('foo', $constraint->getErrorMessageId());
+        $this->assertSame('foo', $constraint->getErrorMessageId());
     }
 
     public function testGettingErrorMessagePlaceholdersIncludesValue(): void

--- a/src/Validation/tests/Constraints/ObjectConstraintsTest.php
+++ b/src/Validation/tests/Constraints/ObjectConstraintsTest.php
@@ -71,7 +71,7 @@ class ObjectConstraintsTest extends TestCase
     public function testGettingClassReturnsOneSetInConstructor(): void
     {
         $objectConstraints = new ObjectConstraints('foo', [], []);
-        $this->assertEquals('foo', $objectConstraints->getClassName());
+        $this->assertSame('foo', $objectConstraints->getClassName());
     }
 
     public function testGettingMethodConstraintsForMethodWithoutAnyReturnsEmptyArray(): void

--- a/src/Validation/tests/Constraints/RegexConstraintTest.php
+++ b/src/Validation/tests/Constraints/RegexConstraintTest.php
@@ -20,7 +20,7 @@ class RegexConstraintTest extends TestCase
     public function testGettingErrorMessageId(): void
     {
         $constraint = new RegexConstraint('/foo/', 'foo');
-        $this->assertEquals('foo', $constraint->getErrorMessageId());
+        $this->assertSame('foo', $constraint->getErrorMessageId());
     }
 
     public function testGettingErrorMessagePlaceholdersIncludesValue(): void

--- a/src/Validation/tests/Constraints/RequiredConstraintTest.php
+++ b/src/Validation/tests/Constraints/RequiredConstraintTest.php
@@ -32,7 +32,7 @@ class RequiredConstraintTest extends TestCase
     public function testGettingErrorMessageId(): void
     {
         $constraint = new RequiredConstraint('foo');
-        $this->assertEquals('foo', $constraint->getErrorMessageId());
+        $this->assertSame('foo', $constraint->getErrorMessageId());
     }
 
     public function testGettingErrorMessagePlaceholdersIncludesValue(): void

--- a/src/Validation/tests/ErrorMessages/DefaultErrorMessageTemplateRegistryTest.php
+++ b/src/Validation/tests/ErrorMessages/DefaultErrorMessageTemplateRegistryTest.php
@@ -20,7 +20,7 @@ class DefaultErrorMessageTemplateRegistryTest extends TestCase
     public function testGetErrorMessageTemplateReturnsErrorMessageIdRegardlessOfLocale(): void
     {
         $errorMessageTemplates = new DefaultErrorMessageTemplateRegistry();
-        $this->assertEquals('foo', $errorMessageTemplates->getErrorMessageTemplate('foo'));
-        $this->assertEquals('foo', $errorMessageTemplates->getErrorMessageTemplate('foo', 'de'));
+        $this->assertSame('foo', $errorMessageTemplates->getErrorMessageTemplate('foo'));
+        $this->assertSame('foo', $errorMessageTemplates->getErrorMessageTemplate('foo', 'de'));
     }
 }

--- a/src/Validation/tests/ErrorMessages/IcuFormatErrorMessageInterpolatorTest.php
+++ b/src/Validation/tests/ErrorMessages/IcuFormatErrorMessageInterpolatorTest.php
@@ -22,7 +22,7 @@ class IcuFormatErrorMessageInterpolatorTest extends TestCase
     public function testInterpolatingCorrectlyFormatsIcuFormattedErrorMessageIdWithNoPlaceholders(): void
     {
         $interpolator = new IcuFormatErrorMessageInterpolator();
-        $this->assertEquals(
+        $this->assertSame(
             'foo bar',
             $interpolator->interpolate('foo bar')
         );
@@ -31,7 +31,7 @@ class IcuFormatErrorMessageInterpolatorTest extends TestCase
     public function testInterpolatingCorrectlyFormatsIcuFormattedErrorMessageIdWithFallbackLocale(): void
     {
         $interpolator = new IcuFormatErrorMessageInterpolator(null, 'de');
-        $this->assertEquals(
+        $this->assertSame(
             'Dave has $1,23',
             $interpolator->interpolate('Dave has ${amount, number}', ['amount' => 1.23])
         );
@@ -40,7 +40,7 @@ class IcuFormatErrorMessageInterpolatorTest extends TestCase
     public function testInterpolatingCorrectlyFormatsIcuFormattedErrorMessageIdWithInputLocale(): void
     {
         $interpolator = new IcuFormatErrorMessageInterpolator();
-        $this->assertEquals(
+        $this->assertSame(
             'Dave has $1,23',
             $interpolator->interpolate('Dave has ${amount, number}', ['amount' => 1.23], 'de')
         );
@@ -49,7 +49,7 @@ class IcuFormatErrorMessageInterpolatorTest extends TestCase
     public function testInterpolatingCorrectlyFormatsIcuFormattedErrorMessageIdWithPlaceholders(): void
     {
         $interpolator = new IcuFormatErrorMessageInterpolator();
-        $this->assertEquals(
+        $this->assertSame(
             'Dave has $1.23',
             $interpolator->interpolate('Dave has ${amount, number}', ['amount' => 1.23])
         );
@@ -71,14 +71,14 @@ class IcuFormatErrorMessageInterpolatorTest extends TestCase
             ->with('foo', 'en-US')
             ->willReturn('bar');
         $interpolator = new IcuFormatErrorMessageInterpolator($errorMessageTemplates);
-        $this->assertEquals('bar', $interpolator->interpolate('foo', [], 'en-US'));
+        $this->assertSame('bar', $interpolator->interpolate('foo', [], 'en-US'));
     }
 
     public function testSettingDefaultLocaleCausesInterpolationToUseItAsFallbackLocale(): void
     {
         $interpolator = new IcuFormatErrorMessageInterpolator();
         $interpolator->setDefaultLocale('de');
-        $this->assertEquals(
+        $this->assertSame(
             'Dave has $1,23',
             $interpolator->interpolate('Dave has ${amount, number}', ['amount' => 1.23])
         );

--- a/src/Validation/tests/ErrorMessages/StringReplaceErrorMessageInterpolatorTest.php
+++ b/src/Validation/tests/ErrorMessages/StringReplaceErrorMessageInterpolatorTest.php
@@ -21,7 +21,7 @@ class StringReplaceErrorMessageInterpolatorTest extends TestCase
     public function testErrorMessageIdWithNoPlaceholdersIsReturnedIntact(): void
     {
         $interpolator = new StringReplaceErrorMessageInterpolator();
-        $this->assertEquals('foo bar', $interpolator->interpolate('foo bar'));
+        $this->assertSame('foo bar', $interpolator->interpolate('foo bar'));
     }
 
     public function testInterpolatingGetsErrorMessageTemplateFromRegistry(): void
@@ -32,19 +32,19 @@ class StringReplaceErrorMessageInterpolatorTest extends TestCase
             ->with('foo', 'en-US')
             ->willReturn('bar');
         $interpolator = new StringReplaceErrorMessageInterpolator($errorMessageTemplates);
-        $this->assertEquals('bar', $interpolator->interpolate('foo', [], 'en-US'));
+        $this->assertSame('bar', $interpolator->interpolate('foo', [], 'en-US'));
     }
 
     public function testLeftoverUnusedPlaceholdersAreRemovedFromInterpolatedErrorMessage(): void
     {
         $interpolator = new StringReplaceErrorMessageInterpolator();
-        $this->assertEquals('foo ', $interpolator->interpolate('foo {bar}'));
+        $this->assertSame('foo ', $interpolator->interpolate('foo {bar}'));
     }
 
     public function testPlaceholdersArePopulated(): void
     {
         $interpolator = new StringReplaceErrorMessageInterpolator();
-        $this->assertEquals(
+        $this->assertSame(
             'foo dave young',
             $interpolator->interpolate('foo {bar} {baz}', ['bar' => 'dave', 'baz' => 'young'])
         );
@@ -54,6 +54,6 @@ class StringReplaceErrorMessageInterpolatorTest extends TestCase
     {
         $interpolator = new StringReplaceErrorMessageInterpolator();
         $interpolator->setDefaultLocale('foo');
-        $this->assertEquals('foo dave', $interpolator->interpolate('foo {bar}', ['bar' => 'dave']));
+        $this->assertSame('foo dave', $interpolator->interpolate('foo {bar}', ['bar' => 'dave']));
     }
 }

--- a/src/Validation/tests/ValidationContextTest.php
+++ b/src/Validation/tests/ValidationContextTest.php
@@ -125,13 +125,13 @@ class ValidationContextTest extends TestCase
     public function testGettingMethodNameReturnsOneSetInConstructor(): void
     {
         $context = new ValidationContext($this, null, 'method');
-        $this->assertEquals('method', $context->getMethodName());
+        $this->assertSame('method', $context->getMethodName());
     }
 
     public function testGettingPropertyNameReturnsOneSetInConstructor(): void
     {
         $context = new ValidationContext($this, 'prop');
-        $this->assertEquals('prop', $context->getPropertyName());
+        $this->assertSame('prop', $context->getPropertyName());
     }
 
     public function testGettingRootValueReturnsParentValueIfParentContextExists(): void
@@ -203,6 +203,6 @@ class ValidationContextTest extends TestCase
     public function testGettingValueReturnsOneSetInConstructor(): void
     {
         $context = new ValidationContext(1);
-        $this->assertEquals(1, $context->getValue());
+        $this->assertSame(1, $context->getValue());
     }
 }

--- a/src/Validation/tests/ValidatorTest.php
+++ b/src/Validation/tests/ValidatorTest.php
@@ -162,10 +162,10 @@ class ValidatorTest extends TestCase
         $violations = [];
         $this->assertFalse($this->validator->tryValidateMethod($object, 'method', $violations));
         $this->assertCount(1, $violations);
-        $this->assertEquals('error', $violations[0]->getErrorMessage());
+        $this->assertSame('error', $violations[0]->getErrorMessage());
         $this->assertSame($constraints[0], $violations[0]->getConstraint());
         $this->assertEquals($object, $violations[0]->getRootValue());
-        $this->assertEquals(1, $violations[0]->getInvalidValue());
+        $this->assertSame(1, $violations[0]->getInvalidValue());
     }
 
     public function testTryValidateMethodWithValidValueHasNoConstraintViolations(): void
@@ -273,10 +273,10 @@ class ValidatorTest extends TestCase
         $violations = [];
         $this->assertFalse($this->validator->tryValidateObject($object, $violations));
         $this->assertCount(1, $violations);
-        $this->assertEquals('error', $violations[0]->getErrorMessage());
+        $this->assertSame('error', $violations[0]->getErrorMessage());
         $this->assertSame($constraints[0], $violations[0]->getConstraint());
         $this->assertEquals($object, $violations[0]->getRootValue());
-        $this->assertEquals(1, $violations[0]->getInvalidValue());
+        $this->assertSame(1, $violations[0]->getInvalidValue());
     }
 
     public function testTryValidatePropertyReturnsFalseForInvalidValue(): void
@@ -377,10 +377,10 @@ class ValidatorTest extends TestCase
         $violations = [];
         $this->assertFalse($this->validator->tryValidateProperty($object, 'prop', $violations));
         $this->assertCount(1, $violations);
-        $this->assertEquals('error', $violations[0]->getErrorMessage());
+        $this->assertSame('error', $violations[0]->getErrorMessage());
         $this->assertSame($constraints[0], $violations[0]->getConstraint());
         $this->assertEquals($object, $violations[0]->getRootValue());
-        $this->assertEquals(1, $violations[0]->getInvalidValue());
+        $this->assertSame(1, $violations[0]->getInvalidValue());
     }
 
     public function testTryValidateValueWithInvalidValueSetsConstraintViolations(): void
@@ -391,8 +391,8 @@ class ValidatorTest extends TestCase
         $this->assertFalse($this->validator->tryValidateValue('foo', $constraints, $violations));
         $this->assertCount(1, $violations);
         $this->assertSame($constraints[0], $violations[0]->getConstraint());
-        $this->assertEquals('foo', $violations[0]->getRootValue());
-        $this->assertEquals('foo', $violations[0]->getInvalidValue());
+        $this->assertSame('foo', $violations[0]->getRootValue());
+        $this->assertSame('foo', $violations[0]->getInvalidValue());
     }
 
     public function testTryValidateValueWithValidValueHasNoConstraintViolations(): void


### PR DESCRIPTION
# Changed log

- To make assertion equals strict, it should use `assertSame` to let developers know current expected and actual assertions.