### PR TITLE
Renamed IModule::build() to IModule::configure() for clarity

### DIFF
--- a/src/Application/src/Builders/ApplicationBuilder.php
+++ b/src/Application/src/Builders/ApplicationBuilder.php
@@ -86,13 +86,13 @@ abstract class ApplicationBuilder implements IApplicationBuilder
     }
 
     /**
-     * Builds all the registered modules
+     * Configures all the registered modules
      */
-    protected function buildModules(): void
+    protected function configureModules(): void
     {
         // Modules might be registered inside of modules, so we use a for loop instead of foreach (keys are changing)
         for ($i = 0;$i < \count($this->modules);$i++) {
-            $this->modules[$i]->build($this);
+            $this->modules[$i]->configure($this);
         }
     }
 }

--- a/src/Application/src/IModule.php
+++ b/src/Application/src/IModule.php
@@ -15,14 +15,14 @@ namespace Aphiria\Application;
 use Aphiria\Application\Builders\IApplicationBuilder;
 
 /**
- * Defines the interface implemented by classes that build whole modules of code
+ * Defines the interface implemented by classes that configure whole modules of code
  */
 interface IModule
 {
     /**
-     * Builds the module's components with the input app builder
+     * Configures the module's components with the input app builder
      *
      * @param IApplicationBuilder $appBuilder The app builder to use
      */
-    public function build(IApplicationBuilder $appBuilder): void;
+    public function configure(IApplicationBuilder $appBuilder): void;
 }

