### PR TITLE
Updated to PHPUnit 9.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "nyholm/psr7": "^1.2",
-        "phpunit/phpunit": "~9.1"
+        "phpunit/phpunit": "~9.3"
     },
     "scripts": {
         "lint-check": "php-cs-fixer fix --config=.php_cs.dist -v --diff --dry-run",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,14 @@
-<phpunit
-    bootstrap="phpunit.bootstrap.php"
-    colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="phpunit.bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src/*/src</directory>
+        </include>
+        <report>
+          <html outputDirectory="./.coverage"/>
+        </report>
+    </coverage>
     <testsuite name="Aphiria">
         <directory>src/*/tests</directory>
     </testsuite>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/*/src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="./.coverage"/>
-    </logging>
 </phpunit>

--- a/src/Api/composer.json
+++ b/src/Api/composer.json
@@ -37,7 +37,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-coveralls/php-coveralls": "^2.2",
-        "phpunit/phpunit": "~9.1"
+        "phpunit/phpunit": "~9.3"
     },
     "scripts": {
         "lint-check": "php-cs-fixer fix --config=.php_cs.dist -v --diff --dry-run",

--- a/src/Api/phpunit.xml.dist
+++ b/src/Api/phpunit.xml.dist
@@ -1,15 +1,14 @@
-<phpunit
-    bootstrap="vendor/autoload.php"
-    colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <html outputDirectory="./.coverage"/>
+        </report>
+    </coverage>
     <testsuite name="API">
         <directory>tests</directory>
     </testsuite>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="./.coverage"/>
-    </logging>
 </phpunit>

--- a/src/Api/tests/Mocks/MiddlewareThatIncrementsHeader.php
+++ b/src/Api/tests/Mocks/MiddlewareThatIncrementsHeader.php
@@ -27,7 +27,6 @@ class MiddlewareThatIncrementsHeader implements IMiddleware
      */
     public function handle(IRequest $request, IRequestHandler $next): IResponse
     {
-        /** @var IResponse $response */
         $response = $next->handle($request);
         $currValues = [];
 

--- a/src/Api/tests/RouterTest.php
+++ b/src/Api/tests/RouterTest.php
@@ -69,14 +69,9 @@ class RouterTest extends TestCase
         $middlewareBinding = new MiddlewareBinding(AttributeMiddleware::class, ['foo' => 'bar']);
         $request = $this->createRequestMock('GET', 'http://foo.com/bar');
         $controller = new ControllerMock();
-        $this->serviceResolver->expects($this->at(0))
-            ->method('resolve')
-            ->with(ControllerMock::class)
-            ->willReturn($controller);
-        $this->serviceResolver->expects($this->at(1))
-            ->method('resolve')
-            ->with(AttributeMiddleware::class)
-            ->willReturn($middleware);
+        $this->serviceResolver->method('resolve')
+            ->withConsecutive([ControllerMock::class], [AttributeMiddleware::class])
+            ->willReturnOnConsecutiveCalls($controller, $middleware);
         $matchingResult = new RouteMatchingResult(
             new Route(
                 new UriTemplate('foo'),
@@ -104,14 +99,9 @@ class RouterTest extends TestCase
         $middlewareBinding = new MiddlewareBinding(__CLASS__);
         $request = $this->createRequestMock('GET', 'http://foo.com/bar');
         $controller = new ControllerMock();
-        $this->serviceResolver->expects($this->at(0))
-            ->method('resolve')
-            ->with(ControllerMock::class)
-            ->willReturn($controller);
-        $this->serviceResolver->expects($this->at(1))
-            ->method('resolve')
-            ->with(__CLASS__)
-            ->willReturn($middleware);
+        $this->serviceResolver->method('resolve')
+            ->withConsecutive([ControllerMock::class], [__CLASS__])
+            ->willReturnOnConsecutiveCalls($controller, $middleware);
         $matchingResult = new RouteMatchingResult(
             new Route(
                 new UriTemplate('foo'),

--- a/src/Api/tests/Validation/RequestBodyValidatorTest.php
+++ b/src/Api/tests/Validation/RequestBodyValidatorTest.php
@@ -54,12 +54,8 @@ class RequestBodyValidatorTest extends TestCase
         $bodyParts = [new class() {
         }, new class() {
         }];
-        $this->validator->expects($this->at(0))
-            ->method('validateObject')
-            ->with($bodyParts[0]);
-        $this->validator->expects($this->at(1))
-            ->method('validateObject')
-            ->with($bodyParts[1]);
+        $this->validator->method('validateObject')
+            ->withConsecutive([$bodyParts[0]], [$bodyParts[1]]);
         $this->requestBodyValidator->validate($this->request, $bodyParts);
         // Dummy assertion
         $this->assertTrue(true);

--- a/src/Application/composer.json
+++ b/src/Application/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-coveralls/php-coveralls": "^2.2",
-        "phpunit/phpunit": "~9.1"
+        "phpunit/phpunit": "~9.3"
     },
     "scripts": {
         "lint-check": "php-cs-fixer fix --config=.php_cs.dist -v --diff --dry-run",

--- a/src/Application/phpunit.xml.dist
+++ b/src/Application/phpunit.xml.dist
@@ -1,15 +1,14 @@
-<phpunit
-    bootstrap="vendor/autoload.php"
-    colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <html outputDirectory="./.coverage"/>
+        </report>
+    </coverage>
     <testsuite name="Application">
         <directory>tests</directory>
     </testsuite>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="./.coverage"/>
-    </logging>
 </phpunit>

--- a/src/Collections/composer.json
+++ b/src/Collections/composer.json
@@ -34,7 +34,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-coveralls/php-coveralls": "^2.2",
-        "phpunit/phpunit": "~9.1"
+        "phpunit/phpunit": "~9.3"
     },
     "scripts": {
         "lint-check": "php-cs-fixer fix --config=.php_cs.dist -v --diff --dry-run",

--- a/src/Collections/phpunit.xml.dist
+++ b/src/Collections/phpunit.xml.dist
@@ -1,15 +1,14 @@
-<phpunit
-    bootstrap="vendor/autoload.php"
-    colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <html outputDirectory="./.coverage"/>
+        </report>
+    </coverage>
     <testsuite name="Collections">
         <directory>tests</directory>
     </testsuite>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="./.coverage"/>
-    </logging>
 </phpunit>

--- a/src/Console/composer.json
+++ b/src/Console/composer.json
@@ -33,7 +33,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-coveralls/php-coveralls": "^2.2",
-        "phpunit/phpunit": "~9.1"
+        "phpunit/phpunit": "~9.3"
     },
     "scripts": {
         "lint-check": "php-cs-fixer fix --config=.php_cs.dist -v --diff --dry-run",

--- a/src/Console/phpunit.xml.dist
+++ b/src/Console/phpunit.xml.dist
@@ -1,15 +1,14 @@
-<phpunit
-    bootstrap="phpunit.bootstrap.php"
-    colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="phpunit.bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <html outputDirectory="./.coverage"/>
+        </report>
+    </coverage>
     <testsuite name="Console">
         <directory>tests</directory>
     </testsuite>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="./.coverage"/>
-    </logging>
 </phpunit>

--- a/src/Console/tests/Commands/CommandRegistrantCollectionTest.php
+++ b/src/Console/tests/Commands/CommandRegistrantCollectionTest.php
@@ -46,8 +46,7 @@ class CommandRegistrantCollectionTest extends TestCase
         $cachedCommands = new CommandRegistry();
         $cachedCommands->registerCommand(new Command('foo'), 'Handler');
         $cache = $this->createMock(ICommandRegistryCache::class);
-        $cache->expects($this->at(0))
-            ->method('get')
+        $cache->method('get')
             ->willReturn($cachedCommands);
         $collection = new CommandRegistrantCollection($cache);
         $paramCommands = new CommandRegistry();
@@ -59,13 +58,13 @@ class CommandRegistrantCollectionTest extends TestCase
     {
         $expectedCommands = new CommandRegistry();
         $cache = $this->createMock(ICommandRegistryCache::class);
-        $cache->expects($this->at(0))
-            ->method('get')
+        $cache->method('get')
             ->willReturn(null);
-        $cache->expects($this->at(1))
-            ->method('set')
+        $cache->method('set')
             ->with($expectedCommands);
         $collection = new CommandRegistrantCollection($cache);
         $collection->registerCommands($expectedCommands);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 }

--- a/src/Console/tests/Commands/Defaults/AboutCommandHandlerTest.php
+++ b/src/Console/tests/Commands/Defaults/AboutCommandHandlerTest.php
@@ -37,8 +37,7 @@ class AboutCommandHandlerTest extends TestCase
         $driver->expects($this->once())
             ->method('getCliWidth')
             ->willReturn(3);
-        $this->output->expects($this->at(0))
-            ->method('getDriver')
+        $this->output->method('getDriver')
             ->willReturn($driver);
     }
 
@@ -50,8 +49,7 @@ class AboutCommandHandlerTest extends TestCase
             . '  <info>ant:bar</info>' . \PHP_EOL
             . '<comment>cat</comment>' . \PHP_EOL
             . '  <info>cat:foo</info>';
-        $this->output->expects($this->at(1))
-            ->method('writeln')
+        $this->output->method('writeln')
             ->with(self::compileOutput($body));
         $this->handler->handle(new Input('about', [], []), $this->output);
     }
@@ -63,8 +61,7 @@ class AboutCommandHandlerTest extends TestCase
         $body = '<comment>cat</comment>' . \PHP_EOL
             . '  <info>cat:bar</info>' . \PHP_EOL
             . '  <info>cat:foo</info>';
-        $this->output->expects($this->at(1))
-            ->method('writeln')
+        $this->output->method('writeln')
             ->with(self::compileOutput($body));
         $this->handler->handle(new Input('about', [], []), $this->output);
     }
@@ -72,8 +69,7 @@ class AboutCommandHandlerTest extends TestCase
     public function testHavingNoCommandsDisplaysMessageSayingSo(): void
     {
         $body = '  <info>No commands</info>';
-        $this->output->expects($this->at(1))
-            ->method('writeln')
+        $this->output->method('writeln')
             ->with(self::compileOutput($body));
         $this->handler->handle(new Input('about', [], []), $this->output);
     }
@@ -88,8 +84,7 @@ class AboutCommandHandlerTest extends TestCase
             . '  <info>foo    </info>' . \PHP_EOL
             . '<comment>cat</comment>' . \PHP_EOL
             . '  <info>cat:bar</info>';
-        $this->output->expects($this->at(1))
-            ->method('writeln')
+        $this->output->method('writeln')
             ->with(self::compileOutput($body));
         $this->handler->handle(new Input('about', [], []), $this->output);
     }

--- a/src/Console/tests/Commands/Defaults/HelpCommandHandlerTest.php
+++ b/src/Console/tests/Commands/Defaults/HelpCommandHandlerTest.php
@@ -61,8 +61,7 @@ class HelpCommandHandlerTest extends TestCase
             ),
             'Handler'
         );
-        $this->output->expects($this->at(1))
-            ->method('writeln')
+        $this->output->method('writeln')
             ->with(self::compileOutput('foo', 'foo', 'The description', '  No arguments', '  No options', 'The help text'));
         $this->handler->handle(new Input('help', ['command' => 'foo'], []), $this->output);
     }
@@ -79,8 +78,7 @@ class HelpCommandHandlerTest extends TestCase
             ),
             'Handler'
         );
-        $this->output->expects($this->at(1))
-            ->method('writeln')
+        $this->output->method('writeln')
             ->with(self::compileOutput('foo', 'foo arg1', 'The description', '  <info>arg1</info> - Arg1 description', '  No options'));
         $this->handler->handle(new Input('help', ['command' => 'foo'], []), $this->output);
     }
