### PR TITLE
Switched to using Mockery for any PHPUnit mocks that were using withC…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.2",
+        "mockery/mockery": "^1.4",
         "nyholm/psr7": "^1.4",
         "phpunit/phpunit": "~9.5",
         "vimeo/psalm": "^4.11"

--- a/src/Api/composer.json
+++ b/src/Api/composer.json
@@ -49,6 +49,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.2",
+        "mockery/mockery": "^1.4",
         "phpunit/phpunit": "~9.5"
     },
     "scripts": {

--- a/src/Console/composer.json
+++ b/src/Console/composer.json
@@ -44,6 +44,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.2",
+        "mockery/mockery": "^1.4",
         "phpunit/phpunit": "~9.5"
     },
     "scripts": {

--- a/src/Console/tests/Output/Formatters/ProgressBarTest.php
+++ b/src/Console/tests/Output/Formatters/ProgressBarTest.php
@@ -15,6 +15,7 @@ namespace Aphiria\Console\Tests\Output\Formatters;
 use Aphiria\Console\Output\Formatters\IProgressBarObserver;
 use Aphiria\Console\Output\Formatters\ProgressBar;
 use InvalidArgumentException;
+use Mockery;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -27,6 +28,11 @@ class ProgressBarTest extends TestCase
     {
         $this->formatter = $this->createMock(IProgressBarObserver::class);
         $this->progressBar = new ProgressBar(100, $this->formatter);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
     }
 
     public function testAdvancingBeyondMaxStepsDoesNotCallFormatter(): void
@@ -65,11 +71,15 @@ class ProgressBarTest extends TestCase
 
     public function testSettingProgressToValueLessThanZeroBoundsItToZero(): void
     {
-        $this->formatter->method('onProgressChanged')
-            ->withConsecutive([0, 1, 100], [1, 0, 100]);
+        $formatter = Mockery::mock(IProgressBarObserver::class);
+        $formatter->shouldReceive('onProgressChanged')
+            ->with(0, 1, 100);
+        $formatter->shouldReceive('onProgressChanged')
+            ->with(1, 0, 100);
+        $progressBar = new ProgressBar(100, $formatter);
         // Note: We're advancing at least once so that the update is sent to the formatter
-        $this->progressBar->advance();
-        $this->progressBar->setProgress(-1);
+        $progressBar->advance();
+        $progressBar->setProgress(-1);
         // Dummy assertion
         $this->assertTrue(true);
     }

--- a/src/Framework/composer.json
+++ b/src/Framework/composer.json
@@ -45,6 +45,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.2",
+        "mockery/mockery": "^1.4",
         "phpunit/phpunit": "~9.5"
     },
     "scripts": {

--- a/src/Framework/tests/Routing/Binders/RoutingBinderTest.php
+++ b/src/Framework/tests/Routing/Binders/RoutingBinderTest.php
@@ -28,21 +28,22 @@ use Aphiria\Routing\UriTemplates\Compilers\Tries\Caching\FileTrieCache;
 use Aphiria\Routing\UriTemplates\Compilers\Tries\Caching\ITrieCache;
 use Aphiria\Routing\UriTemplates\IRouteUriFactory;
 use Closure;
-use PHPUnit\Framework\MockObject\MockObject;
+use Mockery;
+use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 
 class RoutingBinderTest extends TestCase
 {
     private const ROUTE_CACHE_PATH = __DIR__ . '/tmp/routes.txt';
     private const TRIE_CACHE_PATH = __DIR__ . '/tmp/trie.txt';
-    private IContainer&MockObject $container;
+    private IContainer&MockInterface $container;
     private RoutingBinder $binder;
     private ?string $currEnvironment;
 
     protected function setUp(): void
     {
         $this->binder = new RoutingBinder();
-        $this->container = $this->createMock(IContainer::class);
+        $this->container = Mockery::mock(IContainer::class);
         GlobalConfiguration::resetConfigurationSources();
         $this->currEnvironment = \getenv('APP_ENV') ?: null;
 
@@ -57,6 +58,8 @@ class RoutingBinderTest extends TestCase
 
     protected function tearDown(): void
     {
+        Mockery::close();
+
         // Restore the environment name
         if ($this->currEnvironment === null) {
             \putenv('APP_ENV=');
@@ -75,11 +78,9 @@ class RoutingBinderTest extends TestCase
     public function testAttributeRegistrantIsBound(): void
     {
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(self::getBaseConfig()));
-        $this->setUpContainerMock([
-            [AttributeRouteRegistrant::class, $this->isInstanceOf(AttributeRouteRegistrant::class)]
-        ]);
-        $this->container->method('bindFactory')
-            ->with([IRouteMatcher::class, TrieRouteMatcher::class], $this->isInstanceOf(Closure::class));
+        $this->setUpContainerMock();
+        $this->container->shouldReceive('bindFactory')
+            ->with([IRouteMatcher::class, TrieRouteMatcher::class], Mockery::type(Closure::class), true);
         $this->binder->bind($this->container);
         // Dummy assertion
         $this->assertTrue(true);
@@ -91,12 +92,13 @@ class RoutingBinderTest extends TestCase
         \putenv('APP_ENV=production');
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(self::getBaseConfig()));
         $this->setUpContainerMock();
-        $this->container->method('bindFactory')
+        $this->container->shouldReceive('bindFactory')
             ->with(
                 [IRouteMatcher::class, TrieRouteMatcher::class],
-                $this->callback(function (Closure $factory) {
+                Mockery::on(function (Closure $factory) {
                     return $factory() instanceof TrieRouteMatcher;
-                })
+                }),
+                true
             );
         $this->binder->bind($this->container);
         // Dummy assertion
@@ -107,6 +109,14 @@ class RoutingBinderTest extends TestCase
     {
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(self::getBaseConfig()));
         $this->setUpContainerMock();
+        $this->container->shouldReceive('bindFactory')
+            ->with(
+                [IRouteMatcher::class, TrieRouteMatcher::class],
+                Mockery::on(function (Closure $factory) {
+                    return $factory() instanceof TrieRouteMatcher;
+                }),
+                true
+            );
         $this->binder->bind($this->container);
         // Dummy assertion
         $this->assertTrue(true);
@@ -116,12 +126,13 @@ class RoutingBinderTest extends TestCase
     {
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(self::getBaseConfig()));
         $this->setUpContainerMock();
-        $this->container->method('bindFactory')
+        $this->container->shouldReceive('bindFactory')
             ->with(
                 [IRouteMatcher::class, TrieRouteMatcher::class],
-                $this->callback(function (Closure $factory) {
+                Mockery::on(function (Closure $factory) {
                     return $factory() instanceof TrieRouteMatcher;
-                })
+                }),
+                true
             );
         $this->binder->bind($this->container);
         // Dummy assertion
@@ -146,26 +157,20 @@ class RoutingBinderTest extends TestCase
         ];
     }
 
-    /**
-     * Sets up the container mock
-     *
-     * @param list<array> $additionalParameters The additional parameters to configure
-     */
-    private function setUpContainerMock(array $additionalParameters = []): void
+    private function setUpContainerMock(): void
     {
         $parameters = [
-            [RouteCollection::class, $this->isInstanceOf(RouteCollection::class)],
-            [IRouteCache::class, $this->isInstanceOf(FileRouteCache::class)],
-            [ITrieCache::class, $this->isInstanceOf(FileTrieCache::class)],
-            [RouteRegistrantCollection::class, $this->isInstanceOf(RouteRegistrantCollection::class)],
-            [IRouteUriFactory::class, $this->isInstanceOf(AstRouteUriFactory::class)]
+            [RouteCollection::class, RouteCollection::class],
+            [IRouteCache::class, FileRouteCache::class],
+            [ITrieCache::class, FileTrieCache::class],
+            [RouteRegistrantCollection::class, RouteRegistrantCollection::class],
+            [IRouteUriFactory::class, AstRouteUriFactory::class],
+            [AttributeRouteRegistrant::class, AttributeRouteRegistrant::class]
         ];
 
-        foreach ($additionalParameters as $additionalParameter) {
-            $parameters[] = $additionalParameter;
+        foreach ($parameters as $parameter) {
+            $this->container->shouldReceive('bindInstance')
+                ->with($parameter[0], Mockery::type($parameter[1]));
         }
-
-        $this->container->method('bindInstance')
-            ->withConsecutive(...$parameters);
     }
 }

--- a/src/Framework/tests/Validation/Binders/ValidationBinderTest.php
+++ b/src/Framework/tests/Validation/Binders/ValidationBinderTest.php
@@ -29,25 +29,28 @@ use Aphiria\Validation\ErrorMessages\StringReplaceErrorMessageInterpolator;
 use Aphiria\Validation\IValidator;
 use Aphiria\Validation\Validator;
 use InvalidArgumentException;
-use PHPUnit\Framework\MockObject\MockObject;
+use Mockery;
+use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 
 class ValidationBinderTest extends TestCase
 {
-    private IContainer&MockObject $container;
+    private IContainer&MockInterface $container;
     private ValidationBinder $binder;
     private ?string $currEnvironment;
 
     protected function setUp(): void
     {
         $this->binder = new ValidationBinder();
-        $this->container = $this->createMock(IContainer::class);
+        $this->container = Mockery::mock(IContainer::class);
         GlobalConfiguration::resetConfigurationSources();
         $this->currEnvironment = \getenv('APP_ENV') ?: null;
     }
 
     protected function tearDown(): void
     {
+        Mockery::close();
+
         // Restore the environment name
         if ($this->currEnvironment === null) {
             \putenv('APP_ENV=');
@@ -60,8 +63,8 @@ class ValidationBinderTest extends TestCase
     {
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(self::getBaseConfig()));
         $this->setUpContainerMock([
-            [IErrorMessageInterpolator::class, $this->isInstanceOf(IErrorMessageInterpolator::class)],
-            [AttributeObjectConstraintsRegistrant::class, $this->isInstanceOf(AttributeObjectConstraintsRegistrant::class)]
+            [IErrorMessageInterpolator::class, IErrorMessageInterpolator::class],
+            [AttributeObjectConstraintsRegistrant::class, AttributeObjectConstraintsRegistrant::class]
         ]);
         $this->binder->bind($this->container);
         // Dummy assertion
@@ -73,7 +76,9 @@ class ValidationBinderTest extends TestCase
         // Basically just ensuring we cover the production case in this test
         \putenv('APP_ENV=production');
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(self::getBaseConfig()));
-        $this->setUpContainerMock();
+        $this->setUpContainerMock([
+            [IErrorMessageInterpolator::class, StringReplaceErrorMessageInterpolator::class]
+        ]);
         $this->binder->bind($this->container);
         // Dummy assertion
         $this->assertTrue(true);
@@ -81,16 +86,18 @@ class ValidationBinderTest extends TestCase
 
     public function testCustomErrorMessageRegistriesAreResolved(): void
     {
-        $errorMessageTemplates = $this->createMock(IErrorMessageTemplateRegistry::class);
+        $errorMessageTemplates = Mockery::mock(IErrorMessageTemplateRegistry::class);
         $config = self::getBaseConfig();
         $config['aphiria']['validation']['errorMessageTemplates'] = [
             'type' => $errorMessageTemplates::class
         ];
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration($config));
-        $this->setUpContainerMock();
-        $this->container->method('resolve')
+        $this->setUpContainerMock([
+            [IErrorMessageInterpolator::class, StringReplaceErrorMessageInterpolator::class]
+        ]);
+        $this->container->shouldReceive('resolve')
             ->with($errorMessageTemplates::class)
-            ->willReturn($errorMessageTemplates);
+            ->andReturn($errorMessageTemplates);
         $this->binder->bind($this->container);
         // Dummy assertion
         $this->assertTrue(true);
@@ -103,7 +110,9 @@ class ValidationBinderTest extends TestCase
             'type' => DefaultErrorMessageTemplateRegistry::class
         ];
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration($config));
-        $this->setUpContainerMock();
+        $this->setUpContainerMock([
+            [IErrorMessageInterpolator::class, StringReplaceErrorMessageInterpolator::class]
+        ]);
         $this->binder->bind($this->container);
         // Dummy assertion
         $this->assertTrue(true);
@@ -113,7 +122,7 @@ class ValidationBinderTest extends TestCase
     {
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(self::getBaseConfig()));
         $this->setUpContainerMock([
-            [IErrorMessageInterpolator::class, $this->isInstanceOf(StringReplaceErrorMessageInterpolator::class)]
+            [IErrorMessageInterpolator::class, StringReplaceErrorMessageInterpolator::class]
         ]);
         $this->binder->bind($this->container);
         // Dummy assertion
@@ -129,7 +138,12 @@ class ValidationBinderTest extends TestCase
             'type' => self::class
         ];
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration($config));
-        $this->setUpContainerMock();
+        $this->setUpContainerMock([
+            [IErrorMessageInterpolator::class, StringReplaceErrorMessageInterpolator::class]
+        ]);
+        $this->container->shouldReceive('resolve')
+            ->with(self::class)
+            ->andReturn($this);
         $this->binder->bind($this->container);
     }
 
