### PR TITLE
Changed key-value pair collections to allow you to iterate over the keys and values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Changed
 
 - Removed `IRequest` parameter from `ProblemDetailsExceptionRenderer::__construct()` and changed `RequestBinder` to bind the request as a factory instead of a singleton ([214](https://github.com/aphiria/aphiria/pull/214))
+- `Aphiria\Collections\HashTable::getIterator()` and `ImmutableHashTable::getIterator()` now return `KeyValuePairIterator`, which allows you to grab the key and value directly from a `foreach` loop rather than iterating over a list of `KeyValuePair` objects ([#215](https://github.com/aphiria/aphiria/pull/215))
 - Changed to using templatized CI workflows for DRY ([#183](https://github.com/aphiria/aphiria/pull/183))
 - Removed PhpStorm meta files now that we're using generics ([#210](https://github.com/aphiria/aphiria/pull/210))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v1.0.0-alpha6](https://github.com/aphiria/aphiria/compare/v1.0.0-alpha5...v1.0.0-alpha6) (?)
+## [v1.0.0-alpha6](https://github.com/aphiria/aphiria/compare/v1.0.0-alpha5...v1.0.0-alpha6) (2022-02-26)
 
 ### Fixed
 
@@ -9,14 +9,14 @@
 - Fixed `RouteCollectionBuilder` to remove trailing slashes when the group path is not empty but the route path is ([#198](https://github.com/aphiria/aphiria/pull/198))
 - Fixed bug that caused console drivers to incorrectly detect the OS ([#207](https://github.com/aphiria/aphiria/pull/207))
 - Fixed bug that failed to handle problem detail factories that used an `HttpStatusCode` enum value for the status ([#202](https://github.com/aphiria/aphiria/pull/202))
-- Fixed some PHPDoc to use generics where applicable ([#178](https://github.com/aphiria/aphiria/pull/178)), ([#180](https://github.com/aphiria/aphiria/pull/180))
+- Fixed some PHPDoc to use generics where applicable ([#178](https://github.com/aphiria/aphiria/pull/178), [#180](https://github.com/aphiria/aphiria/pull/180))
 - Fixed `Aphiria\Net\Http\Formatting\ResponseFormatter::redirectToUri()` to accept an `HttpStatusCode` as well as an `int` status code ([#184](https://github.com/aphiria/aphiria/pull/184))
 - Re-enabled PHP-CS-Fixer in CI ([#188](https://github.com/aphiria/aphiria/pull/188))
 
 ### Changed
 
 - Removed `IRequest` parameter from `ProblemDetailsExceptionRenderer::__construct()` and changed `RequestBinder` to bind the request as a factory instead of a singleton ([214](https://github.com/aphiria/aphiria/pull/214))
-- `Aphiria\Collections\HashTable::getIterator()` and `ImmutableHashTable::getIterator()` now return `KeyValuePairIterator`, which allows you to grab the key and value directly from a `foreach` loop rather than iterating over a list of `KeyValuePair` objects ([#215](https://github.com/aphiria/aphiria/pull/215))
+- `Aphiria\Collections\HashTable::getIterator()` and `ImmutableHashTable::getIterator()` now return `KeyValuePairIterator`, which allows you to grab the key and value directly from a `foreach` loop rather than iterating over a list of `KeyValuePair` objects ([#221](https://github.com/aphiria/aphiria/pull/221))
 - Changed to using templatized CI workflows for DRY ([#183](https://github.com/aphiria/aphiria/pull/183))
 - Removed PhpStorm meta files now that we're using generics ([#210](https://github.com/aphiria/aphiria/pull/210))
 

--- a/src/Collections/src/HashTable.php
+++ b/src/Collections/src/HashTable.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Aphiria\Collections;
 
-use ArrayIterator;
 use InvalidArgumentException;
 use OutOfBoundsException;
 use RuntimeException;
@@ -120,6 +119,14 @@ class HashTable implements IDictionary
     /**
      * @inheritdoc
      */
+    public function getIterator(): Traversable
+    {
+        return new KeyValuePairIterator(\array_values($this->hashKeysToKvps));
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function getKeys(): array
     {
         $keys = [];
@@ -143,14 +150,6 @@ class HashTable implements IDictionary
         }
 
         return $values;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getIterator(): Traversable
-    {
-        return new ArrayIterator(\array_values($this->hashKeysToKvps));
     }
 
     /**

--- a/src/Collections/src/ImmutableHashTable.php
+++ b/src/Collections/src/ImmutableHashTable.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Aphiria\Collections;
 
-use ArrayIterator;
 use InvalidArgumentException;
 use OutOfBoundsException;
 use RuntimeException;
@@ -100,7 +99,7 @@ class ImmutableHashTable implements IImmutableDictionary
      */
     public function getIterator(): Traversable
     {
-        return new ArrayIterator(\array_values($this->hashKeysToKvps));
+        return new KeyValuePairIterator(\array_values($this->hashKeysToKvps));
     }
 
     /**

--- a/src/Collections/src/KeyValuePairIterator.php
+++ b/src/Collections/src/KeyValuePairIterator.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2022 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Collections;
+
+use Iterator;
+
+/**
+ * Defines an iterator for a list of key-value pairs
+ *
+ * @template TKey
+ * @template TValue
+ * @implements Iterator<TKey, TValue>
+ */
+class KeyValuePairIterator implements Iterator
+{
+    /** @var int The current index */
+    private int $currIndex = 0;
+
+    /**
+     * @param list<KeyValuePair<TKey, TValue>> $kvps The list of key-value pairs to iterate over
+     */
+    public function __construct(private readonly array $kvps)
+    {
+    }
+
+    /**
+     * @inheritdoc
+     * @return TValue
+     */
+    public function current(): mixed
+    {
+        return $this->kvps[$this->currIndex]->value;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function next(): void
+    {
+        $this->currIndex++;
+    }
+
+    /**
+     * @inheritdoc
+     * @return TKey
+     */
+    public function key(): mixed
+    {
+        return $this->kvps[$this->currIndex]->key;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function valid(): bool
+    {
+        return isset($this->kvps[$this->currIndex]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function rewind(): void
+    {
+        $this->currIndex = 0;
+    }
+}

--- a/src/Collections/tests/HashTableTest.php
+++ b/src/Collections/tests/HashTableTest.php
@@ -123,19 +123,15 @@ class HashTableTest extends TestCase
     {
         $this->hashTable->add('foo', 'bar');
         $this->hashTable->add('baz', 'blah');
-        $expectedArray = [
-            new KeyValuePair('foo', 'bar'),
-            new KeyValuePair('baz', 'blah')
-        ];
-        $actualValues = [];
+        /** @var list<array{0: string, 1: string}> $expectedValues */
+        $expectedValues = [['foo', 'bar'], ['baz', 'blah']];
+        $expectedValuesIndex = 0;
 
         foreach ($this->hashTable as $key => $value) {
-            // Make sure the hash keys aren't returned by the iterator
-            $this->assertIsInt($key);
-            $actualValues[] = $value;
+            $this->assertSame($expectedValues[$expectedValuesIndex][0], $key);
+            $this->assertSame($expectedValues[$expectedValuesIndex][1], $value);
+            $expectedValuesIndex++;
         }
-
-        $this->assertEquals($expectedArray, $actualValues);
     }
 
     /**

--- a/src/Collections/tests/ImmutableHashTableTest.php
+++ b/src/Collections/tests/ImmutableHashTableTest.php
@@ -99,15 +99,15 @@ class ImmutableHashTableTest extends TestCase
             new KeyValuePair('baz', 'blah')
         ];
         $hashTable = new ImmutableHashTable($expectedArray);
-        $actualValues = [];
+        /** @var list<array{0: string, 1: string}> $expectedValues */
+        $expectedValues = [['foo', 'bar'], ['baz', 'blah']];
+        $expectedValuesIndex = 0;
 
         foreach ($hashTable as $key => $value) {
-            // Make sure the hash keys aren't returned by the iterator
-            $this->assertIsInt($key);
-            $actualValues[] = $value;
+            $this->assertSame($expectedValues[$expectedValuesIndex][0], $key);
+            $this->assertSame($expectedValues[$expectedValuesIndex][1], $value);
+            $expectedValuesIndex++;
         }
-
-        $this->assertEquals($expectedArray, $actualValues);
     }
 
     public function testNonKeyValuePairInConstructorThrowsException(): void

--- a/src/Collections/tests/KeyValuePairIteratorTest.php
+++ b/src/Collections/tests/KeyValuePairIteratorTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2022 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Collections\Tests;
+
+use Aphiria\Collections\KeyValuePair;
+use Aphiria\Collections\KeyValuePairIterator;
+use PHPUnit\Framework\TestCase;
+
+class KeyValuePairIteratorTest extends TestCase
+{
+    public function testCurrentReturnsCurrentValueEvenWhenCallingNext(): void
+    {
+        $kvps = [
+            new KeyValuePair('foo', 'bar'),
+            new KeyValuePair('baz', 'quz')
+        ];
+        $iterator = new KeyValuePairIterator($kvps);
+        $this->assertSame('bar', $iterator->current());
+        $iterator->next();
+        $this->assertSame('quz', $iterator->current());
+    }
+    public function testKeyReturnsCurrentKeyEvenWhenCallingNext(): void
+    {
+        $kvps = [
+            new KeyValuePair('foo', 'bar'),
+            new KeyValuePair('baz', 'quz')
+        ];
+        $iterator = new KeyValuePairIterator($kvps);
+        $this->assertSame('foo', $iterator->key());
+        $iterator->next();
+        $this->assertSame('baz', $iterator->key());
+    }
+
+    public function testRewindResetsIterator(): void
+    {
+        $kvps = [
+            new KeyValuePair('foo', 'bar'),
+            new KeyValuePair('baz', 'quz')
+        ];
+        $iterator = new KeyValuePairIterator($kvps);
+        $this->assertSame('foo', $iterator->key());
+        $this->assertSame('bar', $iterator->current());
+        $iterator->next();
+        $this->assertSame('baz', $iterator->key());
+        $this->assertSame('quz', $iterator->current());
+        $iterator->rewind();
+        $this->assertSame('foo', $iterator->key());
+        $this->assertSame('bar', $iterator->current());
+        $iterator->next();
+        $this->assertSame('baz', $iterator->key());
+        $this->assertSame('quz', $iterator->current());
+    }
+
+    public function testValidIsOnlyTrueWhileIteratorIsInBounds(): void
+    {
+        $kvps = [
+            new KeyValuePair('foo', 'bar'),
+            new KeyValuePair('baz', 'quz')
+        ];
+        $iterator = new KeyValuePairIterator($kvps);
+        $this->assertTrue($iterator->valid());
+        $iterator->next();
+        $this->assertTrue($iterator->valid());
+        $iterator->next();
+        $this->assertFalse($iterator->valid());
+    }
+}

--- a/src/Net/src/Http/Formatting/ResponseHeaderParser.php
+++ b/src/Net/src/Http/Formatting/ResponseHeaderParser.php
@@ -41,20 +41,20 @@ class ResponseHeaderParser extends HeaderParser
         $numSetCookieHeaders = \count($setCookieHeaders);
 
         for ($i = 0;$i < $numSetCookieHeaders;$i++) {
-            $name = $value = $maxAge = $path = $domain = $sameSite = null;
+            $name = $cookieValue = $maxAge = $path = $domain = $sameSite = null;
             $isSecure = $isHttpOnly = false;
 
             /** @var KeyValuePair<string, string> $kvp */
-            foreach ($this->parseParameters($headers, 'Set-Cookie', $i) as $kvp) {
-                switch ($kvp->key) {
+            foreach ($this->parseParameters($headers, 'Set-Cookie', $i) as $key => $value) {
+                switch ($key) {
                     case 'Max-Age':
-                        $maxAge = (int)$kvp->value;
+                        $maxAge = (int)$value;
                         break;
                     case 'Path':
-                        $path = (string)$kvp->value;
+                        $path = (string)$value;
                         break;
                     case 'Domain':
-                        $domain = (string)$kvp->value;
+                        $domain = (string)$value;
                         break;
                     case 'Secure':
                         $isSecure = true;
@@ -63,12 +63,12 @@ class ResponseHeaderParser extends HeaderParser
                         $isHttpOnly = true;
                         break;
                     case 'SameSite':
-                        $sameSite = SameSiteMode::tryFrom((string)$kvp->value);
+                        $sameSite = SameSiteMode::tryFrom((string)$value);
                         break;
                     default:
                         // Treat the default value as the cookie name
-                        $name = (string)$kvp->key;
-                        $value = $kvp->value;
+                        $name = (string)$key;
+                        $cookieValue = $value;
                         break;
                 }
             }
@@ -79,7 +79,7 @@ class ResponseHeaderParser extends HeaderParser
 
             $cookies[] = new Cookie(
                 $name,
-                $value,
+                $cookieValue,
                 $maxAge,
                 $path,
                 $domain,

--- a/src/Net/src/Http/StreamResponseWriter.php
+++ b/src/Net/src/Http/StreamResponseWriter.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Aphiria\Net\Http;
 
-use Aphiria\Collections\KeyValuePair;
 use Aphiria\IO\Streams\IStream;
 use Aphiria\IO\Streams\Stream;
 
@@ -71,17 +70,16 @@ class StreamResponseWriter implements IResponseWriter
 
         $this->header($startLine);
 
-        /** @var KeyValuePair<string, list<string|int|float>> $kvp */
-        foreach ($response->getHeaders() as $kvp) {
-            $headerName = (string)$kvp->key;
+        foreach ($response->getHeaders() as $key => $value) {
+            $headerName = (string)$key;
 
             if (isset(self::$headersToNotConcatenate[$headerName])) {
                 /** @var string $headerValue */
-                foreach ($kvp->value as $headerValue) {
+                foreach ($value as $headerValue) {
                     $this->header("$headerName: $headerValue", false);
                 }
             } else {
-                $this->header("$headerName: " . \implode(', ', \array_map(static fn (mixed $value) => (string)$value, (array)$kvp->value)));
+                $this->header("$headerName: " . \implode(', ', \array_map(static fn (mixed $value) => (string)$value, (array)$value)));
             }
         }
 

--- a/src/PsrAdapters/src/Psr7/Psr7Factory.php
+++ b/src/PsrAdapters/src/Psr7/Psr7Factory.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Aphiria\PsrAdapters\Psr7;
 
-use Aphiria\Collections\KeyValuePair;
 use Aphiria\IO\Streams\IStream;
 use Aphiria\IO\Streams\Stream;
 use Aphiria\Net\Http\Formatting\RequestHeaderParser;
@@ -176,10 +175,9 @@ class Psr7Factory implements IPsr7Factory
             (string)$aphiriaRequest->getUri()
         );
 
-        /** @var KeyValuePair<string, list<string|int|float>> $kvp */
-        foreach ($aphiriaRequest->getHeaders() as $kvp) {
-            foreach ($kvp->value as $headerValue) {
-                $psr7Request = $psr7Request->withHeader((string)$kvp->key, (string)$headerValue);
+        foreach ($aphiriaRequest->getHeaders() as $key => $value) {
+            foreach ((array)$value as $headerValue) {
+                $psr7Request = $psr7Request->withHeader((string)$key, (string)$headerValue);
             }
         }
 
@@ -190,14 +188,12 @@ class Psr7Factory implements IPsr7Factory
         $psr7Request = $psr7Request->withUploadedFiles($this->createPsr7UploadedFiles($aphiriaRequest));
         $psr7CookieParams = $psr7QueryParams = [];
 
-        /** @var KeyValuePair<string, string> $kvp */
-        foreach ($this->aphiriaRequestParser->parseCookies($aphiriaRequest) as $kvp) {
-            $psr7CookieParams[$kvp->key] = $kvp->value;
+        foreach ($this->aphiriaRequestParser->parseCookies($aphiriaRequest) as $key => $value) {
+            $psr7CookieParams[$key] = $value;
         }
 
-        /** @var KeyValuePair<string, string> $kvp */
-        foreach ($this->aphiriaRequestParser->parseQueryString($aphiriaRequest) as $kvp) {
-            $psr7QueryParams[$kvp->key] = $kvp->value;
+        foreach ($this->aphiriaRequestParser->parseQueryString($aphiriaRequest) as $key => $value) {
+            $psr7QueryParams[$key] = $value;
         }
 
         $psr7Request = $psr7Request->withCookieParams($psr7CookieParams)
@@ -210,9 +206,8 @@ class Psr7Factory implements IPsr7Factory
             $psr7Request = $psr7Request->withParsedBody($parsedBody);
         }
 
-        /** @var KeyValuePair<string, mixed> $kvp */
-        foreach ($aphiriaRequest->getProperties() as $kvp) {
-            $psr7Request = $psr7Request->withAttribute((string)$kvp->key, $kvp->value);
+        foreach ($aphiriaRequest->getProperties() as $key => $value) {
+            $psr7Request = $psr7Request->withAttribute((string)$key, $value);
         }
 
         return $psr7Request;
@@ -229,10 +224,9 @@ class Psr7Factory implements IPsr7Factory
         )
             ->withProtocolVersion($aphiriaResponse->getProtocolVersion());
 
-        /** @var KeyValuePair<string, list<string|int|float>> $kvp */
-        foreach ($aphiriaResponse->getHeaders() as $kvp) {
-            foreach ((array)$kvp->value as $headerValue) {
-                $psr7Response = $psr7Response->withHeader((string)$kvp->key, (string)$headerValue);
+        foreach ($aphiriaResponse->getHeaders() as $key => $value) {
+            foreach ((array)$value as $headerValue) {
+                $psr7Response = $psr7Response->withHeader((string)$key, (string)$headerValue);
             }
         }
 

--- a/src/Sessions/tests/Middleware/SessionTest.php
+++ b/src/Sessions/tests/Middleware/SessionTest.php
@@ -25,7 +25,7 @@ use SessionHandlerInterface;
 class SessionTest extends TestCase
 {
     private ISession&MockObject $session;
-    private \SessionHandlerInterface&MockObject $sessionHandler;
+    private SessionHandlerInterface&MockObject $sessionHandler;
     private Headers $requestHeaders;
     private IRequest&MockObject $request;
     private Headers $responseHeaders;


### PR DESCRIPTION
Prior to this commit, you'd have to access keys and values like this:

```php
foreach ($collection as $kvp) {
    $key = $kvp->key;
    $value = $kvp->value;
}
```

This has been simplified to
```php
foreach ($collection as $key => $value) {
    // ...
}
```