@@ -105,8 +103,7 @@ class HelpCommandHandlerTest extends TestCase
             ),
             'Handler'
         );
-        $this->output->expects($this->at(1))
-            ->method('writeln')
+        $this->output->method('writeln')
             ->with(self::compileOutput('foo', 'foo', 'The description', '  No arguments', '  No options'));
         $this->handler->handle(new Input('help', ['command' => 'foo'], []), $this->output);
     }
@@ -123,8 +120,7 @@ class HelpCommandHandlerTest extends TestCase
             ),
             'Handler'
         );
-        $this->output->expects($this->at(1))
-            ->method('writeln')
+        $this->output->method('writeln')
             ->with(self::compileOutput('foo', 'foo', 'No description', '  No arguments', '  No options'));
         $this->handler->handle(new Input('help', ['command' => 'foo'], []), $this->output);
     }
@@ -141,8 +137,7 @@ class HelpCommandHandlerTest extends TestCase
             ),
             'Handler'
         );
-        $this->output->expects($this->at(1))
-            ->method('writeln')
+        $this->output->method('writeln')
             ->with(self::compileOutput('foo', 'foo', 'No description', '  No arguments', '  No options'));
         $this->handler->handle(new Input('help', ['command' => 'foo'], []), $this->output);
     }
@@ -159,8 +154,7 @@ class HelpCommandHandlerTest extends TestCase
             ),
             'Handler'
         );
-        $this->output->expects($this->at(1))
-            ->method('writeln')
+        $this->output->method('writeln')
             ->with(self::compileOutput('foo', 'foo', 'The description', '  No arguments', '  No options'));
         $this->handler->handle(new Input('help', ['command' => 'foo'], []), $this->output);
     }
@@ -177,8 +171,7 @@ class HelpCommandHandlerTest extends TestCase
             ),
             'Handler'
         );
-        $this->output->expects($this->at(1))
-            ->method('writeln')
+        $this->output->method('writeln')
             ->with(self::compileOutput('foo', 'foo [--opt1]', 'The description', '  No arguments', '  <info>--opt1</info> - Opt1 description'));
         $this->handler->handle(new Input('help', ['command' => 'foo'], []), $this->output);
     }
@@ -195,8 +188,7 @@ class HelpCommandHandlerTest extends TestCase
             ),
             'Handler'
         );
-        $this->output->expects($this->at(1))
-            ->method('writeln')
+        $this->output->method('writeln')
             ->with(self::compileOutput('foo', 'foo [--opt1|-o]', 'The description', '  No arguments', '  <info>--opt1|-o</info> - Opt1 description'));
         $this->handler->handle(new Input('help', ['command' => 'foo'], []), $this->output);
     }
@@ -259,8 +251,7 @@ EOF;
         $driver->expects($this->once())
             ->method('getCliWidth')
             ->willReturn(3);
-        $this->output->expects($this->at(0))
-            ->method('getDriver')
+        $this->output->method('getDriver')
             ->willReturn($driver);
     }
 }

--- a/src/Console/tests/Output/Formatters/ProgressBarFormatterTest.php
+++ b/src/Console/tests/Output/Formatters/ProgressBarFormatterTest.php
@@ -58,32 +58,37 @@ class ProgressBarFormatterTest extends TestCase
     {
         // Use a redraw frequency of 0 so that it redraws every time
         $formatter = new ProgressBarFormatter($this->output, 12, null, 0);
-        $this->output->expects($this->at(1))
-            ->method('write')
-            ->with($this->callback(fn ($value) => $this->progressBarMatchesExpectedValue("\033[2K\033[0G\033[1A\033[2K[20%-------] 2/10" . \PHP_EOL . 'Time remaining:', $value, true)));
+        $this->output->method('write')
+            ->withConsecutive(
+                [$this->anything()],
+                [$this->callback(fn ($value) => $this->progressBarMatchesExpectedValue("\033[2K\033[0G\033[1A\033[2K[20%-------] 2/10" . \PHP_EOL . 'Time remaining:', $value, true))]
+            );
         $formatter->onProgressChanged(0, 1, 10);
         $formatter->onProgressChanged(1, 2, 10);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testOnProgressThatReachesMaxStepsDrawsCompleteProgressBar(): void
     {
         $formatter = new ProgressBarFormatter($this->output, 12);
-        $this->output->expects($this->at(0))
-            ->method('write')
+        $this->output->method('write')
             ->with($this->callback(fn ($value) => $this->progressBarMatchesExpectedValue('[==========] 10/10' . \PHP_EOL . 'Time remaining: Complete', $value, false)));
-        $this->output->expects($this->at(1))
-            ->method('writeln')
+        $this->output->method('writeln')
             ->with('');
         $formatter->onProgressChanged(0, 10, 10);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testOnProgressWithFormatThatIncludesPercentPopulatesPercent(): void
     {
         $formatter = new ProgressBarFormatter($this->output, null, '%percent%');
-        $this->output->expects($this->at(0))
-            ->method('write')
+        $this->output->method('write')
             ->with('50%');
         $formatter->onProgressChanged(0, 5, 10);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testOnProgressWithImpossiblyLowTimeLeftShowsCorrectTime(): void
@@ -94,11 +99,12 @@ class ProgressBarFormatterTest extends TestCase
                 return -1;
             }
         };
-        $this->output->expects($this->at(0))
-            ->method('write')
+        $this->output->method('write')
             ->with($this->callback(fn ($value) => $this->progressBarMatchesExpectedValue('[10%-------] 1/10' . \PHP_EOL . 'Time remaining: Estimating...', $value, false)));
         $formatter->numSeconds = 172800;
         $formatter->onProgressChanged(0, 1, 10);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testOnProgressWithVeryLongTimeLeftShowsCorrectTime(): void
@@ -109,19 +115,21 @@ class ProgressBarFormatterTest extends TestCase
                 return 172800;
             }
         };