--- a/src/Application/tests/Builders/ApplicationBuilderTest.php
+++ b/src/Application/tests/Builders/ApplicationBuilderTest.php
@@ -28,7 +28,7 @@ class ApplicationBuilderTest extends TestCase
         $this->appBuilder = new class () extends ApplicationBuilder {
             public function build(): object
             {
-                $this->buildModules();
+                $this->configureModules();
                 $this->buildComponents();
 
                 return $this;
@@ -111,21 +111,21 @@ class ApplicationBuilderTest extends TestCase
         $this->appBuilder->getComponent($component::class);
     }
 
-    public function testModulesAreBuiltOnBuild(): void
+    public function testModulesAreConfiguredOnBuild(): void
     {
         $module = $this->createMock(IModule::class);
         $module->expects($this->once())
-            ->method('build')
+            ->method('configure')
             ->with($this->appBuilder);
         $this->appBuilder->withModule($module);
         $this->appBuilder->build();
     }
 
-    public function testModulesThatAreRegisteredInsideOfModulesAreBuilt(): void
+    public function testModulesThatAreRegisteredInsideOfModulesAreConfigured(): void
     {
         $innerModule = $this->createMock(IModule::class);
         $innerModule->expects($this->once())
-            ->method('build')
+            ->method('configure')
             ->with($this->appBuilder);
         $outerModule = new class ($innerModule) implements IModule {
             private IModule $innerModule;
@@ -135,7 +135,7 @@ class ApplicationBuilderTest extends TestCase
                 $this->innerModule = $innerModule;
             }
 
-            public function build(IApplicationBuilder $appBuilder): void
+            public function configure(IApplicationBuilder $appBuilder): void
             {
                 $appBuilder->withModule($this->innerModule);
             }

--- a/src/Console/src/Commands/ClosureCommandRegistrant.php
+++ b/src/Console/src/Commands/ClosureCommandRegistrant.php
@@ -20,7 +20,7 @@ use Closure;
 final class ClosureCommandRegistrant implements ICommandRegistrant
 {
     /**
-     * @param array<Closure(CommandRegistry): void> $closures The list of closures to execute
+     * @param list<Closure(CommandRegistry): void> $closures The list of closures to execute
      */
     public function __construct(private array $closures)
     {

--- a/src/Framework/src/Api/Builders/ApiApplicationBuilder.php
+++ b/src/Framework/src/Api/Builders/ApiApplicationBuilder.php
@@ -38,7 +38,7 @@ final class ApiApplicationBuilder extends ApplicationBuilder
      */
     public function build(): IRequestHandler
     {
-        $this->buildModules();
+        $this->configureModules();
         $this->buildComponents();
 
         try {

--- a/src/Framework/src/Console/Builders/ConsoleApplicationBuilder.php
+++ b/src/Framework/src/Console/Builders/ConsoleApplicationBuilder.php
@@ -37,7 +37,7 @@ final class ConsoleApplicationBuilder extends ApplicationBuilder
      */
     public function build(): ICommandBus
     {
-        $this->buildModules();
+        $this->configureModules();
         $this->buildComponents();
 
         try {

--- a/src/Framework/src/Console/Components/CommandComponent.php
+++ b/src/Framework/src/Console/Components/CommandComponent.php
@@ -27,7 +27,7 @@ use RuntimeException;
  */
 class CommandComponent implements IComponent
 {
-    /** @var array<Closure(CommandRegistry): void> The list of callbacks that can register commands */
+    /** @var list<Closure(CommandRegistry): void> The list of callbacks that can register commands */
     private array $callbacks = [];
     /** @var bool Whether or not attributes are enabled */
     private bool $attributesEnabled = false;

--- a/src/Framework/src/Routing/Components/RouterComponent.php
+++ b/src/Framework/src/Routing/Components/RouterComponent.php
@@ -32,7 +32,7 @@ use RuntimeException;
  */
 class RouterComponent implements IComponent
 {
-    /** @var array<Closure(RouteCollectionBuilder): void> The list of callbacks that can register route builders */
+    /** @var list<Closure(RouteCollectionBuilder): void> The list of callbacks that can register route builders */
     private array $callbacks = [];
     /** @var bool Whether or not attributes are enabled */
     private bool $attributesEnabled = false;

--- a/src/Framework/src/Validation/Components/ValidationComponent.php
+++ b/src/Framework/src/Validation/Components/ValidationComponent.php
@@ -30,7 +30,7 @@ class ValidationComponent implements IComponent
 {
     /** @var bool Whether or not attributes are enabled */
     private bool $attributesEnabled = false;
-    /** @var array<Closure(ObjectConstraintsRegistryBuilder): void> The list of callbacks that can register object constraints */
+    /** @var list<Closure(ObjectConstraintsRegistryBuilder): void> The list of callbacks that can register object constraints */
     private array $callbacks = [];
 
     /**

--- a/src/Framework/tests/Api/Builders/ApiApplicationBuilderTest.php
+++ b/src/Framework/tests/Api/Builders/ApiApplicationBuilderTest.php
@@ -58,7 +58,7 @@ class ApiApplicationBuilderTest extends TestCase
                 $this->builtParts = &$builtParts;
             }
 
-            public function build(IApplicationBuilder $appBuilder): void
+            public function configure(IApplicationBuilder $appBuilder): void
             {
                 $this->builtParts[] = $this::class;
             }

--- a/src/Framework/tests/Console/Builders/ConsoleApplicationBuilderTest.php
+++ b/src/Framework/tests/Console/Builders/ConsoleApplicationBuilderTest.php
@@ -54,7 +54,7 @@ class ConsoleApplicationBuilderTest extends TestCase
                 $this->builtParts = &$builtParts;
             }
 
-            public function build(IApplicationBuilder $appBuilder): void
+            public function configure(IApplicationBuilder $appBuilder): void
             {
                 $this->builtParts[] = $this::class;
             }

--- a/src/Net/tests/Http/StreamResponseWriterTest.php
+++ b/src/Net/tests/Http/StreamResponseWriterTest.php
@@ -52,7 +52,7 @@ class StreamResponseWriterTest extends TestCase
     /**
      * Gets a list of headers that should be not be concatenated
      *
-     * @return array<array<mixed>> The list of parameters to use
+     * @return list<list<mixed>> The list of parameters to use
      */
     public function getHeadersThatShouldNotBeConcatenated(): array
     {

--- a/src/Router/src/Builders/RouteCollectionBuilderRouteRegistrant.php
+++ b/src/Router/src/Builders/RouteCollectionBuilderRouteRegistrant.php
@@ -21,11 +21,11 @@ use Closure;
  */
 final class RouteCollectionBuilderRouteRegistrant implements IRouteRegistrant
 {
-    /** @var array<Closure(RouteCollectionBuilder): void> The list of closures that take in a RouteCollectionBuilder instance and register routes */
+    /** @var list<Closure(RouteCollectionBuilder): void> The list of closures that take in a RouteCollectionBuilder instance and register routes */
     private array $routeCollectionBuilderClosures;
 
     /**
-     * @param array<Closure(RouteCollectionBuilder): void>|Closure(RouteCollectionBuilder): void $routeCollectionBuilderClosures The list of closures that take in a RouteCollectionBuilder instance and register routes
+     * @param list<Closure(RouteCollectionBuilder): void>|Closure(RouteCollectionBuilder): void $routeCollectionBuilderClosures The list of closures that take in a RouteCollectionBuilder instance and register routes
      */
     public function __construct(Closure|array $routeCollectionBuilderClosures)
     {


### PR DESCRIPTION
`IModule::build()` was really just configuring all the components to use in that module - it wasn't building anything.  So, to clarify that fact, it was renamed to `IModule::configure()`.  `IComponent::build()`, on the other hand, is where the actual component gets built - it is configured via the `with*()` methods defined on the component.