@@ -153,7 +167,7 @@ class ValidationBinderTest extends TestCase
         ];
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration($config));
         $this->setUpContainerMock([
-            [IErrorMessageInterpolator::class, $this->isInstanceOf(IcuFormatErrorMessageInterpolator::class)]
+            [IErrorMessageInterpolator::class, IcuFormatErrorMessageInterpolator::class]
         ]);
         $this->binder->bind($this->container);
         // Dummy assertion
@@ -169,6 +183,9 @@ class ValidationBinderTest extends TestCase
             'type' => 'foo'
         ];
         GlobalConfiguration::addConfigurationSource(new HashTableConfiguration($config));
+        $this->setUpContainerMock([
+            [IErrorMessageInterpolator::class, 'foo']
+        ]);
         $this->binder->bind($this->container);
     }
 
@@ -200,17 +217,20 @@ class ValidationBinderTest extends TestCase
     private function setUpContainerMock(array $additionalParameters = []): void
     {
         $parameters = [
-            [ObjectConstraintsRegistry::class, $this->isInstanceOf(ObjectConstraintsRegistry::class)],
-            [[IValidator::class, Validator::class], $this->isInstanceOf(Validator::class)],
-            [IObjectConstraintsRegistryCache::class, $this->isInstanceOf(FileObjectConstraintsRegistryCache::class)],
-            [ObjectConstraintsRegistrantCollection::class, $this->isInstanceOf(ObjectConstraintsRegistrantCollection::class)]
+            [ObjectConstraintsRegistry::class, ObjectConstraintsRegistry::class],
+            [[IValidator::class, Validator::class], Validator::class],
+            [IObjectConstraintsRegistryCache::class, FileObjectConstraintsRegistryCache::class],
+            [ObjectConstraintsRegistrantCollection::class, ObjectConstraintsRegistrantCollection::class],
+            [AttributeObjectConstraintsRegistrant::class, AttributeObjectConstraintsRegistrant::class]
         ];
 
         foreach ($additionalParameters as $additionalParameter) {
             $parameters[] = $additionalParameter;
         }
 
-        $this->container->method('bindInstance')
-            ->withConsecutive(...$parameters);
+        foreach ($parameters as $parameter) {
+            $this->container->shouldReceive('bindInstance')
+                ->with($parameter[0], Mockery::type($parameter[1]));
+        }
     }
 }


### PR DESCRIPTION
…onsecutive(), which is to be deprecated in its version 10 release

Closes #161 