-        $this->output->expects($this->at(0))
-            ->method('write')
+        $this->output->method('write')
             ->with($this->callback(fn ($value) => $this->progressBarMatchesExpectedValue('[10%-------] 1/10' . \PHP_EOL . 'Time remaining: 2 days', $value, false)));
         $formatter->onProgressChanged(0, 1, 10);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testOnProgressWithZeroProgressIndicatesThatTheTimeRemainingIsStillBeingEstimated(): void
     {
         $formatter = new ProgressBarFormatter($this->output, 12);
-        $this->output->expects($this->at(0))
-            ->method('write')
+        $this->output->method('write')
             ->with($this->callback(fn ($value) => $this->progressBarMatchesExpectedValue('[0%--------] 0/10' . \PHP_EOL . 'Time remaining: Estimating...', $value, false)));
         $formatter->onProgressChanged(null, 0, 10);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     /**
@@ -133,10 +141,11 @@ class ProgressBarFormatterTest extends TestCase
     public function testOnProgressWritesCorrectStringsForBaseCases(int $percentComplete, string $expectedString): void
     {
         $formatter = new ProgressBarFormatter($this->output, 12);
-        $this->output->expects($this->at(0))
-            ->method('write')
+        $this->output->method('write')
             ->with($this->callback(fn ($value) => $this->progressBarMatchesExpectedValue($expectedString . " $percentComplete/100" . \PHP_EOL . 'Time remaining:', $value, true)));
         $formatter->onProgressChanged(0, $percentComplete, 100);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     /**

--- a/src/Console/tests/Output/Formatters/ProgressBarTest.php
+++ b/src/Console/tests/Output/Formatters/ProgressBarTest.php
@@ -66,15 +66,13 @@ class ProgressBarTest extends TestCase
 
     public function testSettingProgressToValueLessThanZeroBoundsItToZero(): void
     {
-        $this->formatter->expects($this->at(0))
-            ->method('onProgressChanged')
-            ->with(0, 1, 100);
-        $this->formatter->expects($this->at(1))
-            ->method('onProgressChanged')
-            ->with(1, 0, 100);
+        $this->formatter->method('onProgressChanged')
+            ->withConsecutive([0, 1, 100], [1, 0, 100]);
         // Note: We're advancing at least once so that the update is sent to the formatter
         $this->progressBar->advance();
         $this->progressBar->setProgress(-1);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testSettingProgressToValueOverMaxStepsBoundsItToMaxSteps(): void
@@ -87,9 +85,10 @@ class ProgressBarTest extends TestCase
 
     public function testSettingProgressToZeroStillNotifiesObserversOfProgress(): void
     {
-        $this->formatter->expects($this->at(0))
-            ->method('onProgressChanged')
+        $this->formatter->method('onProgressChanged')
             ->with(0, 0, 100);
         $this->progressBar->setProgress(0);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 }

--- a/src/Console/tests/Output/Prompts/PromptTest.php
+++ b/src/Console/tests/Output/Prompts/PromptTest.php
@@ -53,18 +53,10 @@ class PromptTest extends TestCase
         $question = new MultipleChoice('Pick', ['foo', 'bar']);
         $this->output->method('readLine')
             ->willReturn('2');
-        $this->output->expects($this->at(0))
-            ->method('write')
-            ->with("<question>{$question->text}</question>");
-        $this->output->expects($this->at(1))
-            ->method('writeln')
-            ->with('');
-        $this->output->expects($this->at(2))
-            ->method('writeln')
-            ->with('  1) foo' . PHP_EOL . '  2) bar');
-        $this->output->expects($this->at(3))
-            ->method('write')
-            ->with('  > ');
+        $this->output->method('write')
+            ->withConsecutive(["<question>{$question->text}</question>"], ['  > ']);
+        $this->output->method('writeln')
+            ->withConsecutive([''], ['  1) foo' . PHP_EOL . '  2) bar']);
         $answer = $this->prompt->ask($question, $this->output);
         $this->assertSame('bar', $answer);
     }
@@ -74,18 +66,10 @@ class PromptTest extends TestCase
         $question = new MultipleChoice('Pick', ['a' => 'b', 'c' => 'd']);
         $this->output->method('readLine')
             ->willReturn('c');
-        $this->output->expects($this->at(0))
-            ->method('write')
-            ->with("<question>{$question->text}</question>");
-        $this->output->expects($this->at(1))
-            ->method('writeln')
-            ->with('');
-        $this->output->expects($this->at(2))
-            ->method('writeln')
-            ->with('  a) b' . PHP_EOL . '  c) d');
-        $this->output->expects($this->at(3))
-            ->method('write')
-            ->with('  > ');
+        $this->output->method('write')
+            ->withConsecutive(["<question>{$question->text}</question>"], ['  > ']);
+        $this->output->method('writeln')
+            ->withConsecutive([''], ['  a) b' . PHP_EOL . '  c) d']);
         $answer = $this->prompt->ask($question, $this->output);
         $this->assertSame('d', $answer);
     }
@@ -96,18 +80,10 @@ class PromptTest extends TestCase
         $question->setAnswerLineString('  : ');
         $this->output->method('readLine')
             ->willReturn('1');
-        $this->output->expects($this->at(0))
-            ->method('write')
-            ->with("<question>{$question->text}</question>");
-        $this->output->expects($this->at(1))
-            ->method('writeln')
-            ->with('');
-        $this->output->expects($this->at(2))
-            ->method('writeln')
-            ->with('  1) foo' . PHP_EOL . '  2) bar');
-        $this->output->expects($this->at(3))
-            ->method('write')
-            ->with('  : ');
+        $this->output->method('write')
+            ->withConsecutive(["<question>{$question->text}</question>"], ['  : ']);
+        $this->output->method('writeln')
+            ->withConsecutive([''], ['  1) foo' . PHP_EOL . '  2) bar']);
         $answer = $this->prompt->ask($question, $this->output);
         $this->assertSame('foo', $answer);
     }

--- a/src/ContentNegotiation/composer.json
+++ b/src/ContentNegotiation/composer.json
@@ -38,7 +38,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-coveralls/php-coveralls": "^2.2",
-        "phpunit/phpunit": "~9.1"
+        "phpunit/phpunit": "~9.3"
     },
     "scripts": {
         "lint-check": "php-cs-fixer fix --config=.php_cs.dist -v --diff --dry-run",

--- a/src/ContentNegotiation/phpunit.xml.dist
+++ b/src/ContentNegotiation/phpunit.xml.dist
@@ -1,15 +1,14 @@
-<phpunit
-    bootstrap="vendor/autoload.php"
-    colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <html outputDirectory="./.coverage"/>
+        </report>
+    </coverage>
     <testsuite name="ContentNegotiation">
         <directory>tests</directory>
     </testsuite>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="./.coverage"/>
-    </logging>
 </phpunit>

--- a/src/ContentNegotiation/tests/NegotiatedRequestBuilderTest.php
+++ b/src/ContentNegotiation/tests/NegotiatedRequestBuilderTest.php
@@ -77,12 +77,10 @@ class NegotiatedRequestBuilderTest extends TestCase
     public function testWithBodyWithNonHttpBodyUsesContentNegotiationToSetBody(string $expectedType, $rawBody): void
     {
         $mediaTypeFormatter = $this->createMock(IMediaTypeFormatter::class);
-        $mediaTypeFormatter->expects($this->at(0))
-            ->method('getDefaultEncoding')
+        $mediaTypeFormatter->method('getDefaultEncoding')
             ->willReturn('UTF-8');
         $expectedStream = null;
-        $mediaTypeFormatter->expects($this->at(1))
-            ->method('writeToStream')
+        $mediaTypeFormatter->method('writeToStream')
             ->with(
                 $rawBody,
                 $this->callback(function (IStream $stream) use (&$expectedStream) {

--- a/src/DependencyInjection/composer.json
+++ b/src/DependencyInjection/composer.json
@@ -33,7 +33,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-coveralls/php-coveralls": "^2.2",
-        "phpunit/phpunit": "~9.1"
+        "phpunit/phpunit": "~9.3"
     },
     "scripts": {
         "lint-check": "php-cs-fixer fix --config=.php_cs.dist -v --diff --dry-run",

--- a/src/DependencyInjection/phpunit.xml.dist
+++ b/src/DependencyInjection/phpunit.xml.dist
@@ -1,15 +1,14 @@
-<phpunit
-    bootstrap="vendor/autoload.php"
-    colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <html outputDirectory="./.coverage"/>
+        </report>
+    </coverage>
     <testsuite name="DependencyInjection">
         <directory>tests</directory>
     </testsuite>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="./.coverage"/>
-    </logging>
 </phpunit>

--- a/src/Exceptions/composer.json
+++ b/src/Exceptions/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-coveralls/php-coveralls": "^2.2",
-        "phpunit/phpunit": "~9.1"
+        "phpunit/phpunit": "~9.3"
     },
     "scripts": {
         "lint-check": "php-cs-fixer fix --config=.php_cs.dist -v --diff --dry-run",

--- a/src/Exceptions/phpunit.xml.dist
+++ b/src/Exceptions/phpunit.xml.dist
@@ -1,15 +1,14 @@
-<phpunit
-    bootstrap="vendor/autoload.php"
-    colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <html outputDirectory="./.coverage"/>
+        </report>
+    </coverage>
     <testsuite name="Exceptions">
         <directory>tests</directory>
     </testsuite>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="./.coverage"/>
-    </logging>
 </phpunit>

--- a/src/Framework/composer.json
+++ b/src/Framework/composer.json
@@ -33,7 +33,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-coveralls/php-coveralls": "^2.2",
-        "phpunit/phpunit": "~9.1"
+        "phpunit/phpunit": "~9.3"
     },
     "scripts": {
         "lint-check": "php-cs-fixer fix --config=.php_cs.dist -v --diff --dry-run",

--- a/src/Framework/phpunit.xml.dist
+++ b/src/Framework/phpunit.xml.dist
@@ -1,15 +1,14 @@
-<phpunit
-    bootstrap="vendor/autoload.php"
-    colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <html outputDirectory="./.coverage"/>
+        </report>
+    </coverage>
     <testsuite name="Framework">
         <directory>tests</directory>
     </testsuite>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="./.coverage"/>
-    </logging>
 </phpunit>

--- a/src/Framework/tests/Api/Binders/ControllerBinderTest.php
+++ b/src/Framework/tests/Api/Binders/ControllerBinderTest.php
@@ -35,33 +35,21 @@ class ControllerBinderTest extends TestCase
         $this->binder = new ControllerBinder();
 
         // Set up some universal mocks
-        $this->container->expects($this->at(0))
-            ->method('resolve')
-            ->with(IValidator::class)
-            ->willReturn($this->createMock(IValidator::class));
-        $this->container->expects($this->at(1))
-            ->method('resolve')
-            ->with(IErrorMessageInterpolator::class)
-            ->willReturn($this->createMock(IErrorMessageInterpolator::class));
-        $this->container->expects($this->at(2))
-            ->method('resolve')
-            ->with(IContentNegotiator::class)
-            ->willReturn($this->createMock(IContentNegotiator::class));
-        $this->container->expects($this->at(3))
-            ->method('resolve')
-            ->with(IContentNegotiator::class)
-            ->willReturn($this->createMock(IContentNegotiator::class));
-        $this->container->expects($this->at(4))
-            ->method('resolve')
-            ->with(IResponseFactory::class)
-            ->willReturn($this->createMock(IResponseFactory::class));
+        $this->container->method('resolve')
+            ->willReturnMap([
+                [IValidator::class, $this->createMock(IValidator::class)],
+                [IErrorMessageInterpolator::class, $this->createMock(IErrorMessageInterpolator::class)],
+                [IContentNegotiator::class, $this->createMock(IContentNegotiator::class)],
+                [IResponseFactory::class, $this->createMock(IResponseFactory::class)]
+            ]);
     }
 
     public function testRouteActionInvokerIsBound(): void
     {
-        $this->container->expects($this->at(5))
-            ->method('bindInstance')
+        $this->container->method('bindInstance')
             ->with(IRouteActionInvoker::class, $this->isInstanceOf(RouteActionInvoker::class));
         $this->binder->bind($this->container);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 }

--- a/src/Framework/tests/Api/Exceptions/ExceptionHandlerTest.php
+++ b/src/Framework/tests/Api/Exceptions/ExceptionHandlerTest.php
@@ -51,11 +51,9 @@ class ExceptionHandlerTest extends TestCase
             ->method('handle')
             ->with($request)
             ->willThrowException($expectedException);
-        $this->exceptionRenderer->expects($this->at(0))
-            ->method('setRequest')
+        $this->exceptionRenderer->method('setRequest')
             ->with($request);
-        $this->exceptionRenderer->expects($this->at(1))
-            ->method('createResponse')
+        $this->exceptionRenderer->method('createResponse')
             ->willReturn($expectedResponse);
         $this->logLevelFactory->registerLogLevelFactory(Exception::class, fn (Exception $ex) => LogLevel::EMERGENCY);
         $this->logger->expects($this->once())

--- a/src/Framework/tests/Api/Testing/ApplicationClientTest.php
+++ b/src/Framework/tests/Api/Testing/ApplicationClientTest.php
@@ -59,12 +59,10 @@ class ApplicationClientTest extends TestCase
     {
         $response = $this->createMock(IResponse::class);
         $request = $this->createMock(IRequest::class);
-        $this->container->expects($this->at(0))
-            ->method('resolve')
+        $this->container->method('resolve')
             ->with(IRequest::class)
             ->willReturn($this->createMock(IRequest::class));
-        $this->container->expects($this->at(1))
-            ->method('bindInstance')
+        $this->container->method('bindInstance')
             ->with(IRequest::class, $request);
         $this->app->expects($this->once())
             ->method('handle')

--- a/src/Framework/tests/Application/AphiriaComponentsTest.php
+++ b/src/Framework/tests/Application/AphiriaComponentsTest.php
@@ -59,12 +59,10 @@ class AphiriaComponentsTest extends TestCase
         $expectedComponent->expects($this->once())
             ->method('withBinderDispatcher')
             ->with($binderDispatcher);
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(BinderComponent::class)
             ->willReturn(true);
-        $this->appBuilder->expects($this->at(1))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(BinderComponent::class)
             ->willReturn($expectedComponent);
         $component = new class() {
@@ -80,15 +78,12 @@ class AphiriaComponentsTest extends TestCase
 
     public function testWithBinderDispatcherRegistersComponentIfItIsNotRegisteredYet(): void
     {
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(BinderComponent::class)
             ->willReturn(false);
-        $this->appBuilder->expects($this->at(1))
-            ->method('withComponent')
+        $this->appBuilder->method('withComponent')
             ->with($this->isInstanceOf(BinderComponent::class), 0);
-        $this->appBuilder->expects($this->at(2))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(BinderComponent::class)
             ->willReturn($this->createMock(BinderComponent::class));
         $component = new class() {
@@ -100,6 +95,8 @@ class AphiriaComponentsTest extends TestCase
             }
         };
         $component->build($this->appBuilder, $this->createMock(IBinderDispatcher::class));
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testWithBindersRegistersBindersToComponent(): void
@@ -114,12 +111,10 @@ class AphiriaComponentsTest extends TestCase
         $expectedComponent->expects($this->once())
             ->method('withBinders')
             ->with($binder);
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(BinderComponent::class)
             ->willReturn(true);
-        $this->appBuilder->expects($this->at(1))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(BinderComponent::class)
             ->willReturn($expectedComponent);
         $component = new class() {
@@ -135,15 +130,12 @@ class AphiriaComponentsTest extends TestCase
 
     public function testWithBindersRegistersComponentIfItIsNotRegisteredYet(): void
     {
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(BinderComponent::class)
             ->willReturn(false);
-        $this->appBuilder->expects($this->at(1))
-            ->method('withComponent')
+        $this->appBuilder->method('withComponent')
             ->with($this->isInstanceOf(BinderComponent::class), 0);
-        $this->appBuilder->expects($this->at(2))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(BinderComponent::class)
             ->willReturn($this->createMock(BinderComponent::class));
         $component = new class() {
@@ -155,6 +147,8 @@ class AphiriaComponentsTest extends TestCase
             }
         };
         $component->build($this->appBuilder, $this->createMock(Binder::class));
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testWithCommandAnnotationsConfiguresComponentToHaveAnnotations(): void
@@ -162,12 +156,10 @@ class AphiriaComponentsTest extends TestCase
         $expectedComponent = $this->createMock(CommandComponent::class);
         $expectedComponent->expects($this->once())
             ->method('withAnnotations');
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(CommandComponent::class)
             ->willReturn(true);
-        $this->appBuilder->expects($this->at(1))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(CommandComponent::class)
             ->willReturn($expectedComponent);
         $component = new class() {
@@ -183,15 +175,12 @@ class AphiriaComponentsTest extends TestCase
 
     public function testWithCommandAnnotationsRegistersComponentIfItIsNotRegisteredYet(): void
     {
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(CommandComponent::class)
             ->willReturn(false);
-        $this->appBuilder->expects($this->at(1))
-            ->method('withComponent')
+        $this->appBuilder->method('withComponent')
             ->with($this->isInstanceOf(CommandComponent::class));
-        $this->appBuilder->expects($this->at(2))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(CommandComponent::class)
             ->willReturn($this->createMock(CommandComponent::class));
         $component = new class() {
@@ -203,6 +192,8 @@ class AphiriaComponentsTest extends TestCase
             }
         };
         $component->build($this->appBuilder);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testWithCommandsConfiguresComponentToHaveCommands(): void
@@ -212,12 +203,10 @@ class AphiriaComponentsTest extends TestCase
         $expectedComponent->expects($this->once())
             ->method('withCommands')
             ->with($callback);
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(CommandComponent::class)
             ->willReturn(true);
-        $this->appBuilder->expects($this->at(1))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(CommandComponent::class)
             ->willReturn($expectedComponent);
         $component = new class() {
@@ -233,15 +222,12 @@ class AphiriaComponentsTest extends TestCase
 
     public function testWithCommandsRegistersComponentIfItIsNotRegisteredYet(): void
     {
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(CommandComponent::class)
             ->willReturn(false);
-        $this->appBuilder->expects($this->at(1))
-            ->method('withComponent')
+        $this->appBuilder->method('withComponent')
             ->with($this->isInstanceOf(CommandComponent::class));
-        $this->appBuilder->expects($this->at(2))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(CommandComponent::class)
             ->willReturn($this->createMock(CommandComponent::class));
         $component = new class() {
@@ -254,6 +240,8 @@ class AphiriaComponentsTest extends TestCase
         };
         $callback = fn (CommandRegistry $commands) => null;
         $component->build($this->appBuilder, $callback);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testWithComponentAddsComponentToAppBuilder(): void
@@ -284,12 +272,10 @@ class AphiriaComponentsTest extends TestCase
         $expectedComponent->expects($this->once())
             ->method('withConsoleOutputWriter')
             ->with(Exception::class, $outputWriter);
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(ExceptionHandlerComponent::class)
             ->willReturn(true);
-        $this->appBuilder->expects($this->at(1))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(ExceptionHandlerComponent::class)
             ->willReturn($expectedComponent);
         $component = new class() {
@@ -305,15 +291,12 @@ class AphiriaComponentsTest extends TestCase
 
     public function testWithConsoleExceptionOutputWriterRegistersComponentIfItIsNotRegisteredYet(): void
     {
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(ExceptionHandlerComponent::class)
             ->willReturn(false);
-        $this->appBuilder->expects($this->at(1))
-            ->method('withComponent')
+        $this->appBuilder->method('withComponent')
             ->with($this->isInstanceOf(ExceptionHandlerComponent::class));
-        $this->appBuilder->expects($this->at(2))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(ExceptionHandlerComponent::class)
             ->willReturn($this->createMock(ExceptionHandlerComponent::class));
         $component = new class() {
@@ -326,6 +309,8 @@ class AphiriaComponentsTest extends TestCase
         };
         $callback = fn (Exception $ex, IOutput $output) => null;
         $component->build($this->appBuilder, Exception::class, $callback);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testWithFrameworkCommandsConfiguresComponentToHaveCommands(): void
@@ -340,12 +325,10 @@ class AphiriaComponentsTest extends TestCase
                 return $commands->tryGetCommand('framework:flushcaches', $flushCommandHandler)
                     && $commands->tryGetCommand('app:serve', $serveCommandHandler);
             }));
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(CommandComponent::class)
             ->willReturn(true);
-        $this->appBuilder->expects($this->at(1))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(CommandComponent::class)
             ->willReturn($expectedComponent);
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration([
@@ -374,12 +357,10 @@ class AphiriaComponentsTest extends TestCase
                 return $commands->tryGetCommand('framework:flushcaches', $flushCommandHandler)
                     && !$commands->tryGetCommand('app:serve', $serveCommandHandler);
             }));
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(CommandComponent::class)
             ->willReturn(true);
-        $this->appBuilder->expects($this->at(1))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(CommandComponent::class)
             ->willReturn($expectedComponent);
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration([
@@ -398,15 +379,12 @@ class AphiriaComponentsTest extends TestCase
 
     public function testWithFrameworkCommandsRegistersComponentIfItIsNotRegisteredYet(): void
     {
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(CommandComponent::class)
             ->willReturn(false);
-        $this->appBuilder->expects($this->at(1))
-            ->method('withComponent')
+        $this->appBuilder->method('withComponent')
             ->with($this->isInstanceOf(CommandComponent::class));
-        $this->appBuilder->expects($this->at(2))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(CommandComponent::class)
             ->willReturn($this->createMock(CommandComponent::class));
         $component = new class() {
@@ -418,6 +396,8 @@ class AphiriaComponentsTest extends TestCase
             }
         };
         $component->build($this->appBuilder);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testWithGlobalMiddlewareConfiguresComponentToHaveMiddleware(): void
@@ -427,12 +407,10 @@ class AphiriaComponentsTest extends TestCase
         $expectedComponent->expects($this->once())
             ->method('withGlobalMiddleware')
             ->with($middlewareBinding, 1);
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(MiddlewareComponent::class)
             ->willReturn(true);
-        $this->appBuilder->expects($this->at(1))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(MiddlewareComponent::class)
             ->willReturn($expectedComponent);
         $component = new class() {
@@ -451,15 +429,12 @@ class AphiriaComponentsTest extends TestCase
 
     public function testWithGlobalMiddlewareRegistersComponentIfItIsNotRegisteredYet(): void
     {
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(MiddlewareComponent::class)
             ->willReturn(false);
-        $this->appBuilder->expects($this->at(1))
-            ->method('withComponent')
+        $this->appBuilder->method('withComponent')
             ->with($this->isInstanceOf(MiddlewareComponent::class));
-        $this->appBuilder->expects($this->at(2))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(MiddlewareComponent::class)
             ->willReturn($this->createMock(MiddlewareComponent::class));
         $component = new class() {
@@ -471,20 +446,19 @@ class AphiriaComponentsTest extends TestCase
             }
         };
         $component->build($this->appBuilder, new MiddlewareBinding('foo'));
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testWithGlobalMiddlewareRegistersComponentIfItIsNotRegisteredYetAndUsesBoundMiddlewareCollection(): void
     {
         Container::$globalInstance->bindInstance(MiddlewareCollection::class, new MiddlewareCollection());
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(MiddlewareComponent::class)
             ->willReturn(false);
-        $this->appBuilder->expects($this->at(1))
-            ->method('withComponent')
+        $this->appBuilder->method('withComponent')
             ->with($this->isInstanceOf(MiddlewareComponent::class));
-        $this->appBuilder->expects($this->at(2))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(MiddlewareComponent::class)
             ->willReturn($this->createMock(MiddlewareComponent::class));
         $component = new class() {
@@ -496,6 +470,8 @@ class AphiriaComponentsTest extends TestCase
             }
         };
         $component->build($this->appBuilder, new MiddlewareBinding('foo'));
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testWithLogLevelFactoryConfiguresComponentToHaveFactory(): void
@@ -505,12 +481,10 @@ class AphiriaComponentsTest extends TestCase
         $expectedComponent->expects($this->once())
             ->method('withLogLevelFactory')
             ->with(Exception::class, $logLevelFactory);
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(ExceptionHandlerComponent::class)
             ->willReturn(true);
-        $this->appBuilder->expects($this->at(1))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(ExceptionHandlerComponent::class)
             ->willReturn($expectedComponent);
         $component = new class() {
@@ -529,15 +503,12 @@ class AphiriaComponentsTest extends TestCase
 
     public function testWithLogLevelFactoryRegistersComponentIfItIsNotRegisteredYet(): void
     {
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(ExceptionHandlerComponent::class)
             ->willReturn(false);
-        $this->appBuilder->expects($this->at(1))
-            ->method('withComponent')
+        $this->appBuilder->method('withComponent')
             ->with($this->isInstanceOf(ExceptionHandlerComponent::class));
-        $this->appBuilder->expects($this->at(2))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(ExceptionHandlerComponent::class)
             ->willReturn($this->createMock(ExceptionHandlerComponent::class));
         $component = new class() {
@@ -550,17 +521,15 @@ class AphiriaComponentsTest extends TestCase
         };
         $logLevelFactory = fn (Exception $ex) => LogLevel::ALERT;
         $component->build($this->appBuilder, Exception::class, $logLevelFactory);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testWithModulesAddsMultipleModulesToAppBuilder(): void
     {
         $modules = [$this->createMock(IModule::class), $this->createMock(IModule::class)];
-        $this->appBuilder->expects($this->at(0))
-            ->method('withModule')
-            ->with($modules[0]);
-        $this->appBuilder->expects($this->at(1))
-            ->method('withModule')
-            ->with($modules[1]);
+        $this->appBuilder->method('withModule')
+            ->withConsecutive([$modules[0]], [$modules[1]]);
         $component = new class() {
             use AphiriaComponents;
 
@@ -570,6 +539,8 @@ class AphiriaComponentsTest extends TestCase
             }
         };
         $component->build($this->appBuilder, $modules);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testWithModulesAddsSingleModuleToAppBuilder(): void
@@ -596,12 +567,10 @@ class AphiriaComponentsTest extends TestCase
         $expectedComponent->expects($this->once())
             ->method('withObjectConstraints')
             ->with($callback);
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(ValidationComponent::class)
             ->willReturn(true);
-        $this->appBuilder->expects($this->at(1))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(ValidationComponent::class)
             ->willReturn($expectedComponent);
         $component = new class() {
@@ -617,15 +586,12 @@ class AphiriaComponentsTest extends TestCase
 
     public function testWithObjectConstraintsRegistersComponentIfItIsNotRegisteredYet(): void
     {
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(ValidationComponent::class)
             ->willReturn(false);
-        $this->appBuilder->expects($this->at(1))
-            ->method('withComponent')
+        $this->appBuilder->method('withComponent')
             ->with($this->isInstanceOf(ValidationComponent::class));
-        $this->appBuilder->expects($this->at(2))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(ValidationComponent::class)
             ->willReturn($this->createMock(ValidationComponent::class));
         $component = new class() {
@@ -638,6 +604,8 @@ class AphiriaComponentsTest extends TestCase
         };
         $factory = fn (ObjectConstraintsRegistry $objectConstraints) => null;
         $component->build($this->appBuilder, $factory);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testWithProblemDetailsConfiguresComponentToHaveProblemDetails(): void
@@ -646,12 +614,10 @@ class AphiriaComponentsTest extends TestCase
         $expectedComponent->expects($this->once())
             ->method('withProblemDetails')
             ->with(Exception::class, 'type', 'title', 'detail', 400, 'instance', ['foo' => 'bar']);
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(ExceptionHandlerComponent::class)
             ->willReturn(true);
-        $this->appBuilder->expects($this->at(1))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(ExceptionHandlerComponent::class)
             ->willReturn($expectedComponent);
         $component = new class() {
@@ -675,15 +641,12 @@ class AphiriaComponentsTest extends TestCase
 
     public function testWithProblemDetailsRegistersComponentIfItIsNotRegisteredYet(): void
     {
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(ExceptionHandlerComponent::class)
             ->willReturn(false);
-        $this->appBuilder->expects($this->at(1))
-            ->method('withComponent')
+        $this->appBuilder->method('withComponent')
             ->with($this->isInstanceOf(ExceptionHandlerComponent::class));
-        $this->appBuilder->expects($this->at(2))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(ExceptionHandlerComponent::class)
             ->willReturn($this->createMock(ExceptionHandlerComponent::class));
         $component = new class() {
@@ -703,6 +666,8 @@ class AphiriaComponentsTest extends TestCase
             }
         };
         $component->build($this->appBuilder, Exception::class, 'type', 'title', 'detail', 400, 'instance', ['foo' => 'bar']);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testWithRouteAnnotationsConfiguresComponentToHaveAnnotations(): void
@@ -710,12 +675,10 @@ class AphiriaComponentsTest extends TestCase
         $expectedComponent = $this->createMock(RouterComponent::class);
         $expectedComponent->expects($this->once())
             ->method('withAnnotations');
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(RouterComponent::class)
             ->willReturn(true);
-        $this->appBuilder->expects($this->at(1))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(RouterComponent::class)
             ->willReturn($expectedComponent);
         $component = new class() {
@@ -731,15 +694,12 @@ class AphiriaComponentsTest extends TestCase
 
     public function testWithRouteAnnotationsRegistersComponentIfItIsNotRegisteredYet(): void
     {
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(RouterComponent::class)
             ->willReturn(false);
-        $this->appBuilder->expects($this->at(1))
-            ->method('withComponent')
+        $this->appBuilder->method('withComponent')
             ->with($this->isInstanceOf(RouterComponent::class));
-        $this->appBuilder->expects($this->at(2))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(RouterComponent::class)
             ->willReturn($this->createMock(RouterComponent::class));
         $component = new class() {
@@ -751,6 +711,8 @@ class AphiriaComponentsTest extends TestCase
             }
         };
         $component->build($this->appBuilder);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testWithRoutesConfiguresComponentToHaveRoutes(): void
@@ -760,12 +722,10 @@ class AphiriaComponentsTest extends TestCase
         $expectedComponent->expects($this->once())
             ->method('withRoutes')
             ->with($callback);
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(RouterComponent::class)
             ->willReturn(true);
-        $this->appBuilder->expects($this->at(1))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(RouterComponent::class)
             ->willReturn($expectedComponent);
         $component = new class() {
@@ -781,15 +741,12 @@ class AphiriaComponentsTest extends TestCase
 
     public function testWithRoutesRegistersComponentIfItIsNotRegisteredYet(): void
     {
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(RouterComponent::class)
             ->willReturn(false);
-        $this->appBuilder->expects($this->at(1))
-            ->method('withComponent')
+        $this->appBuilder->method('withComponent')
             ->with($this->isInstanceOf(RouterComponent::class));
-        $this->appBuilder->expects($this->at(2))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(RouterComponent::class)
             ->willReturn($this->createMock(RouterComponent::class));
         $component = new class() {
@@ -802,6 +759,8 @@ class AphiriaComponentsTest extends TestCase
         };
         $callback = fn (RouteCollectionBuilder $routeBuilders) => null;
         $component->build($this->appBuilder, $callback);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testWithValidatorAnnotationsConfiguresComponentToHaveAnnotations(): void
@@ -809,12 +768,10 @@ class AphiriaComponentsTest extends TestCase
         $expectedComponent = $this->createMock(ValidationComponent::class);
         $expectedComponent->expects($this->once())
             ->method('withAnnotations');
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(ValidationComponent::class)
             ->willReturn(true);
-        $this->appBuilder->expects($this->at(1))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(ValidationComponent::class)
             ->willReturn($expectedComponent);
         $component = new class() {
@@ -830,15 +787,12 @@ class AphiriaComponentsTest extends TestCase
 
     public function testWithValidatorAnnotationsComponentIfItIsNotRegisteredYet(): void
     {
-        $this->appBuilder->expects($this->at(0))
-            ->method('hasComponent')
+        $this->appBuilder->method('hasComponent')
             ->with(ValidationComponent::class)
             ->willReturn(false);
-        $this->appBuilder->expects($this->at(1))
-            ->method('withComponent')
+        $this->appBuilder->method('withComponent')
             ->with($this->isInstanceOf(ValidationComponent::class));
-        $this->appBuilder->expects($this->at(2))
-            ->method('getComponent')
+        $this->appBuilder->method('getComponent')
             ->with(ValidationComponent::class)
             ->willReturn($this->createMock(ValidationComponent::class));
         $component = new class() {
@@ -850,5 +804,7 @@ class AphiriaComponentsTest extends TestCase
             }
         };
         $component->build($this->appBuilder);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 }

--- a/src/Framework/tests/Console/Commands/FlushFrameworkCachesCommandHandlerTest.php
+++ b/src/Framework/tests/Console/Commands/FlushFrameworkCachesCommandHandlerTest.php
@@ -35,115 +35,135 @@ class FlushFrameworkCachesCommandHandlerTest extends TestCase
 
     public function testBinderMetadataCacheIsFlushedIfSet(): void
     {
-        $this->output->expects($this->at(0))
-            ->method('writeln')
-            ->with('<info>Binder metadata cache flushed</info>');
+        $correctOutputWritten = false;
+        $this->setUpMockOutput('<info>Binder metadata cache flushed</info>', $correctOutputWritten);
         $binderMetadataCache = $this->createMock(IBinderMetadataCollectionCache::class);
         $binderMetadataCache->expects($this->once())
             ->method('flush');
         $commandHandler = new FlushFrameworkCachesCommandHandler($binderMetadataCache, null, null, null, null);
         $commandHandler->handle(new Input('framework:flushcaches', [], []), $this->output);
+        $this->assertTrue($correctOutputWritten);
     }
 
     public function testBinderMetadataCacheIsSkippedIfNotSet(): void
     {
-        $this->output->expects($this->at(0))
-            ->method('writeln')
-            ->with('<info>Binder metadata cache not set - skipping</info>');
+        $correctOutputWritten = false;
+        $this->setUpMockOutput('<info>Binder metadata cache not set - skipping</info>', $correctOutputWritten);
         $commandHandler = new FlushFrameworkCachesCommandHandler(null, null, null, null, null);
         $commandHandler->handle(new Input('framework:flushcaches', [], []), $this->output);
+        $this->assertTrue($correctOutputWritten);
     }
 
     public function testConsoleCommandCacheIsFlushedIfSet(): void
     {
-        $this->output->expects($this->at(1))
-            ->method('writeln')
-            ->with('<info>Console command cache flushed</info>');
+        $correctOutputWritten = false;
+        $this->setUpMockOutput('<info>Console command cache flushed</info>', $correctOutputWritten);
         $consoleCommandCache = $this->createMock(ICommandRegistryCache::class);
         $consoleCommandCache->expects($this->once())
             ->method('flush');
         $commandHandler = new FlushFrameworkCachesCommandHandler(null, $consoleCommandCache, null, null, null);
         $commandHandler->handle(new Input('framework:flushcaches', [], []), $this->output);
+        $this->assertTrue($correctOutputWritten);
     }
 
     public function testConsoleCommandCacheIsSkippedIfNotSet(): void
     {
-        $this->output->expects($this->at(1))
-            ->method('writeln')
-            ->with('<info>Console command cache not set - skipping</info>');
+        $correctOutputWritten = false;
+        $this->setUpMockOutput('<info>Console command cache not set - skipping</info>', $correctOutputWritten);
         $commandHandler = new FlushFrameworkCachesCommandHandler(null, null, null, null, null);
         $commandHandler->handle(new Input('framework:flushcaches', [], []), $this->output);
+        $this->assertTrue($correctOutputWritten);
     }
 
     public function testConstraintsCacheIsFlushedIfSet(): void
     {
-        $this->output->expects($this->at(4))
-            ->method('writeln')
-            ->with('<info>Constraints cache flushed</info>');
+        $correctOutputWritten = false;
+        $this->setUpMockOutput('<info>Constraints cache flushed</info>', $correctOutputWritten);
         $constraintsCache = $this->createMock(IObjectConstraintsRegistryCache::class);
         $constraintsCache->expects($this->once())
             ->method('flush');
         $commandHandler = new FlushFrameworkCachesCommandHandler(null, null, null, null, $constraintsCache);
         $commandHandler->handle(new Input('framework:flushcaches', [], []), $this->output);
+        $this->assertTrue($correctOutputWritten);
     }
 
     public function testConstraintsCacheIsSkippedIfNotSet(): void
     {
-        $this->output->expects($this->at(4))
-            ->method('writeln')
-            ->with('<info>Constraints cache not set - skipping</info>');
+        $correctOutputWritten = false;
+        $this->setUpMockOutput('<info>Constraints cache not set - skipping</info>', $correctOutputWritten);
         $commandHandler = new FlushFrameworkCachesCommandHandler(null, null, null, null, null);
         $commandHandler->handle(new Input('framework:flushcaches', [], []), $this->output);
+        $this->assertTrue($correctOutputWritten);
     }
 
     public function testRouteCacheIsFlushedIfSet(): void
     {
-        $this->output->expects($this->at(2))
-            ->method('writeln')
-            ->with('<info>Route cache flushed</info>');
+        $correctOutputWritten = false;
+        $this->setUpMockOutput('<info>Route cache flushed</info>', $correctOutputWritten);
         $routeCache = $this->createMock(IRouteCache::class);
         $routeCache->expects($this->once())
             ->method('flush');
         $commandHandler = new FlushFrameworkCachesCommandHandler(null, null, $routeCache, null, null);
         $commandHandler->handle(new Input('framework:flushcaches', [], []), $this->output);
+        $this->assertTrue($correctOutputWritten);
     }
 
     public function testRouteCacheIsSkippedIfNotSet(): void
     {
-        $this->output->expects($this->at(2))
-            ->method('writeln')
-            ->with('<info>Route cache not set - skipping</info>');
+        $correctOutputWritten = false;
+        $this->setUpMockOutput('<info>Route cache not set - skipping</info>', $correctOutputWritten);
         $commandHandler = new FlushFrameworkCachesCommandHandler(null, null, null, null, null);
         $commandHandler->handle(new Input('framework:flushcaches', [], []), $this->output);
+        $this->assertTrue($correctOutputWritten);
     }
 
     public function testSuccessMessageIsWrittenAtEnd(): void
     {
-        $this->output->expects($this->at(5))
-            ->method('writeln')
-            ->with('<success>Framework caches flushed</success>');
+        $correctOutputWritten = false;
+        $this->setUpMockOutput('<success>Framework caches flushed</success>', $correctOutputWritten);
         $commandHandler = new FlushFrameworkCachesCommandHandler(null, null, null, null, null);
         $commandHandler->handle(new Input('framework:flushcaches', [], []), $this->output);
+        $this->assertTrue($correctOutputWritten);
     }
 
     public function testTrieCacheIsFlushedIfSet(): void
     {
-        $this->output->expects($this->at(3))
-            ->method('writeln')
-            ->with('<info>Trie cache flushed</info>');
+        $correctOutputWritten = false;
+        $this->setUpMockOutput('<info>Trie cache flushed</info>', $correctOutputWritten);
         $trieCache = $this->createMock(ITrieCache::class);
         $trieCache->expects($this->once())
             ->method('flush');
         $commandHandler = new FlushFrameworkCachesCommandHandler(null, null, null, $trieCache, null);
         $commandHandler->handle(new Input('framework:flushcaches', [], []), $this->output);
+        $this->assertTrue($correctOutputWritten);
     }
 
     public function testTrieCacheIsSkippedIfNotSet(): void
     {
-        $this->output->expects($this->at(3))
-            ->method('writeln')
-            ->with('<info>Trie cache not set - skipping</info>');
+        $correctOutputWritten = false;
+        $this->setUpMockOutput('<info>Trie cache not set - skipping</info>', $correctOutputWritten);
         $commandHandler = new FlushFrameworkCachesCommandHandler(null, null, null, null, null);
         $commandHandler->handle(new Input('framework:flushcaches', [], []), $this->output);
+        $this->assertTrue($correctOutputWritten);
+    }
+
+    /**
+     * Sets up the expected message to be written to output
+     *
+     * @param string $expectedMessage The expected message
+     * @param bool $correctOutputWritten The "out" param for whether or not the correct output was written
+     */
+    private function setUpMockOutput(string $expectedMessage, bool &$correctOutputWritten): void
+    {
+        $correctOutputWritten = false;
+        $this->output->method('writeln')
+            ->with($this->callback(function (string $message) use ($expectedMessage, &$correctOutputWritten) {
+                if ($message === $expectedMessage) {
+                    $correctOutputWritten = true;
+                }
+
+                // We'll always return true, and check if the correct output was written later
+                return true;
+            }));
     }
 }

