### PR TITLE
Fixed bug when a custom console exception output writer returns an en…

### DIFF
--- a/src/Framework/src/Api/Exceptions/ProblemDetailsExceptionRenderer.php
+++ b/src/Framework/src/Api/Exceptions/ProblemDetailsExceptionRenderer.php
@@ -89,7 +89,7 @@ class ProblemDetailsExceptionRenderer implements IApiExceptionRenderer
      * @param string|null|Closure(T): string $type The optional problem details type, or a closure that takes in the exception and returns a type, or null
      * @param string|null|Closure(T): string $title The optional problem details title, or a closure that takes in the exception and returns a title, or null
      * @param string|null|Closure(T): string $detail The optional problem details detail, or a closure that takes in the exception and returns a detail, or null
-     * @param HttpStatusCode|int|Closure(T): int $status The optional problem details status, or a closure that takes in the exception and returns a type, or null
+     * @param HttpStatusCode|int|Closure(T): HttpStatusCode|Closure(T): int $status The optional problem details status, or a closure that takes in the exception and returns a type, or null
      * @param string|null|Closure(T): string $instance The optional problem details instance, or a closure that takes in the exception and returns an instance, or null
      * @param array|null|Closure(T): array $extensions The optional problem details extensions, or a closure that takes in the exception and returns an exception, or null
      */

--- a/src/Framework/src/Application/AphiriaComponents.php
+++ b/src/Framework/src/Application/AphiriaComponents.php
@@ -25,6 +25,7 @@ use Aphiria\Authorization\IAuthorizationRequirementHandler;
 use Aphiria\Console\Commands\CommandBinding;
 use Aphiria\Console\Commands\CommandRegistry;
 use Aphiria\Console\Output\IOutput;
+use Aphiria\Console\StatusCode;
 use Aphiria\DependencyInjection\Binders\Binder;
 use Aphiria\DependencyInjection\Binders\IBinderDispatcher;
 use Aphiria\DependencyInjection\Container;
@@ -297,7 +298,7 @@ trait AphiriaComponents
      * @template T of Exception
      * @param IApplicationBuilder $appBuilder The app builder to decorate
      * @param class-string<T> $exceptionType The type of exception whose result factory we're registering
-     * @param Closure(T, IOutput): void|Closure(T, IOutput): int $callback The callback that takes in an exception and the output, and writes messages/returns the status code
+     * @param Closure(T, IOutput): void|Closure(T, IOutput): StatusCode|Closure(T, IOutput): int $callback The callback that takes in an exception and the output, and writes messages/returns the status code
      * @return static For chaining
      * @throws RuntimeException Thrown if the global instance of the container is not set
      */
@@ -482,7 +483,7 @@ trait AphiriaComponents
      * @param string|null|Closure(T): string $type The optional problem details type, or a closure that takes in the exception and returns a type, or null
      * @param string|null|Closure(T): string $title The optional problem details title, or a closure that takes in the exception and returns a title, or null
      * @param string|null|Closure(T): string $detail The optional problem details detail, or a closure that takes in the exception and returns a detail, or null
-     * @param HttpStatusCode|int|Closure(T): int $status The optional problem details status, or a closure that takes in the exception and returns a type, or null
+     * @param HttpStatusCode|int|Closure(T): HttpStatusCode|Closure(T): int $status The optional problem details status, or a closure that takes in the exception and returns a type, or null
      * @param string|null|Closure(T): string $instance The optional problem details instance, or a closure that takes in the exception and returns an instance, or null
      * @param array|null|Closure(T): array $extensions The optional problem details extensions, or a closure that takes in the exception and returns an exception, or null
      * @return static For chaining