--- a/src/Framework/tests/Console/Exceptions/ConsoleExceptionRendererTest.php
+++ b/src/Framework/tests/Console/Exceptions/ConsoleExceptionRendererTest.php
@@ -45,14 +45,12 @@ class ConsoleExceptionRendererTest extends TestCase
                 return 1;
             }
         ]);
-        $this->output->expects($this->at(0))
-            ->method('writeln')
-            ->with('foo');
-        $this->output->expects($this->at(1))
-            ->method('writeln')
-            ->with('bar');
+        $this->output->method('writeln')
+            ->withConsecutive(['foo'], ['bar']);
         $this->exceptionRenderer->render(new Exception());
         $this->exceptionRenderer->render(new InvalidArgumentException());
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testRenderingExceptionWithNoRegisteredOutputWriterUsesDefaultResultMessage(): void

--- a/src/Framework/tests/ContentNegotiation/Binders/ContentNegotiationBinderTest.php
+++ b/src/Framework/tests/ContentNegotiation/Binders/ContentNegotiationBinderTest.php
@@ -39,42 +39,51 @@ class ContentNegotiationBinderTest extends TestCase
         $this->container = $this->createMock(IContainer::class);
         $this->binder = new ContentNegotiationBinder();
         GlobalConfiguration::resetConfigurationSources();
-
-        // Some universal assertions
-        $this->container->expects($this->at(0))
-            ->method('resolve')
-            ->with(JsonMediaTypeFormatter::class)
-            ->willReturn(new JsonMediaTypeFormatter());
-        $this->container->expects($this->at(1))
-            ->method('bindInstance')
-            ->with(IMediaTypeFormatterMatcher::class, $this->isInstanceOf(MediaTypeFormatterMatcher::class));
     }
 
     public function testAcceptCharsetEncodingMatcherIsCreatedDirectly(): void
     {
+        $this->setUpContainerMockBindInstance([
+            [IMediaTypeFormatterMatcher::class, $this->isInstanceOf(MediaTypeFormatterMatcher::class)],
+            [IEncodingMatcher::class, $this->isInstanceOf(AcceptCharsetEncodingMatcher::class)],
+            [ILanguageMatcher::class, $this->isInstanceOf(AcceptLanguageMatcher::class)],
+            [IContentNegotiator::class, $this->isInstanceOf(ContentNegotiator::class)]
+        ]);
+        $this->setUpContainerMockResolve();
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(self::getBaseConfig()));
-        $this->container->expects($this->at(2))
-            ->method('bindInstance')
-            ->with(IEncodingMatcher::class, $this->isInstanceOf(AcceptCharsetEncodingMatcher::class));
         $this->binder->bind($this->container);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testAcceptLanguageMatcherIsCreatedDirectly(): void
     {
+        $this->setUpContainerMockBindInstance([
+            [IMediaTypeFormatterMatcher::class, $this->isInstanceOf(MediaTypeFormatterMatcher::class)],
+            [IEncodingMatcher::class, $this->isInstanceOf(AcceptCharsetEncodingMatcher::class)],
+            [ILanguageMatcher::class, $this->isInstanceOf(AcceptLanguageMatcher::class)],
+            [IContentNegotiator::class, $this->isInstanceOf(ContentNegotiator::class)]
+        ]);
+        $this->setUpContainerMockResolve();
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(self::getBaseConfig()));
-        $this->container->expects($this->at(3))
-            ->method('bindInstance')
-            ->with(ILanguageMatcher::class, $this->isInstanceOf(AcceptLanguageMatcher::class));
         $this->binder->bind($this->container);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testContentNegotiatorIsBound(): void
     {
+        $this->setUpContainerMockBindInstance([
+            [IMediaTypeFormatterMatcher::class, $this->isInstanceOf(MediaTypeFormatterMatcher::class)],
+            [IEncodingMatcher::class, $this->isInstanceOf(AcceptCharsetEncodingMatcher::class)],
+            [ILanguageMatcher::class, $this->isInstanceOf(AcceptLanguageMatcher::class)],
+            [IContentNegotiator::class, $this->isInstanceOf(ContentNegotiator::class)]
+        ]);
+        $this->setUpContainerMockResolve();
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(self::getBaseConfig()));
-        $this->container->expects($this->at(4))
-            ->method('bindInstance')
-            ->with(IContentNegotiator::class, $this->isInstanceOf(ContentNegotiator::class));
         $this->binder->bind($this->container);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testUnknownEncodingMatchersAreResolved(): void