--- a/src/Framework/src/Console/Exceptions/ConsoleExceptionRenderer.php
+++ b/src/Framework/src/Console/Exceptions/ConsoleExceptionRenderer.php
@@ -24,7 +24,7 @@ use Exception;
  */
 class ConsoleExceptionRenderer implements IExceptionRenderer
 {
-    /** @var array<class-string<Exception>, Closure(Exception, IOutput): void|Closure(Exception, IOutput): int> The mapping of exception types to callbacks that write output and return status codes */
+    /** @var array<class-string<Exception>, Closure(Exception, IOutput): void|Closure(Exception, IOutput): int|Closure(Exception, IOutput): StatusCode> The mapping of exception types to callbacks that write output and return status codes */
     protected array $outputWriters = [];
 
     /**
@@ -52,7 +52,7 @@ class ConsoleExceptionRenderer implements IExceptionRenderer
         if ($this->shouldExit) {
             // We cannot actually call exit() from a test, even from a separate process
             // @codeCoverageIgnoreStart
-            exit($statusCode);
+            exit($statusCode instanceof StatusCode ? $statusCode->value : $statusCode);
             // @codeCoverageIgnoreEnd
         }
     }

--- a/src/Framework/src/Exceptions/Components/ExceptionHandlerComponent.php
+++ b/src/Framework/src/Exceptions/Components/ExceptionHandlerComponent.php
@@ -14,6 +14,7 @@ namespace Aphiria\Framework\Exceptions\Components;
 
 use Aphiria\Application\IComponent;
 use Aphiria\Console\Output\IOutput;
+use Aphiria\Console\StatusCode;
 use Aphiria\DependencyInjection\IServiceResolver;
 use Aphiria\DependencyInjection\ResolutionException;
 use Aphiria\Exceptions\LogLevelFactory;
@@ -29,9 +30,9 @@ use Exception;
  */
 class ExceptionHandlerComponent implements IComponent
 {
-    /** @var array<class-string<Exception>, array{type: string|Closure(Exception): string|null, title: string|Closure(Exception): string|null, detail: string|Closure(Exception): string|null, status: HttpStatusCode|int|Closure(Exception): int, instance: string|Closure(Exception): string|null, extensions: array|Closure(Exception): array|null}> The mapping of exception types to problem detail settings */
+    /** @var array<class-string<Exception>, array{type: string|Closure(Exception): string|null, title: string|Closure(Exception): string|null, detail: string|Closure(Exception): string|null, status: HttpStatusCode|int|Closure(Exception): HttpStatusCode|Closure(Exception): int, instance: string|Closure(Exception): string|null, extensions: array|Closure(Exception): array|null}> The mapping of exception types to problem detail settings */
     private array $exceptionProblemDetailMappings = [];
-    /** @var array<class-string<Exception>, Closure(Exception, IOutput): void|Closure(mixed, IOutput): int> The mapping of exception types to console result factories */
+    /** @var array<class-string<Exception>, Closure(Exception, IOutput): void|Closure(mixed, IOutput): int|Closure(mixed, IOutput): StatusCode> The mapping of exception types to console result factories */
     private array $consoleOutputWriters = [];
     /** @var array<class-string<Exception>, Closure(Exception): string> The mapping of exception types to log level factories */
     private array $logLevelFactories = [];
@@ -72,7 +73,7 @@ class ExceptionHandlerComponent implements IComponent
      *
      * @template T of Exception
      * @param class-string<T> $exceptionType The type of exception that's thrown
-     * @param Closure(T, IOutput): void|Closure(T, IOutput): int $callback The factory that takes in the exception and output, and writes messages/returns a status code
+     * @param Closure(T, IOutput): void|Closure(T, IOutput): int|Closure(mixed, IOutput): StatusCode $callback The factory that takes in the exception and output, and writes messages/returns a status code
      * @return static For chaining
      */
     public function withConsoleOutputWriter(string $exceptionType, Closure $callback): static
@@ -107,7 +108,7 @@ class ExceptionHandlerComponent implements IComponent
      * @param string|null|Closure(T): string $type The optional problem details type, or a closure that takes in the exception and returns a type, or null
      * @param string|null|Closure(T): string $title The optional problem details title, or a closure that takes in the exception and returns a title, or null
      * @param string|null|Closure(T): string $detail The optional problem details detail, or a closure that takes in the exception and returns a detail, or null
-     * @param HttpStatusCode|int|Closure(T): int $status The optional problem details status, or a closure that takes in the exception and returns a type, or null
+     * @param HttpStatusCode|int|Closure(T): HttpStatusCode|Closure(T): int $status The optional problem details status, or a closure that takes in the exception and returns a type, or null
      * @param string|null|Closure(T): string $instance The optional problem details instance, or a closure that takes in the exception and returns an instance, or null
      * @param array|null|Closure(T): array $extensions The optional problem details extensions, or a closure that takes in the exception and returns an exception, or null
      * @return static For chaining


### PR DESCRIPTION
…um rather that just void or an int, fixed other PHPDoc for closures that return either enums or ints