@@ -83,14 +92,16 @@ class ContentNegotiationBinderTest extends TestCase
         $config = self::getBaseConfig();
         $config['aphiria']['contentNegotiation']['encodingMatcher'] = \get_class($encodingMatcher);
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration($config));
-        $this->container->expects($this->at(2))
-            ->method('resolve')
-            ->with(\get_class($encodingMatcher))
-            ->willReturn($encodingMatcher);
-        $this->container->expects($this->at(3))
-            ->method('bindInstance')
-            ->with(IEncodingMatcher::class, $encodingMatcher);
+        $this->setUpContainerMockBindInstance([
+            [IMediaTypeFormatterMatcher::class, $this->isInstanceOf(MediaTypeFormatterMatcher::class)],
+            [IEncodingMatcher::class, $encodingMatcher],
+            [ILanguageMatcher::class, $this->isInstanceOf(AcceptLanguageMatcher::class)],
+            [IContentNegotiator::class, $this->isInstanceOf(ContentNegotiator::class)]
+        ]);
+        $this->setUpContainerMockResolve([\get_class($encodingMatcher), $encodingMatcher]);
         $this->binder->bind($this->container);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testUnknownLanguageMatchersAreResolved(): void
@@ -99,14 +110,16 @@ class ContentNegotiationBinderTest extends TestCase
         $config = self::getBaseConfig();
         $config['aphiria']['contentNegotiation']['languageMatcher'] = \get_class($languageMatcher);
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration($config));
-        $this->container->expects($this->at(3))
-            ->method('resolve')
-            ->with(\get_class($languageMatcher))
-            ->willReturn($languageMatcher);
-        $this->container->expects($this->at(4))
-            ->method('bindInstance')
-            ->with(ILanguageMatcher::class, $languageMatcher);
+        $this->setUpContainerMockBindInstance([
+            [IMediaTypeFormatterMatcher::class, $this->isInstanceOf(MediaTypeFormatterMatcher::class)],
+            [IEncodingMatcher::class, $this->isInstanceOf(AcceptCharsetEncodingMatcher::class)],
+            [ILanguageMatcher::class, $languageMatcher],
+            [IContentNegotiator::class, $this->isInstanceOf(ContentNegotiator::class)]
+        ]);
+        $this->setUpContainerMockResolve([\get_class($languageMatcher), $languageMatcher]);
         $this->binder->bind($this->container);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     /**
@@ -128,5 +141,35 @@ class ContentNegotiationBinderTest extends TestCase
                 ]
             ]
         ];
+    }
+
+    /**
+     * Sets up tbe bindInstance() calls on the container mock
+     *
+     * @param array[] $parameters The parameters to pass in
+     */
+    private function setUpContainerMockBindInstance(array $parameters): void
+    {
+        $this->container->method('bindInstance')
+            ->withConsecutive(...$parameters);
+    }
+
+    /**
+     * Sets up tbe resolve() calls on the container mock
+     *
+     * @param array|null $additionalParameters The additional parameters to set up in the mock, or null if none
+     */
+    private function setUpContainerMockResolve(array $additionalParameters = null): void
+    {
+        $parameters = [
+            [JsonMediaTypeFormatter::class, new JsonMediaTypeFormatter()]
+        ];
+
+        if ($additionalParameters !== null) {
+            $parameters[] = $additionalParameters;
+        }
+
+        $this->container->method('resolve')
+            ->willReturnMap($parameters);
     }
 }

--- a/src/Framework/tests/Exceptions/Binders/ExceptionHandlerBinderTest.php
+++ b/src/Framework/tests/Exceptions/Binders/ExceptionHandlerBinderTest.php
@@ -36,43 +36,41 @@ class ExceptionHandlerBinderTest extends TestCase
         $this->binder = new ExceptionHandlerBinder();
         $this->apiExceptionRenderer = $this->request = $this->responseFactory = null;
 
-        // Set up some universal mocks
-        $this->container->expects($this->at(0))
-            ->method('tryResolve')
-            ->with(IApiExceptionRenderer::class, $this->apiExceptionRenderer)
+        // We need to set up the "out" params based on the type that's set
+        $this->container->method('tryResolve')
             ->willReturnCallback(function ($type, &$object) {
-                // Capture the object parameter so we can make assertions on it later
-                $object = $this->apiExceptionRenderer = new class() extends ProblemDetailsExceptionRenderer {
-                    public function getRequest(): ?IRequest
-                    {
-                        return $this->request;
-                    }
+                if ($type === IApiExceptionRenderer::class) {
+                    // Capture the object parameter so we can make assertions on it later
+                    $object = $this->apiExceptionRenderer = new class() extends ProblemDetailsExceptionRenderer {
+                        public function getRequest(): ?IRequest
+                        {
+                            return $this->request;
+                        }
 
-                    public function getResponseFactory(): ?IResponseFactory
-                    {
-                        return $this->responseFactory;
-                    }
-                };
+                        public function getResponseFactory(): ?IResponseFactory
+                        {
+                            return $this->responseFactory;
+                        }
+                    };
 
-                return true;
-            });
-        $this->container->expects($this->at(1))
-            ->method('tryResolve')
-            ->with(IRequest::class, $this->request)
-            ->willReturnCallback(function ($type, &$object) {
-                // Capture the object parameter so we can make assertions on it later
-                $object = $this->request = $this->createMock(IRequest::class);
+                    return true;
+                }
 
-                return true;
-            });
-        $this->container->expects($this->at(2))
-            ->method('tryResolve')
-            ->with(IResponseFactory::class, $this->responseFactory)
-            ->willReturnCallback(function ($type, &$object) {
-                // Capture the object parameter so we can make assertions on it later
-                $object = $this->responseFactory = $this->createMock(IResponseFactory::class);
+                if ($type === IRequest::class) {
+                    // Capture the object parameter so we can make assertions on it later
+                    $object = $this->request = $this->createMock(IRequest::class);
 
-                return true;
+                    return true;
+                }
+
+                if ($type === IResponseFactory::class) {
+                    // Capture the object parameter so we can make assertions on it later
+                    $object = $this->responseFactory = $this->createMock(IResponseFactory::class);
+
+                    return true;
+                }
+
+                return false;
             });
     }
 

--- a/src/Framework/tests/Middleware/Components/MiddlewareComponentTest.php
+++ b/src/Framework/tests/Middleware/Components/MiddlewareComponentTest.php
@@ -55,14 +55,11 @@ class MiddlewareComponentTest extends TestCase
         };
         $expectedMiddleware->setAttributes(['bar' => 'baz']);
         $middlewareCollection = new MiddlewareCollection();
-        $this->dependencyResolver->expects($this->at(0))
-            ->method('resolve')
-            ->with(MiddlewareCollection::class)
-            ->willReturn($middlewareCollection);
-        $this->dependencyResolver->expects($this->at(1))
-            ->method('resolve')
-            ->with('foo')
-            ->willReturn($expectedMiddleware);
+        $this->dependencyResolver->method('resolve')
+            ->willReturnMap([
+                [MiddlewareCollection::class, $middlewareCollection],
+                ['foo', $expectedMiddleware]
+            ]);
         $this->middlewareComponent->withGlobalMiddleware(new MiddlewareBinding('foo', ['bar' => 'baz']));
         $this->middlewareComponent->build();
         $this->assertEquals([$expectedMiddleware], $middlewareCollection->getAll());
@@ -73,10 +70,11 @@ class MiddlewareComponentTest extends TestCase
         $invalidMiddleware = $this;
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(\get_class($invalidMiddleware) . ' does not implement ' . IMiddleware::class);
-        $this->dependencyResolver->expects($this->at(1))
-            ->method('resolve')
-            ->with('foo')
-            ->willReturn($invalidMiddleware);
+        $this->dependencyResolver->method('resolve')
+            ->willReturnMap([
+                [MiddlewareCollection::class, new MiddlewareCollection()],
+                ['foo', $invalidMiddleware]
+            ]);
         $this->middlewareComponent->withGlobalMiddleware(new MiddlewareBinding('foo'));
         $this->middlewareComponent->build();
     }
@@ -86,18 +84,12 @@ class MiddlewareComponentTest extends TestCase
         $expectedMiddleware1 = $this->createMock(IMiddleware::class);
         $expectedMiddleware2 = $this->createMock(IMiddleware::class);
         $middlewareCollection = new MiddlewareCollection();
-        $this->dependencyResolver->expects($this->at(0))
-            ->method('resolve')
-            ->with(MiddlewareCollection::class)
-            ->willReturn($middlewareCollection);
-        $this->dependencyResolver->expects($this->at(1))
-            ->method('resolve')
-            ->with('foo')
-            ->willReturn($expectedMiddleware1);
-        $this->dependencyResolver->expects($this->at(2))
-            ->method('resolve')
-            ->with('bar')
-            ->willReturn($expectedMiddleware2);
+        $this->dependencyResolver->method('resolve')
+            ->willReturnMap([
+                [MiddlewareCollection::class, $middlewareCollection],
+                ['foo', $expectedMiddleware1],
+                ['bar', $expectedMiddleware2]
+            ]);
         $this->middlewareComponent->withGlobalMiddleware(new MiddlewareBinding('foo'));
         $this->middlewareComponent->withGlobalMiddleware(new MiddlewareBinding('bar'));
         $this->middlewareComponent->build();
@@ -109,18 +101,12 @@ class MiddlewareComponentTest extends TestCase
         $expectedMiddleware1 = $this->createMock(IMiddleware::class);
         $expectedMiddleware2 = $this->createMock(IMiddleware::class);
         $middlewareCollection = new MiddlewareCollection();
-        $this->dependencyResolver->expects($this->at(0))
-            ->method('resolve')
-            ->with(MiddlewareCollection::class)
-            ->willReturn($middlewareCollection);
-        $this->dependencyResolver->expects($this->at(1))
-            ->method('resolve')
-            ->with('foo')
-            ->willReturn($expectedMiddleware1);
-        $this->dependencyResolver->expects($this->at(2))
-            ->method('resolve')
-            ->with('bar')
-            ->willReturn($expectedMiddleware2);
+        $this->dependencyResolver->method('resolve')
+            ->willReturnMap([
+                [MiddlewareCollection::class, $middlewareCollection],
+                ['foo', $expectedMiddleware1],
+                ['bar', $expectedMiddleware2]
+            ]);
         $this->middlewareComponent->withGlobalMiddleware([new MiddlewareBinding('foo'), new MiddlewareBinding('bar')]);
         $this->middlewareComponent->build();
         $this->assertEquals([$expectedMiddleware1, $expectedMiddleware2], $middlewareCollection->getAll());
@@ -130,14 +116,11 @@ class MiddlewareComponentTest extends TestCase
     {
         $expectedMiddleware = $this->createMock(IMiddleware::class);
         $middlewareCollection = new MiddlewareCollection();
-        $this->dependencyResolver->expects($this->at(0))
-            ->method('resolve')
-            ->with(MiddlewareCollection::class)
-            ->willReturn($middlewareCollection);
-        $this->dependencyResolver->expects($this->at(1))
-            ->method('resolve')
-            ->with('foo')
-            ->willReturn($expectedMiddleware);
+        $this->dependencyResolver->method('resolve')
+            ->willReturnMap([
+                [MiddlewareCollection::class, $middlewareCollection],
+                ['foo', $expectedMiddleware]
+            ]);
         $this->middlewareComponent->withGlobalMiddleware(new MiddlewareBinding('foo'));
         $this->middlewareComponent->build();
         $this->assertEquals([$expectedMiddleware], $middlewareCollection->getAll());

--- a/src/Framework/tests/Serialization/Binders/SymfonySerializerBinderTest.php
+++ b/src/Framework/tests/Serialization/Binders/SymfonySerializerBinderTest.php
@@ -40,8 +40,7 @@ class SymfonySerializerBinderTest extends TestCase
         $this->container = $this->createMock(IContainer::class);
         GlobalConfiguration::resetConfigurationSources();
         // Set up some universal expectations
-        $this->container->expects($this->at(0))
-            ->method('bindInstance')
+        $this->container->method('bindInstance')
             ->with([SerializerInterface::class, Serializer::class], $this->isInstanceOf(Serializer::class));
     }
 
@@ -51,6 +50,8 @@ class SymfonySerializerBinderTest extends TestCase
         $config['aphiria']['serialization']['normalizers'][] = ArrayDenormalizer::class;
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration($config));
         $this->binder->bind($this->container);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testDateTimeNormalizerIsInstantiatedWithCorrectFormat(): void
@@ -59,6 +60,8 @@ class SymfonySerializerBinderTest extends TestCase
         $config['aphiria']['serialization']['normalizers'][] = DateTimeNormalizer::class;
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration($config));
         $this->binder->bind($this->container);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testJsonEncoderIsInstantiated(): void
@@ -67,6 +70,8 @@ class SymfonySerializerBinderTest extends TestCase
         $config['aphiria']['serialization']['encoders'][] = JsonEncoder::class;
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration($config));
         $this->binder->bind($this->container);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testObjectNormalizerIsInstantiatedWithNameConverterIfItExists(): void
@@ -76,6 +81,8 @@ class SymfonySerializerBinderTest extends TestCase
         $config['aphiria']['serialization']['nameConverter'] = CamelCaseToSnakeCaseNameConverter::class;
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration($config));
         $this->binder->bind($this->container);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testObjectNormalizerIsInstantiatedWithoutNameConverterIfNoneExists(): void
@@ -84,6 +91,8 @@ class SymfonySerializerBinderTest extends TestCase
         $config['aphiria']['serialization']['normalizers'][] = ObjectNormalizer::class;
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration($config));
         $this->binder->bind($this->container);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testProblemDetailsNormalizerIsInstantiated(): void
@@ -92,6 +101,8 @@ class SymfonySerializerBinderTest extends TestCase
         $config['aphiria']['serialization']['normalizers'][] = ProblemDetailsNormalizer::class;
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration($config));
         $this->binder->bind($this->container);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testXmlEncoderIsInstantiatedWithSupportedParameters(): void
@@ -100,6 +111,8 @@ class SymfonySerializerBinderTest extends TestCase
         $config['aphiria']['serialization']['encoders'][] = XmlEncoder::class;
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration($config));
         $this->binder->bind($this->container);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     /**

--- a/src/IO/composer.json
+++ b/src/IO/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-coveralls/php-coveralls": "^2.2",
-        "phpunit/phpunit": "~9.1"
+        "phpunit/phpunit": "~9.3"
     },
     "scripts": {
         "lint-check": "php-cs-fixer fix --config=.php_cs.dist -v --diff --dry-run",

--- a/src/IO/phpunit.xml.dist
+++ b/src/IO/phpunit.xml.dist
@@ -1,15 +1,14 @@
-<phpunit
-    bootstrap="vendor/autoload.php"
-    colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <html outputDirectory="./.coverage"/>
+        </report>
+    </coverage>
     <testsuite name="IO">
         <directory>tests</directory>
     </testsuite>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="./.coverage"/>
-    </logging>
 </phpunit>

--- a/src/Middleware/composer.json
+++ b/src/Middleware/composer.json
@@ -30,7 +30,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-coveralls/php-coveralls": "^2.2",
-        "phpunit/phpunit": "~9.1"
+        "phpunit/phpunit": "~9.3"
     },
     "scripts": {
         "lint-check": "php-cs-fixer fix --config=.php_cs.dist -v --diff --dry-run",

--- a/src/Middleware/phpunit.xml.dist
+++ b/src/Middleware/phpunit.xml.dist
@@ -1,15 +1,14 @@
-<phpunit
-    bootstrap="vendor/autoload.php"
-    colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <html outputDirectory="./.coverage"/>
+        </report>
+    </coverage>
     <testsuite name="Middleware">
         <directory>tests</directory>
     </testsuite>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="./.coverage"/>
-    </logging>
 </phpunit>

--- a/src/Net/composer.json
+++ b/src/Net/composer.json
@@ -39,7 +39,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-coveralls/php-coveralls": "^2.2",
-        "phpunit/phpunit": "~9.1"
+        "phpunit/phpunit": "~9.3"
     },
     "scripts": {
         "lint-check": "php-cs-fixer fix --config=.php_cs.dist -v --diff --dry-run",

--- a/src/Net/phpunit.xml.dist
+++ b/src/Net/phpunit.xml.dist
@@ -1,15 +1,14 @@
-<phpunit
-    bootstrap="vendor/autoload.php"
-    colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <html outputDirectory="./.coverage"/>
+        </report>
+    </coverage>
     <testsuite name="Net">
         <directory>tests</directory>
     </testsuite>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="./.coverage"/>
-    </logging>
 </phpunit>

--- a/src/PsrAdapters/composer.json
+++ b/src/PsrAdapters/composer.json
@@ -36,7 +36,7 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "nyholm/psr7": "^1.2",
         "php-coveralls/php-coveralls": "^2.2",
-        "phpunit/phpunit": "~9.1"
+        "phpunit/phpunit": "~9.3"
     },
     "scripts": {
         "lint-check": "php-cs-fixer fix --config=.php_cs.dist -v --diff --dry-run",

--- a/src/PsrAdapters/phpunit.xml.dist
+++ b/src/PsrAdapters/phpunit.xml.dist
@@ -1,15 +1,14 @@
-<phpunit
-    bootstrap="vendor/autoload.php"
-    colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <html outputDirectory="./.coverage"/>
+        </report>
+    </coverage>
     <testsuite name="PsrAdapters">
         <directory>tests</directory>
     </testsuite>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="./.coverage"/>
-    </logging>
 </phpunit>

--- a/src/PsrAdapters/tests/Psr11/Psr11ContainerTest.php
+++ b/src/PsrAdapters/tests/Psr11/Psr11ContainerTest.php
@@ -46,12 +46,10 @@ class Psr11ContainerTest extends TestCase
     {
         $this->expectException(ContainerException::class);
         $this->expectExceptionMessage('Failed to resolve foo');
-        $this->aphiriaContainer->expects($this->at(0))
-            ->method('resolve')
+        $this->aphiriaContainer->method('resolve')
             ->with('foo')
             ->willThrowException(new ResolutionException('foo', new UniversalContext()));
-        $this->aphiriaContainer->expects($this->at(1))
-            ->method('hasBinding')
+        $this->aphiriaContainer->method('hasBinding')
             ->with('foo')
             ->willReturn(false);
         $this->psr11Container->get('foo');
@@ -61,44 +59,42 @@ class Psr11ContainerTest extends TestCase
     {
         $this->expectException(NotFoundException::class);
         $this->expectExceptionMessage('No binding found for foo');
-        $this->aphiriaContainer->expects($this->at(0))
-            ->method('resolve')
+        $this->aphiriaContainer->method('resolve')
             ->with('foo')
             ->willThrowException(new ResolutionException('foo', new UniversalContext()));
-        $this->aphiriaContainer->expects($this->at(1))
-            ->method('hasBinding')
+        $this->aphiriaContainer->method('hasBinding')
             ->with('foo')
             ->willReturn(true);
         $this->psr11Container->get('foo');
     }
 
-    public function testHasReturnsWhetherOrNotContainerHasBinding(): void
+    public function testHasReturnsFalseWhenContainerCannotResolveSomethingWithABinding(): void
     {
-        $this->aphiriaContainer->expects($this->at(0))
-            ->method('resolve')
+        $this->aphiriaContainer->method('resolve')
             ->with('foo')
             ->willThrowException(new ResolutionException('foo', new UniversalContext()));
-        $this->aphiriaContainer->expects($this->at(1))
-            ->method('hasBinding')
+        $this->aphiriaContainer->method('hasBinding')
             ->with('foo')
             ->willReturn(false);
-        $this->aphiriaContainer->expects($this->at(2))
-            ->method('resolve')
-            ->with('bar')
-            ->willThrowException(new ResolutionException('bar', new UniversalContext()));
-        $this->aphiriaContainer->expects($this->at(3))
-            ->method('hasBinding')
-            ->with('bar')
+        $this->assertFalse($this->psr11Container->has('foo'));
+    }
+
+    public function testHasReturnsFalseWhenContainerCannotResolveSomethingWithoutABinding(): void
+    {
+        $this->aphiriaContainer->method('resolve')
+            ->with('foo')
+            ->willThrowException(new ResolutionException('foo', new UniversalContext()));
+        $this->aphiriaContainer->method('hasBinding')
+            ->with('foo')
             ->willReturn(true);
-        $this->aphiriaContainer->expects($this->at(4))
-            ->method('resolve')
+        $this->assertFalse($this->psr11Container->has('foo'));
+    }
+
+    public function testHasReturnsTrueWhenTheContainerCanResolveSomething(): void
+    {
+        $this->aphiriaContainer->method('resolve')
             ->with(self::class)
             ->willReturn($this);
-        // Test failing to resolve something that had no binding
-        $this->assertFalse($this->psr11Container->has('foo'));
-        // Test failing to resolve something that did have a binding
-        $this->assertFalse($this->psr11Container->has('bar'));
-        // Test resolving something successfully
         $this->assertTrue($this->psr11Container->has(self::class));
     }
 }

--- a/src/Reflection/composer.json
+++ b/src/Reflection/composer.json
@@ -30,7 +30,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-coveralls/php-coveralls": "^2.2",
-        "phpunit/phpunit": "~9.1"
+        "phpunit/phpunit": "~9.3"
     },
     "scripts": {
         "lint-check": "php-cs-fixer fix --config=.php_cs.dist -v --diff --dry-run",

--- a/src/Reflection/phpunit.xml.dist
+++ b/src/Reflection/phpunit.xml.dist
@@ -1,15 +1,14 @@
-<phpunit
-    bootstrap="vendor/autoload.php"
-    colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <html outputDirectory="./.coverage"/>
+        </report>
+    </coverage>
     <testsuite name="Reflection">
         <directory>tests</directory>
     </testsuite>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="./.coverage"/>
-    </logging>
 </phpunit>

--- a/src/Router/composer.json
+++ b/src/Router/composer.json
@@ -37,7 +37,7 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "nikic/fast-route": "1.2",
         "php-coveralls/php-coveralls": "^2.2",
-        "phpunit/phpunit": "~9.1",
+        "phpunit/phpunit": "~9.3",
         "symfony/routing": "4.2.*"
     },
     "scripts": {

--- a/src/Router/phpunit.xml.dist
+++ b/src/Router/phpunit.xml.dist
@@ -1,15 +1,14 @@
-<phpunit
-    bootstrap="phpunit.bootstrap.php"
-    colors="true">
-    <testsuite name="RouteMatcher">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="phpunit.bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <html outputDirectory="./.coverage"/>
+        </report>
+    </coverage>
+    <testsuite name="Router">
         <directory>tests</directory>
     </testsuite>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="./.coverage"/>
-    </logging>
 </phpunit>

--- a/src/Router/tests/RouteRegistrantCollectionTest.php
+++ b/src/Router/tests/RouteRegistrantCollectionTest.php
@@ -48,8 +48,7 @@ class RouteRegistrantCollectionTest extends TestCase
         $cachedRoutes = new RouteCollection();
         $cachedRoutes->add(new Route(new UriTemplate('foo'), new RouteAction('Foo', 'bar'), []));
         $cache = $this->createMock(IRouteCache::class);
-        $cache->expects($this->at(0))
-            ->method('get')
+        $cache->method('get')
             ->willReturn($cachedRoutes);
         $collection = new RouteRegistrantCollection($cache);
         $paramRoutes = new RouteCollection();
@@ -61,13 +60,13 @@ class RouteRegistrantCollectionTest extends TestCase
     {
         $expectedRoutes = new RouteCollection();
         $cache = $this->createMock(IRouteCache::class);
-        $cache->expects($this->at(0))
-            ->method('get')
+        $cache->method('get')
             ->willReturn(null);
-        $cache->expects($this->at(1))
-            ->method('set')
+        $cache->method('set')
             ->with($expectedRoutes);
         $collection = new RouteRegistrantCollection($cache);
         $collection->registerRoutes($expectedRoutes);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 }

--- a/src/Sessions/composer.json
+++ b/src/Sessions/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-coveralls/php-coveralls": "^2.2",
-        "phpunit/phpunit": "~9.1"
+        "phpunit/phpunit": "~9.3"
     },
     "scripts": {
         "lint-check": "php-cs-fixer fix --config=.php_cs.dist -v --diff --dry-run",

--- a/src/Sessions/phpunit.xml.dist
+++ b/src/Sessions/phpunit.xml.dist
@@ -1,15 +1,14 @@
-<phpunit
-    bootstrap="vendor/autoload.php"
-    colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <html outputDirectory="./.coverage"/>
+        </report>
+    </coverage>
     <testsuite name="Sessions">
         <directory>tests</directory>
     </testsuite>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="./.coverage"/>
-    </logging>
 </phpunit>

--- a/src/Sessions/tests/Middleware/SessionTest.php
+++ b/src/Sessions/tests/Middleware/SessionTest.php
@@ -187,30 +187,17 @@ class SessionTest extends TestCase
 
     public function testSessionIsOpenedAndVarsAreSet(): void
     {
-        $this->session->expects($this->at(0))
+        $this->session->expects($this->once())
             ->method('regenerateId');
-        $this->session->expects($this->at(1))
-            ->method('getId')
-            ->willReturn('foo');
-        $this->session->expects($this->at(2))
-            ->method('setMany')
-            ->with(['bar' => 'baz']);
-        $this->session->expects($this->at(3))
+        $this->session->expects($this->once())
             ->method('ageFlashData');
-        $this->session->expects($this->at(4))
-            ->method('getId')
+        $this->session->method('getId')
             ->willReturn('foo');
-        $this->session->expects($this->at(5))
-            ->method('getAll')
+        $this->session->method('setMany')
+            ->with(['bar' => 'baz']);
+        $this->session->method('getAll')
             ->willReturn(['bar' => 'baz']);
-        $this->session->expects($this->at(6))
-            ->method('getId')
-            ->willReturn('foo');
-        $this->sessionHandler->expects($this->at(0))
-            ->method('open')
-            ->with(null, 'session');
-        $this->sessionHandler->expects($this->at(1))
-            ->method('read')
+        $this->sessionHandler->method('read')
             ->with('foo')
             ->willReturn(\serialize(['bar' => 'baz']));
         $middleware = new Session(

--- a/src/Sessions/tests/SessionTest.php
+++ b/src/Sessions/tests/SessionTest.php
@@ -225,9 +225,11 @@ class SessionTest extends TestCase
     {
         $generatedId = str_repeat('1', IIdGenerator::MIN_LENGTH);
         $idGenerator = $this->createMock(IIdGenerator::class);
-        $idGenerator->expects($this->at(0))->method('idIsValid')->willReturn(false);
-        $idGenerator->expects($this->at(2))->method('idIsValid')->willReturn(true);
-        $idGenerator->expects($this->at(4))->method('idIsValid')->willReturn(true);
+        $idGenerator->method('idIsValid')
+            ->willReturnMap([
+                [null, false],
+                [$generatedId, true]
+            ]);
         $idGenerator->method('generate')->willReturn($generatedId);
         $session = new Session(null, $idGenerator);
         $session->regenerateId();
@@ -243,12 +245,15 @@ class SessionTest extends TestCase
 
     public function testSettingInvalidIdCausesNewIdToBeGenerated(): void
     {
+        $generatedId = str_repeat('1', IIdGenerator::MIN_LENGTH);
         $idGenerator = $this->createMock(IIdGenerator::class);
-        $idGenerator->expects($this->at(0))->method('idIsValid')->willReturn(false);
-        $idGenerator->expects($this->at(2))->method('idIsValid')->willReturn(true);
-        $idGenerator->expects($this->at(3))->method('idIsValid')->willReturn(false);
-        $idGenerator->expects($this->at(5))->method('idIsValid')->willReturn(true);
-        $idGenerator->method('generate')->willReturn(str_repeat('1', IIdGenerator::MIN_LENGTH));
+        $idGenerator->method('idIsValid')
+            ->willReturnMap([
+                [1, false],
+                [2, false],
+                [$generatedId, true]
+            ]);
+        $idGenerator->method('generate')->willReturn($generatedId);
         $session = new Session(1, $idGenerator);
         $this->assertNotEquals(1, $session->getId());
         $session->setId(2);

--- a/src/Validation/composer.json
+++ b/src/Validation/composer.json
@@ -33,7 +33,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-coveralls/php-coveralls": "^2.2",
-        "phpunit/phpunit": "~9.1"
+        "phpunit/phpunit": "~9.3"
     },
     "scripts": {
         "lint-check": "php-cs-fixer fix --config=.php_cs.dist -v --diff --dry-run",

--- a/src/Validation/phpunit.xml.dist
+++ b/src/Validation/phpunit.xml.dist
@@ -1,15 +1,14 @@
-<phpunit
-    bootstrap="phpunit.bootstrap.php"
-    colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="phpunit.bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <html outputDirectory="./.coverage"/>
+        </report>
+    </coverage>
     <testsuite name="Validation">
         <directory>tests</directory>
     </testsuite>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="./.coverage"/>
-    </logging>
 </phpunit>

--- a/src/Validation/tests/Constraints/ObjectConstraintsRegistrantCollectionTest.php
+++ b/src/Validation/tests/Constraints/ObjectConstraintsRegistrantCollectionTest.php
@@ -46,8 +46,7 @@ class ObjectConstraintsRegistrantCollectionTest extends TestCase
         $cachedConstraints = new ObjectConstraintsRegistry();
         $cachedConstraints->registerObjectConstraints(new ObjectConstraints('foo'));
         $cache = $this->createMock(IObjectConstraintsRegistryCache::class);
-        $cache->expects($this->at(0))
-            ->method('get')
+        $cache->method('get')
             ->willReturn($cachedConstraints);
         $collection = new ObjectConstraintsRegistrantCollection($cache);
         $paramConstraints = new ObjectConstraintsRegistry();
@@ -59,13 +58,13 @@ class ObjectConstraintsRegistrantCollectionTest extends TestCase
     {
         $expectedObjectConstraints = new ObjectConstraintsRegistry();
         $cache = $this->createMock(IObjectConstraintsRegistryCache::class);
-        $cache->expects($this->at(0))
-            ->method('get')
+        $cache->method('get')
             ->willReturn(null);
-        $cache->expects($this->at(1))
-            ->method('set')
+        $cache->method('set')
             ->with($expectedObjectConstraints);
         $collection = new ObjectConstraintsRegistrantCollection($cache);
         $collection->registerConstraints($expectedObjectConstraints);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 }


### PR DESCRIPTION
* Updated to use PHPUnit 9.3
* Fixed all deprecated usages of `TestCase::at()` to use alternatives
  * The alternatives (`withConsecutive()` and `willReturnMap()`) do not (easily) cover the cases when you want to verify that a void method was called with particular parameters some number of times

Closes #63 