### PR TITLE
More auth improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Changed
 
 - Updated to PHPUnit 10.1 ([#248](https://github.com/aphiria/aphiria/pull/248), [#250](https://github.com/aphiria/aphiria/pull/250))
+- Updated `IAuthenticator::authenticate()`, `IAuthenticator::challenge()`, `IAuthenticator::forbid()`, `IAuthenticator::logIn()`, and `IAuthenticator::logOut()` to take in no, one, or many authentication scheme names ([#269](https://github.com/aphiria/aphiria/pull/269))
+- Added the authentication scheme name(s) to `AuthenticationResult` ([#269](https://github.com/aphiria/aphiria/pull/269))
+- Removed `IUserAccessor` property from `Authenticator` ([#269](https://github.com/aphiria/aphiria/pull/269))
+- Renamed `SchemeNotFoundException` to `AuthenticationSchemeNotFoundException` ([#269](https://github.com/aphiria/aphiria/pull/269))
 
 ### Added
 
@@ -13,6 +17,7 @@
 - Added ability to easily deserialize request and response bodies in integration tests ([#253](https://github.com/aphiria/aphiria/pull/253))
 - Added `PrincipalBuilder` and `IdentityBuilder` ([#257](https://github.com/aphiria/aphiria/pull/257))
 - Added `IPrincipal::mergeIdentities()` ([#262](https://github.com/aphiria/aphiria/pull/262))
+- Added `AggregateAuthenticationException` when authenticating against multiple schemes and all of them failing ([#269](https://github.com/aphiria/aphiria/pull/269))
 
 ## [v1.0.0-alpha8](https://github.com/aphiria/aphiria/compare/v1.0.0-alpha7...v1.0.0-alpha8) (2022-12-10)
 

--- a/src/Authentication/src/AggregateAuthenticationException.php
+++ b/src/Authentication/src/AggregateAuthenticationException.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2023 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Authentication;
+
+use Exception;
+
+/**
+ * Defines an exception that aggregates multiple authentication exceptions
+ */
+final class AggregateAuthenticationException extends Exception
+{
+    /** @var list<Exception> The list of exceptions that created this exception */
+    public readonly array $innerExceptions;
+
+    /**
+     * @param string $message The message to set
+     * @param Exception|list<Exception> $exceptions The exception or list of exceptions to aggregate
+     */
+    public function __construct(string $message, Exception|array $exceptions)
+    {
+        parent::__construct($message);
+
+        $this->innerExceptions = $exceptions instanceof Exception ? [$exceptions] : $exceptions;
+    }
+}

--- a/src/Authentication/src/AuthenticationResult.php
+++ b/src/Authentication/src/AuthenticationResult.php
@@ -25,12 +25,14 @@ readonly class AuthenticationResult
 {
     /**
      * @param bool $passed Whether or not authentication passed
+     * @param string $schemeName The name of the authentication scheme used
      * @param IPrincipal|null $user The authenticated user if one was found, otherwise null
      * @param Exception|null $failure The failure that occurred, or null if none did
      * @throws InvalidArgumentException Thrown if the result is in an invalid state
      */
-    public function __construct(
+    protected function __construct(
         public bool $passed,
+        public string $schemeName,
         public ?IPrincipal $user = null,
         public ?Exception $failure = null
     ) {
@@ -47,21 +49,23 @@ readonly class AuthenticationResult
      * Creates a failed authentication result
      *
      * @param Exception|string $failure The exception that occurred or a failure message
+     * @param string $schemeName The name of the authentication scheme that failed
      * @return static A failed authentication result
      */
-    public static function fail(Exception|string $failure): static
+    public static function fail(Exception|string $failure, string $schemeName): static
     {
-        return new static(false, failure: \is_string($failure) ? new Exception($failure) : $failure);
+        return new static(false, $schemeName, failure: \is_string($failure) ? new Exception($failure) : $failure);
     }
 
     /**
      * Creates a passing authentication result
      *
      * @param IPrincipal $user The authenticated user
+     * @param string $schemeName The name of the authentication scheme that failed
      * @return static A passing authentication result
      */
-    public static function pass(IPrincipal $user): static
+    public static function pass(IPrincipal $user, string $schemeName): static
     {
-        return new static(true, $user);
+        return new static(true, $schemeName, $user);
     }
 }

--- a/src/Authentication/src/AuthenticationResult.php
+++ b/src/Authentication/src/AuthenticationResult.php
@@ -23,16 +23,19 @@ use InvalidArgumentException;
  */
 readonly class AuthenticationResult
 {
+    /** @var list<string> The list of scheme names evaluated in the result */
+    public array $schemeNames;
+
     /**
      * @param bool $passed Whether or not authentication passed
-     * @param string $schemeName The name of the authentication scheme used
+     * @param list<string>|string $schemeNames The name of the authentication scheme used
      * @param IPrincipal|null $user The authenticated user if one was found, otherwise null
      * @param Exception|null $failure The failure that occurred, or null if none did
      * @throws InvalidArgumentException Thrown if the result is in an invalid state
      */
     protected function __construct(
         public bool $passed,
-        public string $schemeName,
+        array|string $schemeNames,
         public ?IPrincipal $user = null,
         public ?Exception $failure = null
     ) {
@@ -43,29 +46,31 @@ readonly class AuthenticationResult
         if ($this->passed && $this->user === null) {
             throw new InvalidArgumentException('Passing authentication results must specify a user');
         }
+
+        $this->schemeNames = \is_string($schemeNames) ? [$schemeNames] : $schemeNames;
     }
 
     /**
      * Creates a failed authentication result
      *
      * @param Exception|string $failure The exception that occurred or a failure message
-     * @param string $schemeName The name of the authentication scheme that failed
+     *  @param list<string>|string $schemeNames The name or names of the authentication scheme that were evaluated
      * @return static A failed authentication result
      */
-    public static function fail(Exception|string $failure, string $schemeName): static
+    public static function fail(Exception|string $failure, array|string $schemeNames): static
     {
-        return new static(false, $schemeName, failure: \is_string($failure) ? new Exception($failure) : $failure);
+        return new static(false, $schemeNames, failure: \is_string($failure) ? new Exception($failure) : $failure);
     }
 
     /**
      * Creates a passing authentication result
      *
      * @param IPrincipal $user The authenticated user
-     * @param string $schemeName The name of the authentication scheme that failed
+     * @param list<string>|string $schemeNames The name or names of the authentication scheme that were evaluated
      * @return static A passing authentication result
      */
-    public static function pass(IPrincipal $user, string $schemeName): static
+    public static function pass(IPrincipal $user, array|string $schemeNames): static
     {
-        return new static(true, $schemeName, $user);
+        return new static(true, $schemeNames, $user);
     }
 }

--- a/src/Authentication/src/AuthenticationSchemeNotFoundException.php
+++ b/src/Authentication/src/AuthenticationSchemeNotFoundException.php
@@ -17,6 +17,6 @@ use Exception;
 /**
  * Defines the exception that's thrown when an authentication scheme is not found
  */
-final class SchemeNotFoundException extends Exception
+final class AuthenticationSchemeNotFoundException extends Exception
 {
 }

--- a/src/Authentication/src/Authenticator.php
+++ b/src/Authentication/src/Authenticator.php
@@ -49,7 +49,7 @@ class Authenticator implements IAuthenticator
                 // Merge this user with any previously-set user so that all the identities and claims are set for all schemes authenticated against
                 // We store this merged identity in a new authentication result, and return that one instead
                 $user->mergeIdentities($authResult->user);
-                $authResult = new AuthenticationResult($authResult->passed, $user, $authResult->failure);
+                $authResult = AuthenticationResult::pass($user, $scheme->name);
             }
 
             $this->userAccessor->setUser($authResult->user, $request);

--- a/src/Authentication/src/Authenticator.php
+++ b/src/Authentication/src/Authenticator.php
@@ -52,7 +52,7 @@ class Authenticator implements IAuthenticator
                 // Combine the principals
                 $user->mergeIdentities($authResult->user);
                 // TODO: What should the scheme name be here if we're authenticating with multiple schemes?
-                $authResult = AuthenticationResult::pass($user, $schemeName);
+                $authResult = AuthenticationResult::pass($user, $scheme->name);
             }
         }
 

--- a/src/Authentication/src/Authenticator.php
+++ b/src/Authentication/src/Authenticator.php
@@ -65,9 +65,9 @@ class Authenticator implements IAuthenticator
             }
         }
 
-        if (\count($resolvedSchemeNames) === 1) {
+        // Auth result will never be null, but the check below makes Psalm happy
+        if ($authResult instanceof AuthenticationResult && \count($resolvedSchemeNames) === 1) {
             // Just pass back the auth result directly
-            /** @psalm-suppress NullableReturnStatement There will always be at least one auth result because we do not allow an empty list of scheme names */
             return $authResult;
         }
 
@@ -144,7 +144,7 @@ class Authenticator implements IAuthenticator
     /**
      * Normalizes scheme names into an array of scheme names
      *
-     * @param list<string>|string|null $schemeNames The scheme name or names to normalize
+     * @param list<string|null>|string|null $schemeNames The scheme name or names to normalize
      * @return list<string|null> The normalized scheme names
      */
     private static function normalizeSchemeNames(array|string|null $schemeNames): array

--- a/src/Authentication/src/Authenticator.php
+++ b/src/Authentication/src/Authenticator.php
@@ -120,7 +120,7 @@ class Authenticator implements IAuthenticator
      * @template T of AuthenticationSchemeOptions
      * @param string|null $schemeName The name of the authentication scheme to get, or null if getting the default one
      * @return AuthenticationScheme<T> The authentication scheme
-     * @throws SchemeNotFoundException Thrown if no scheme could be found
+     * @throws AuthenticationSchemeNotFoundException Thrown if no scheme could be found
      */
     private function getScheme(?string $schemeName): AuthenticationScheme
     {
@@ -128,7 +128,7 @@ class Authenticator implements IAuthenticator
             $scheme = $this->schemes->getDefaultScheme();
 
             if ($scheme === null) {
-                throw new SchemeNotFoundException('No default authentication scheme found');
+                throw new AuthenticationSchemeNotFoundException('No default authentication scheme found');
             }
 
             return $scheme;
@@ -137,7 +137,7 @@ class Authenticator implements IAuthenticator
         try {
             return $this->schemes->getScheme($schemeName);
         } catch (OutOfBoundsException $ex) {
-            throw new SchemeNotFoundException("No authentication scheme with name \"$schemeName\" found", 0, $ex);
+            throw new AuthenticationSchemeNotFoundException("No authentication scheme with name \"$schemeName\" found", 0, $ex);
         }
     }
 }

--- a/src/Authentication/src/AuthenticatorBuilder.php
+++ b/src/Authentication/src/AuthenticatorBuilder.php
@@ -21,8 +21,6 @@ class AuthenticatorBuilder
 {
     /** @var IAuthenticationSchemeHandlerResolver|null The handler resolver to use, or null if none is set */
     private ?IAuthenticationSchemeHandlerResolver $handlerResolver = null;
-    /** @var IUserAccessor|null The user accessor to use, or null if none is set */
-    private ?IUserAccessor $userAccessor = null;
 
     /**
      * @param AuthenticationSchemeRegistry $schemes The authentication schemes to use
@@ -44,13 +42,7 @@ class AuthenticatorBuilder
             throw new RuntimeException('No handler resolver was specified');
         }
 
-        if ($this->userAccessor === null) {
-            $authenticator = new Authenticator($this->schemes, $this->handlerResolver);
-        } else {
-            $authenticator = new Authenticator($this->schemes, $this->handlerResolver, $this->userAccessor);
-        }
-
-        return $authenticator;
+        return new Authenticator($this->schemes, $this->handlerResolver);
     }
 
     /**
@@ -77,19 +69,6 @@ class AuthenticatorBuilder
     public function withScheme(AuthenticationScheme $scheme, bool $isDefault = false): static
     {
         $this->schemes->registerScheme($scheme, $isDefault);
-
-        return $this;
-    }
-
-    /**
-     * Sets the user accessor the authenticator will use
-     *
-     * @param IUserAccessor $userAccessor The user accessor to use
-     * @return static For chaining
-     */
-    public function withUserAccessor(IUserAccessor $userAccessor): static
-    {
-        $this->userAccessor = $userAccessor;
 
         return $this;
     }

--- a/src/Authentication/src/IAuthenticator.php
+++ b/src/Authentication/src/IAuthenticator.php
@@ -25,7 +25,7 @@ interface IAuthenticator
      * Attempts to authenticate a request
      *
      * @param IRequest $request The current request
-     * @param list<string>|string|null $schemeNames The name or names of the authentication scheme to use, or null if using the default one
+     * @param list<string|null>|string|null $schemeNames The name or names of the authentication scheme to use, or null if using the default one
      * @return AuthenticationResult The result of authentication
      * @throws AuthenticationSchemeNotFoundException Thrown if no scheme could be found
      */
@@ -36,7 +36,7 @@ interface IAuthenticator
      *
      * @param IRequest $request The current request
      * @param IResponse $response The current response
-     * @param list<string>|string|null $schemeNames The name or names of the authentication scheme to use, or null if using the default one
+     * @param list<string|null>|string|null $schemeNames The name or names of the authentication scheme to use, or null if using the default one
      * @throws AuthenticationSchemeNotFoundException Thrown if no scheme could be found
      */
     public function challenge(IRequest $request, IResponse $response, array|string $schemeNames = null): void;
@@ -46,7 +46,7 @@ interface IAuthenticator
      *
      * @param IRequest $request The current request
      * @param IResponse $response The current response
-     * @param list<string>|string|null $schemeNames The name or names of the authentication scheme to use, or null if using the default one
+     * @param list<string|null>|string|null $schemeNames The name or names of the authentication scheme to use, or null if using the default one
      * @throws AuthenticationSchemeNotFoundException Thrown if no scheme could be found
      */
     public function forbid(IRequest $request, IResponse $response, array|string $schemeNames = null): void;
@@ -57,7 +57,7 @@ interface IAuthenticator
      * @param IPrincipal $user The user to log in
      * @param IRequest $request The current request
      * @param IResponse $response The current response
-     * @param list<string>|string|null $schemeNames The name or names of the authentication scheme used, or null if using the default one
+     * @param list<string|null>|string|null $schemeNames The name or names of the authentication scheme used, or null if using the default one
      * @throws AuthenticationSchemeNotFoundException Thrown if no scheme could be found
      * @throws NotAuthenticatedException Thrown if the user's primary identity was not authenticated or set
      * @throws UnsupportedAuthenticationHandlerException Thrown if the scheme's handler does not support login
@@ -69,7 +69,7 @@ interface IAuthenticator
      *
      * @param IRequest $request The current request
      * @param IResponse $response The current response
-     * @param list<string>|string|null $schemeNames The name or names of the authentication scheme used, or null if using the default one
+     * @param list<string|null>|string|null $schemeNames The name or names of the authentication scheme used, or null if using the default one
      * @throws AuthenticationSchemeNotFoundException Thrown if no scheme could be found
      * @throws UnsupportedAuthenticationHandlerException Thrown if the scheme's handler does not support login
      */

--- a/src/Authentication/src/IAuthenticator.php
+++ b/src/Authentication/src/IAuthenticator.php
@@ -25,31 +25,31 @@ interface IAuthenticator
      * Attempts to authenticate a request
      *
      * @param IRequest $request The current request
-     * @param string|null $schemeName The name of the authentication scheme to use, or null if using the default one
+     * @param list<string>|string|null $schemeNames The name or names of the authentication scheme to use, or null if using the default one
      * @return AuthenticationResult The result of authentication
      * @throws AuthenticationSchemeNotFoundException Thrown if no scheme could be found
      */
-    public function authenticate(IRequest $request, string $schemeName = null): AuthenticationResult;
+    public function authenticate(IRequest $request, array|string $schemeNames = null): AuthenticationResult;
 
     /**
      * Challenges an unauthenticated request
      *
      * @param IRequest $request The current request
      * @param IResponse $response The current response
-     * @param string|null $schemeName The name of the authentication scheme to use, or null if using the default one
+     * @param list<string>|string|null $schemeNames The name or names of the authentication scheme to use, or null if using the default one
      * @throws AuthenticationSchemeNotFoundException Thrown if no scheme could be found
      */
-    public function challenge(IRequest $request, IResponse $response, string $schemeName = null): void;
+    public function challenge(IRequest $request, IResponse $response, array|string $schemeNames = null): void;
 
     /**
      * Forbids a request from accessing a resource
      *
      * @param IRequest $request The current request
      * @param IResponse $response The current response
-     * @param string|null $schemeName The name of the authentication scheme to use, or null if using the default one
+     * @param list<string>|string|null $schemeNames The name or names of the authentication scheme to use, or null if using the default one
      * @throws AuthenticationSchemeNotFoundException Thrown if no scheme could be found
      */
-    public function forbid(IRequest $request, IResponse $response, string $schemeName = null): void;
+    public function forbid(IRequest $request, IResponse $response, array|string $schemeNames = null): void;
 
     /**
      * Logs in a user
@@ -57,21 +57,21 @@ interface IAuthenticator
      * @param IPrincipal $user The user to log in
      * @param IRequest $request The current request
      * @param IResponse $response The current response
-     * @param string|null $schemeName The name of the authentication scheme used, or null if using the default one
+     * @param list<string>|string|null $schemeNames The name or names of the authentication scheme used, or null if using the default one
      * @throws AuthenticationSchemeNotFoundException Thrown if no scheme could be found
      * @throws NotAuthenticatedException Thrown if the user's primary identity was not authenticated or set
      * @throws UnsupportedAuthenticationHandlerException Thrown if the scheme's handler does not support login
      */
-    public function logIn(IPrincipal $user, IRequest $request, IResponse $response, string $schemeName = null): void;
+    public function logIn(IPrincipal $user, IRequest $request, IResponse $response, array|string $schemeNames = null): void;
 
     /**
      * Logs out a user
      *
      * @param IRequest $request The current request
      * @param IResponse $response The current response
-     * @param string|null $schemeName The name of the authentication scheme used, or null if using the default one
+     * @param list<string>|string|null $schemeNames The name or names of the authentication scheme used, or null if using the default one
      * @throws AuthenticationSchemeNotFoundException Thrown if no scheme could be found
      * @throws UnsupportedAuthenticationHandlerException Thrown if the scheme's handler does not support login
      */
-    public function logOut(IRequest $request, IResponse $response, string $schemeName = null): void;
+    public function logOut(IRequest $request, IResponse $response, array|string $schemeNames = null): void;
 }

--- a/src/Authentication/src/IAuthenticator.php
+++ b/src/Authentication/src/IAuthenticator.php
@@ -27,7 +27,7 @@ interface IAuthenticator
      * @param IRequest $request The current request
      * @param string|null $schemeName The name of the authentication scheme to use, or null if using the default one
      * @return AuthenticationResult The result of authentication
-     * @throws SchemeNotFoundException Thrown if no scheme could be found
+     * @throws AuthenticationSchemeNotFoundException Thrown if no scheme could be found
      */
     public function authenticate(IRequest $request, string $schemeName = null): AuthenticationResult;
 
@@ -37,7 +37,7 @@ interface IAuthenticator
      * @param IRequest $request The current request
      * @param IResponse $response The current response
      * @param string|null $schemeName The name of the authentication scheme to use, or null if using the default one
-     * @throws SchemeNotFoundException Thrown if no scheme could be found
+     * @throws AuthenticationSchemeNotFoundException Thrown if no scheme could be found
      */
     public function challenge(IRequest $request, IResponse $response, string $schemeName = null): void;
 
@@ -47,7 +47,7 @@ interface IAuthenticator
      * @param IRequest $request The current request
      * @param IResponse $response The current response
      * @param string|null $schemeName The name of the authentication scheme to use, or null if using the default one
-     * @throws SchemeNotFoundException Thrown if no scheme could be found
+     * @throws AuthenticationSchemeNotFoundException Thrown if no scheme could be found
      */
     public function forbid(IRequest $request, IResponse $response, string $schemeName = null): void;
 
@@ -58,7 +58,7 @@ interface IAuthenticator
      * @param IRequest $request The current request
      * @param IResponse $response The current response
      * @param string|null $schemeName The name of the authentication scheme used, or null if using the default one
-     * @throws SchemeNotFoundException Thrown if no scheme could be found
+     * @throws AuthenticationSchemeNotFoundException Thrown if no scheme could be found
      * @throws NotAuthenticatedException Thrown if the user's primary identity was not authenticated or set
      * @throws UnsupportedAuthenticationHandlerException Thrown if the scheme's handler does not support login
      */
@@ -70,7 +70,7 @@ interface IAuthenticator
      * @param IRequest $request The current request
      * @param IResponse $response The current response
      * @param string|null $schemeName The name of the authentication scheme used, or null if using the default one
-     * @throws SchemeNotFoundException Thrown if no scheme could be found
+     * @throws AuthenticationSchemeNotFoundException Thrown if no scheme could be found
      * @throws UnsupportedAuthenticationHandlerException Thrown if the scheme's handler does not support login
      */
     public function logOut(IRequest $request, IResponse $response, string $schemeName = null): void;

--- a/src/Authentication/src/Middleware/Authenticate.php
+++ b/src/Authentication/src/Middleware/Authenticate.php
@@ -39,11 +39,11 @@ class Authenticate extends ParameterizedMiddleware
      */
     public function handle(IRequest $request, IRequestHandler $next): IResponse
     {
+        // Default to a null scheme name if none was set
         /** @var list<string|null> $schemeNames */
         $schemeNames = $this->getParameter('schemeNames') ?? [null];
         $failedAuthenticationResults = [];
 
-        // Default to a null scheme name if none was set
         foreach ($schemeNames as $schemeName) {
             $authenticationResult = $this->authenticator->authenticate($request, $schemeName);
 

--- a/src/Authentication/src/Middleware/Authenticate.php
+++ b/src/Authentication/src/Middleware/Authenticate.php
@@ -45,6 +45,7 @@ class Authenticate extends ParameterizedMiddleware
         $failedAuthenticationResults = [];
 
         foreach ($schemeNames as $schemeName) {
+            // TODO: Should we actually set the user here rather than inside the authenticator?  Could help with abstraction since callers sort of know that the authenticator is setting the user under the hood.
             $authenticationResult = $this->authenticator->authenticate($request, $schemeName);
 
             if (!$authenticationResult->passed) {
@@ -74,7 +75,7 @@ class Authenticate extends ParameterizedMiddleware
         $response = new Response(HttpStatusCode::Unauthorized);
 
         foreach ($failedAuthenticationResults as $failedAuthenticationResult) {
-            $this->authenticator->challenge($request, $response, $failedAuthenticationResult->schemeName);
+            $this->authenticator->challenge($request, $response, $failedAuthenticationResult->schemeNames);
         }
 
         return $response;

--- a/src/Authentication/src/Middleware/Authenticate.php
+++ b/src/Authentication/src/Middleware/Authenticate.php
@@ -15,6 +15,8 @@ namespace Aphiria\Authentication\Middleware;
 use Aphiria\Authentication\AuthenticationResult;
 use Aphiria\Authentication\AuthenticationSchemeNotFoundException;
 use Aphiria\Authentication\IAuthenticator;
+use Aphiria\Authentication\IUserAccessor;
+use Aphiria\Authentication\RequestPropertyUserAccessor;
 use Aphiria\Middleware\ParameterizedMiddleware;
 use Aphiria\Net\Http\HttpStatusCode;
 use Aphiria\Net\Http\IRequest;
@@ -29,9 +31,12 @@ class Authenticate extends ParameterizedMiddleware
 {
     /**
      * @param IAuthenticator $authenticator The authenticator to use
+     * @param IUserAccessor $userAccessor The user accessor we'll store the authenticated user in
      */
-    public function __construct(private readonly IAuthenticator $authenticator)
-    {
+    public function __construct(
+        private readonly IAuthenticator $authenticator,
+        private readonly IUserAccessor $userAccessor = new RequestPropertyUserAccessor()
+    ) {
     }
 
     /**
@@ -42,41 +47,31 @@ class Authenticate extends ParameterizedMiddleware
         // Default to a null scheme name if none was set
         /** @var list<string|null> $schemeNames */
         $schemeNames = $this->getParameter('schemeNames') ?? [null];
-        $failedAuthenticationResults = [];
+        $authenticationResult = $this->authenticator->authenticate($request, $schemeNames);
 
-        foreach ($schemeNames as $schemeName) {
-            // TODO: Should we actually set the user here rather than inside the authenticator?  Could help with abstraction since callers sort of know that the authenticator is setting the user under the hood.
-            $authenticationResult = $this->authenticator->authenticate($request, $schemeName);
-
-            if (!$authenticationResult->passed) {
-                $failedAuthenticationResults[] = $authenticationResult;
-            }
+        if (!$authenticationResult->passed) {
+            return $this->handleFailedAuthenticationResult($request, $authenticationResult);
         }
 
-        // If all the schemes failed to authenticate, handle it
-        if (\count($failedAuthenticationResults) === \count($schemeNames)) {
-            return $this->handleFailedAuthenticationResults($request, $failedAuthenticationResults);
-        }
+        // Persist the user so that it can be retrieved in controllers
+        $this->userAccessor->setUser($authenticationResult->user, $request);
 
         return $next->handle($request);
     }
 
     /**
-     * Handles failed authentication results
+     * Handles a failed authentication result
      * This method can be overridden to, for example, add details about the failed authentication result to the response
      *
      * @param IRequest $request The current request
-     * @param list<AuthenticationResult> $failedAuthenticationResults The list of failed authentication results
+     * @param AuthenticationResult $failedAuthenticationResult The failed authentication result
      * @return IResponse The response
      * @throws AuthenticationSchemeNotFoundException Thrown if the scheme could not be found
      */
-    protected function handleFailedAuthenticationResults(IRequest $request, array $failedAuthenticationResults): IResponse
+    protected function handleFailedAuthenticationResult(IRequest $request, AuthenticationResult $failedAuthenticationResult): IResponse
     {
         $response = new Response(HttpStatusCode::Unauthorized);
-
-        foreach ($failedAuthenticationResults as $failedAuthenticationResult) {
-            $this->authenticator->challenge($request, $response, $failedAuthenticationResult->schemeNames);
-        }
+        $this->authenticator->challenge($request, $response, $failedAuthenticationResult->schemeNames);
 
         return $response;
     }

--- a/src/Authentication/src/Middleware/Authenticate.php
+++ b/src/Authentication/src/Middleware/Authenticate.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 namespace Aphiria\Authentication\Middleware;
 
 use Aphiria\Authentication\AuthenticationResult;
+use Aphiria\Authentication\AuthenticationSchemeNotFoundException;
 use Aphiria\Authentication\IAuthenticator;
-use Aphiria\Authentication\SchemeNotFoundException;
 use Aphiria\Middleware\ParameterizedMiddleware;
 use Aphiria\Net\Http\HttpStatusCode;
 use Aphiria\Net\Http\IRequest;
@@ -54,22 +54,22 @@ class Authenticate extends ParameterizedMiddleware
 
         // If all the schemes failed to authenticate, handle it
         if (\count($failedAuthenticationResults) === \count($schemeNames)) {
-            return $this->handleFailedAuthenticationResult($request, $failedAuthenticationResults);
+            return $this->handleFailedAuthenticationResults($request, $failedAuthenticationResults);
         }
 
         return $next->handle($request);
     }
 
     /**
-     * Handles a failed authentication result
+     * Handles failed authentication results
      * This method can be overridden to, for example, add details about the failed authentication result to the response
      *
      * @param IRequest $request The current request
      * @param list<AuthenticationResult> $failedAuthenticationResults The list of failed authentication results
      * @return IResponse The response
-     * @throws SchemeNotFoundException Thrown if the scheme could not be found
+     * @throws AuthenticationSchemeNotFoundException Thrown if the scheme could not be found
      */
-    protected function handleFailedAuthenticationResult(IRequest $request, array $failedAuthenticationResults): IResponse
+    protected function handleFailedAuthenticationResults(IRequest $request, array $failedAuthenticationResults): IResponse
     {
         $response = new Response(HttpStatusCode::Unauthorized);
 

--- a/src/Authentication/src/Schemes/BasicAuthenticationHandler.php
+++ b/src/Authentication/src/Schemes/BasicAuthenticationHandler.php
@@ -37,31 +37,46 @@ abstract class BasicAuthenticationHandler implements IAuthenticationSchemeHandle
         try {
             $authorizationHeaderValue = (string)$request->getHeaders()->getFirst('Authorization');
         } catch (OutOfBoundsException $ex) {
-            return AuthenticationResult::fail(new MissingAuthenticationDataException('Missing authorization header', previous: $ex));
+            return AuthenticationResult::fail(
+                new MissingAuthenticationDataException('Missing authorization header', previous: $ex),
+                $scheme->name
+            );
         }
 
         $explodedAuthorizationHeaderValue = \explode(' ', \trim($authorizationHeaderValue));
 
         if (\count($explodedAuthorizationHeaderValue) !== 2) {
-            return AuthenticationResult::fail(new InvalidArgumentException('Authorization header value was invalid'));
+            return AuthenticationResult::fail(
+                new InvalidArgumentException('Authorization header value was invalid'),
+                $scheme->name
+            );
         }
 
         [$authType, $base64EncodedCredentials] = $explodedAuthorizationHeaderValue;
 
         if (\strtolower($authType) !== 'basic') {
-            return AuthenticationResult::fail(new MissingAuthenticationDataException('Request did not use basic authentication'));
+            return AuthenticationResult::fail(
+                new MissingAuthenticationDataException('Request did not use basic authentication'),
+                $scheme->name
+            );
         }
 
         $base64DecodedCredentials = \base64_decode($base64EncodedCredentials, true);
 
         if ($base64DecodedCredentials === false) {
-            return AuthenticationResult::fail(new InvalidArgumentException('Authorization header did not contain valid base64-encoded value'));
+            return AuthenticationResult::fail(
+                new InvalidArgumentException('Authorization header did not contain valid base64-encoded value'),
+                $scheme->name
+            );
         }
 
         $explodedCredentials = \explode(':', $base64DecodedCredentials);
 
         if (\count($explodedCredentials) !== 2) {
-            return AuthenticationResult::fail(new InvalidArgumentException('Authorization header did not contain a base64-encoded username:password value'));
+            return AuthenticationResult::fail(
+                new InvalidArgumentException('Authorization header did not contain a base64-encoded username:password value'),
+                $scheme->name
+            );
         }
 
         [$username, $password] = $explodedCredentials;

--- a/src/Authentication/src/Schemes/CookieAuthenticationHandler.php
+++ b/src/Authentication/src/Schemes/CookieAuthenticationHandler.php
@@ -48,7 +48,10 @@ abstract class CookieAuthenticationHandler implements IAuthenticationSchemeHandl
     public function authenticate(IRequest $request, AuthenticationScheme $scheme): AuthenticationResult
     {
         if (($cookieValue = $this->getCookieValueFromRequest($request, $scheme)) === null) {
-            return AuthenticationResult::fail(new MissingAuthenticationDataException("Cookie {$scheme->options->cookieName} not set"));
+            return AuthenticationResult::fail(
+                new MissingAuthenticationDataException("Cookie {$scheme->options->cookieName} not set"),
+                $scheme->name
+            );
         }
 
         return $this->createAuthenticationResultFromCookie($cookieValue, $request, $scheme);

--- a/src/Authentication/tests/AggregateAuthenticationExceptionTest.php
+++ b/src/Authentication/tests/AggregateAuthenticationExceptionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2023 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Authentication\Tests;
+
+use Aphiria\Authentication\AggregateAuthenticationException;
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+class AggregateAuthenticationExceptionTest extends TestCase
+{
+    public function testEmptyInnerExceptionsAreAccepted(): void
+    {
+        $aggregateException = new AggregateAuthenticationException('foo', []);
+        $this->assertEmpty($aggregateException->innerExceptions);
+    }
+
+    public function testMessageSet(): void
+    {
+        $aggregateException = new AggregateAuthenticationException('foo', new Exception());
+        $this->assertSame('foo', $aggregateException->getMessage());
+    }
+
+    public function testMultipleExceptionIsConvertedToList(): void
+    {
+        $innerExceptions = [new Exception(), new Exception()];
+        $aggregateException = new AggregateAuthenticationException('foo', $innerExceptions);
+        $this->assertSame($innerExceptions, $aggregateException->innerExceptions);
+    }
+
+    public function testSingleExceptionIsConvertedToList(): void
+    {
+        $innerException = new Exception();
+        $aggregateException = new AggregateAuthenticationException('foo', $innerException);
+        $this->assertSame([$innerException], $aggregateException->innerExceptions);
+    }
+}

--- a/src/Authentication/tests/AuthenticationResultTest.php
+++ b/src/Authentication/tests/AuthenticationResultTest.php
@@ -17,6 +17,7 @@ use Aphiria\Authentication\Tests\Mocks\MockAuthenticationResult;
 use Aphiria\Security\IPrincipal;
 use Exception;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -49,10 +50,11 @@ class AuthenticationResultTest extends TestCase
         $this->assertFalse($result->passed);
     }
 
-    public function testFailSetsSchemeName(): void
+    #[TestWith(['foo', ['foo', 'bar']])]
+    public function testFailSetsSchemeNames(string|array $schemeNames): void
     {
-        $result = AuthenticationResult::fail(new RuntimeException('foo'), 'foo');
-        $this->assertSame('foo', $result->schemeName);
+        $result = AuthenticationResult::fail(new RuntimeException('foo'), $schemeNames);
+        $this->assertSame((array)$schemeNames, $result->schemeNames);
     }
 
     public function testPassingWithoutUserSetThrowsException(): void
@@ -68,9 +70,10 @@ class AuthenticationResultTest extends TestCase
         $this->assertTrue($result->passed);
     }
 
-    public function testPassSetsSchemeName(): void
+    #[TestWith(['foo', ['foo', 'bar']])]
+    public function testPassSetsSchemeNames(string|array $schemeNames): void
     {
-        $result = AuthenticationResult::pass($this->createMock(IPrincipal::class), 'foo');
-        $this->assertSame('foo', $result->schemeName);
+        $result = AuthenticationResult::pass($this->createMock(IPrincipal::class), $schemeNames);
+        $this->assertSame((array)$schemeNames, $result->schemeNames);
     }
 }

--- a/src/Authentication/tests/AuthenticationResultTest.php
+++ b/src/Authentication/tests/AuthenticationResultTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Aphiria\Authentication\Tests;
 
 use Aphiria\Authentication\AuthenticationResult;
+use Aphiria\Authentication\Tests\Mocks\MockAuthenticationResult;
 use Aphiria\Security\IPrincipal;
 use Exception;
 use InvalidArgumentException;
@@ -23,7 +24,7 @@ class AuthenticationResultTest extends TestCase
 {
     public function testFailConvertsStringToException(): void
     {
-        $result = AuthenticationResult::fail('foo');
+        $result = AuthenticationResult::fail('foo', 'bar');
         $this->assertInstanceOf(Exception::class, $result->failure);
         $this->assertSame('foo', $result->failure->getMessage());
     }
@@ -32,32 +33,44 @@ class AuthenticationResultTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Failed authentication results must specify a failure reason');
-        new AuthenticationResult(false);
+        new MockAuthenticationResult(false, 'foo');
     }
 
     public function testFailSetsFailureToException(): void
     {
         $expectedException = new RuntimeException('foo');
-        $result = AuthenticationResult::fail($expectedException);
+        $result = AuthenticationResult::fail($expectedException, 'foo');
         $this->assertSame($expectedException, $result->failure);
     }
 
     public function testFailSetsPassedToFalse(): void
     {
-        $result = AuthenticationResult::fail('foo');
+        $result = AuthenticationResult::fail('foo', 'bar');
         $this->assertFalse($result->passed);
+    }
+
+    public function testFailSetsSchemeName(): void
+    {
+        $result = AuthenticationResult::fail(new RuntimeException('foo'), 'foo');
+        $this->assertSame('foo', $result->schemeName);
     }
 
     public function testPassingWithoutUserSetThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Passing authentication results must specify a user');
-        new AuthenticationResult(true);
+        new MockAuthenticationResult(true, 'foo');
     }
 
     public function testPassSetsPassedToTrue(): void
     {
-        $result = AuthenticationResult::pass($this->createMock(IPrincipal::class));
+        $result = AuthenticationResult::pass($this->createMock(IPrincipal::class), 'foo');
         $this->assertTrue($result->passed);
+    }
+
+    public function testPassSetsSchemeName(): void
+    {
+        $result = AuthenticationResult::pass($this->createMock(IPrincipal::class), 'foo');
+        $this->assertSame('foo', $result->schemeName);
     }
 }

--- a/src/Authentication/tests/AuthenticationResultTest.php
+++ b/src/Authentication/tests/AuthenticationResultTest.php
@@ -50,8 +50,11 @@ class AuthenticationResultTest extends TestCase
         $this->assertFalse($result->passed);
     }
 
+    /**
+     * @param list<string>|string $schemeNames The scheme names to test
+     */
     #[TestWith(['foo', ['foo', 'bar']])]
-    public function testFailSetsSchemeNames(string|array $schemeNames): void
+    public function testFailSetsSchemeNames(array|string $schemeNames): void
     {
         $result = AuthenticationResult::fail(new RuntimeException('foo'), $schemeNames);
         $this->assertSame((array)$schemeNames, $result->schemeNames);
@@ -70,6 +73,9 @@ class AuthenticationResultTest extends TestCase
         $this->assertTrue($result->passed);
     }
 
+    /**
+     * @param list<string>|string $schemeNames The scheme names to test
+     */
     #[TestWith(['foo', ['foo', 'bar']])]
     public function testPassSetsSchemeNames(string|array $schemeNames): void
     {

--- a/src/Authentication/tests/AuthenticatorBuilderTest.php
+++ b/src/Authentication/tests/AuthenticatorBuilderTest.php
@@ -19,7 +19,6 @@ use Aphiria\Authentication\Authenticator;
 use Aphiria\Authentication\AuthenticatorBuilder;
 use Aphiria\Authentication\IAuthenticationSchemeHandlerResolver;
 use Aphiria\Authentication\IUserAccessor;
-use Aphiria\Authentication\RequestPropertyUserAccessor;
 use Aphiria\Authentication\Schemes\IAuthenticationSchemeHandler;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -38,15 +37,6 @@ class AuthenticatorBuilderTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('No handler resolver was specified');
         $this->authenticatorBuilder->build();
-    }
-
-    public function testBuildWithoutUserAccessorUsesDefaultOne(): void
-    {
-        $schemeHandlerResolver = $this->createMock(IAuthenticationSchemeHandlerResolver::class);
-        $authenticator = $this->authenticatorBuilder->withHandlerResolver($schemeHandlerResolver)
-            ->build();
-        $expectedAuthenticator = new Authenticator(new AuthenticationSchemeRegistry(), $schemeHandlerResolver, new RequestPropertyUserAccessor());
-        $this->assertEquals($expectedAuthenticator, $authenticator);
     }
 
     public function testWithMethodsReturnSameInstance(): void
@@ -86,17 +76,6 @@ class AuthenticatorBuilderTest extends TestCase
         $expectedSchemes = new AuthenticationSchemeRegistry();
         $expectedSchemes->registerScheme($scheme, true);
         $expectedAuthenticator = new Authenticator($expectedSchemes, $schemeHandlerResolver);
-        $this->assertEquals($expectedAuthenticator, $authenticator);
-    }
-
-    public function testWithUserAccessorSetsUserAccessor(): void
-    {
-        $schemeHandlerResolver = $this->createMock(IAuthenticationSchemeHandlerResolver::class);
-        $userAccessor = $this->createMock(IUserAccessor::class);
-        $authenticator = $this->authenticatorBuilder->withHandlerResolver($schemeHandlerResolver)
-            ->withUserAccessor($userAccessor)
-            ->build();
-        $expectedAuthenticator = new Authenticator(new AuthenticationSchemeRegistry(), $schemeHandlerResolver, $userAccessor);
         $this->assertEquals($expectedAuthenticator, $authenticator);
     }
 }

--- a/src/Authentication/tests/AuthenticatorBuilderTest.php
+++ b/src/Authentication/tests/AuthenticatorBuilderTest.php
@@ -44,7 +44,7 @@ class AuthenticatorBuilderTest extends TestCase
         /** @var IAuthenticationSchemeHandler<AuthenticationSchemeOptions> $schemeHandler */
         $schemeHandler = $this->createMock(IAuthenticationSchemeHandler::class);
         $instance2 = $this->authenticatorBuilder->withScheme(new AuthenticationScheme('foo', $schemeHandler::class));
-        $this->assertTrue($instance1 === $instance2 && $instance2);
+        $this->assertSame($instance1, $instance2);
     }
 
     public function testWithSchemeAddsSchemeToAuthenticator(): void

--- a/src/Authentication/tests/AuthenticatorBuilderTest.php
+++ b/src/Authentication/tests/AuthenticatorBuilderTest.php
@@ -18,7 +18,6 @@ use Aphiria\Authentication\AuthenticationSchemeRegistry;
 use Aphiria\Authentication\Authenticator;
 use Aphiria\Authentication\AuthenticatorBuilder;
 use Aphiria\Authentication\IAuthenticationSchemeHandlerResolver;
-use Aphiria\Authentication\IUserAccessor;
 use Aphiria\Authentication\Schemes\IAuthenticationSchemeHandler;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;

--- a/src/Authentication/tests/AuthenticatorBuilderTest.php
+++ b/src/Authentication/tests/AuthenticatorBuilderTest.php
@@ -45,8 +45,7 @@ class AuthenticatorBuilderTest extends TestCase
         /** @var IAuthenticationSchemeHandler<AuthenticationSchemeOptions> $schemeHandler */
         $schemeHandler = $this->createMock(IAuthenticationSchemeHandler::class);
         $instance2 = $this->authenticatorBuilder->withScheme(new AuthenticationScheme('foo', $schemeHandler::class));
-        $instance3 = $this->authenticatorBuilder->withUserAccessor($this->createMock(IUserAccessor::class));
-        $this->assertTrue($instance1 === $instance2 && $instance2 === $instance3);
+        $this->assertTrue($instance1 === $instance2 && $instance2);
     }
 
     public function testWithSchemeAddsSchemeToAuthenticator(): void

--- a/src/Authentication/tests/AuthenticatorTest.php
+++ b/src/Authentication/tests/AuthenticatorTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Aphiria\Authentication\Tests;
 
+use Aphiria\Authentication\AggregateAuthenticationException;
 use Aphiria\Authentication\AuthenticationResult;
 use Aphiria\Authentication\AuthenticationScheme;
 use Aphiria\Authentication\AuthenticationSchemeNotFoundException;
@@ -19,7 +20,6 @@ use Aphiria\Authentication\AuthenticationSchemeOptions;
 use Aphiria\Authentication\AuthenticationSchemeRegistry;
 use Aphiria\Authentication\Authenticator;
 use Aphiria\Authentication\IAuthenticationSchemeHandlerResolver;
-use Aphiria\Authentication\IUserAccessor;
 use Aphiria\Authentication\NotAuthenticatedException;
 use Aphiria\Authentication\Schemes\IAuthenticationSchemeHandler;
 use Aphiria\Authentication\Schemes\ILoginAuthenticationSchemeHandler;
@@ -29,25 +29,25 @@ use Aphiria\Net\Http\IResponse;
 use Aphiria\Security\ClaimType;
 use Aphiria\Security\IIdentity;
 use Aphiria\Security\IPrincipal;
+use InvalidArgumentException;
 use Mockery;
 use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class AuthenticatorTest extends TestCase
 {
-    private IAuthenticationSchemeHandlerResolver&MockObject $authenticationHandlerResolver;
+    private IAuthenticationSchemeHandlerResolver&MockInterface $authenticationHandlerResolver;
     private Authenticator $authenticator;
     private AuthenticationSchemeRegistry $schemes;
-    private IUserAccessor&MockInterface $userAccessor;
 
     protected function setUp(): void
     {
         $this->schemes = new AuthenticationSchemeRegistry();
-        $this->authenticationHandlerResolver = $this->createMock(IAuthenticationSchemeHandlerResolver::class);
-        $this->userAccessor = Mockery::mock(IUserAccessor::class);
-        $this->authenticator = new Authenticator($this->schemes, $this->authenticationHandlerResolver, $this->userAccessor);
+        $this->authenticationHandlerResolver = Mockery::mock(IAuthenticationSchemeHandlerResolver::class);
+        $this->authenticator = new Authenticator($this->schemes, $this->authenticationHandlerResolver);
     }
 
     protected function tearDown(): void
@@ -162,64 +162,10 @@ class AuthenticatorTest extends TestCase
         ];
     }
 
-    public function testAuthenticateDoesNotSetUserOnFailure(): void
-    {
-        $request = $this->createMock(IRequest::class);
-        $expectedResult = AuthenticationResult::fail('whoops', 'scheme');
-        [$scheme, $schemeHandler] = $this->createSchemeAndSetUpResolver('foo');
-        $schemeHandler->method('authenticate')
-            ->with($request, $scheme)
-            ->willReturn($expectedResult);
-        $this->userAccessor->shouldNotReceive('setUser');
-        $this->assertSame($expectedResult, $this->authenticator->authenticate($request, 'foo'));
-    }
-
-    public function testAuthenticateReturnsResultFromSchemeHandler(): void
-    {
-        $request = $this->createMock(IRequest::class);
-        $user = $this->createMock(IPrincipal::class);
-        $this->userAccessor->shouldReceive('getUser')
-            ->with($request)
-            ->andReturn(null);
-        $this->userAccessor->shouldReceive('setUser')
-            ->with($user, $request);
-        [$scheme, $schemeHandler] = $this->createSchemeAndSetUpResolver('foo');
-        $expectedResult = AuthenticationResult::pass($user, 'scheme');
-        $schemeHandler->method('authenticate')
-            ->with($request, $scheme)
-            ->willReturn($expectedResult);
-        $this->assertSame($expectedResult, $this->authenticator->authenticate($request, 'foo'));
-    }
-
-    public function testAuthenticateSetsUserOnSuccess(): void
-    {
-        $request = $this->createMock(IRequest::class);
-        $user = $this->createMock(IPrincipal::class);
-        $this->userAccessor->shouldReceive('getUser')
-            ->with($request)
-            ->andReturn(null);
-        $this->userAccessor->shouldReceive('setUser')
-            ->with($user, $request);
-        $expectedResult = AuthenticationResult::pass($user, 'scheme');
-        [$scheme, $schemeHandler] = $this->createSchemeAndSetUpResolver('foo');
-        $schemeHandler->expects($this->once())
-            ->method('authenticate')
-            ->with($request, $scheme)
-            ->willReturn($expectedResult);
-        $this->userAccessor->shouldReceive('setUser')
-            ->with($user, $request);
-        $this->assertSame($expectedResult, $this->authenticator->authenticate($request, 'foo'));
-    }
-
     public function testAuthenticateWithDefaultAuthenticationSchemeUsesDefaultScheme(): void
     {
         $request = $this->createMock(IRequest::class);
         $user = $this->createMock(IPrincipal::class);
-        $this->userAccessor->shouldReceive('getUser')
-            ->with($request)
-            ->andReturn(null);
-        $this->userAccessor->shouldReceive('setUser')
-            ->with($user, $request);
         $expectedResult = AuthenticationResult::pass($user, 'scheme');
         [$scheme, $schemeHandler] = $this->createSchemeAndSetUpResolver('foo');
         $schemeHandler->expects($this->once())
@@ -244,30 +190,116 @@ class AuthenticatorTest extends TestCase
         $this->authenticator->authenticate($this->createMock(IRequest::class), 'foo');
     }
 
-    public function testAuthenticatingUserWhenOneWasPreviouslySetMergesAuthenticatedIdentitiesAndSetsTheUser(): void
+    public function testAuthenticatingMultipleSchemesThatAllFailReturnsFailingResultWithAggregateFailure(): void
     {
         $request = $this->createMock(IRequest::class);
         $user1 = $this->createMock(IPrincipal::class);
         $user2 = $this->createMock(IPrincipal::class);
         $user1->method('mergeIdentities')
             ->with($user2);
-        $this->userAccessor->shouldReceive('getUser')
-            ->with($request)
-            ->andReturn($user1);
-        // The second user's identities should be merged into the first one's
-        $this->userAccessor->shouldReceive('setUser')
-            ->with($user1, $request);
-        [$scheme, $schemeHandler] = $this->createSchemeAndSetUpResolver('foo');
-        $expectedResult = AuthenticationResult::pass($user2, 'scheme');
-        $schemeHandler->method('authenticate')
-            ->with($request, $scheme)
-            ->willReturn($expectedResult);
+        [$scheme1, $scheme1Handler] = $this->createSchemeAndSetUpResolver('foo');
+        [$scheme2, $scheme2Handler] = $this->createSchemeAndSetUpResolver('bar');
+        $scheme1Handler->method('authenticate')
+            ->with($request, $scheme1)
+            ->willReturn(AuthenticationResult::fail('failure 1', 'foo'));
+        $scheme2Handler->method('authenticate')
+            ->with($request, $scheme2)
+            ->willReturn(AuthenticationResult::fail('failure 2', 'bar'));
+        $actualResult = $this->authenticator->authenticate($request, ['foo', 'bar']);
+        $this->assertFalse($actualResult->passed);
+        $this->assertSame('All authentication schemes failed to authenticate', $actualResult->failure?->getMessage());
+        $this->assertInstanceOf(AggregateAuthenticationException::class, $actualResult->failure);
+        $this->assertCount(2, $actualResult->failure?->innerExceptions);
+    }
+
+    public function testAuthenticatingMultipleSchemesThatMultiplePassReturnsPassingResultWithMergedUserIdentity(): void
+    {
+        $request = $this->createMock(IRequest::class);
+        $user1 = $this->createMock(IPrincipal::class);
+        $user2 = $this->createMock(IPrincipal::class);
+        $user1->method('mergeIdentities')
+            ->with($user2);
+        [$scheme1, $scheme1Handler] = $this->createSchemeAndSetUpResolver('foo');
+        [$scheme2, $scheme2Handler] = $this->createSchemeAndSetUpResolver('bar');
+        $scheme1Handler->method('authenticate')
+            ->with($request, $scheme1)
+            ->willReturn(AuthenticationResult::pass($user1, 'foo'));
+        $scheme2Handler->method('authenticate')
+            ->with($request, $scheme2)
+            ->willReturn(AuthenticationResult::pass($user2, 'bar'));
         // Note: The authenticator will essentially clone the expected result set above, but with user 1 merged with user 2's identities
-        $actualResult = $this->authenticator->authenticate($request, 'foo');
+        $actualResult = $this->authenticator->authenticate($request, ['foo', 'bar']);
+        $this->assertTrue($actualResult->passed);
         $this->assertSame($user1, $actualResult->user);
     }
 
-    public function testChallengeCallsSchemeHandler(): void
+    public function testAuthenticatingMultipleSchemesThatOnePassesReturnsPassingResult(): void
+    {
+        $request = $this->createMock(IRequest::class);
+        $user = $this->createMock(IPrincipal::class);
+        [$scheme1, $scheme1Handler] = $this->createSchemeAndSetUpResolver('foo');
+        [$scheme2, $scheme2Handler] = $this->createSchemeAndSetUpResolver('bar');
+        $scheme1Handler->method('authenticate')
+            ->with($request, $scheme1)
+            ->willReturn(AuthenticationResult::fail('fail', 'foo'));
+        $scheme2Handler->method('authenticate')
+            ->with($request, $scheme2)
+            ->willReturn(AuthenticationResult::pass($user, 'bar'));
+        $actualResult = $this->authenticator->authenticate($request, ['foo', 'bar']);
+        $this->assertTrue($actualResult->passed);
+        $this->assertSame($user, $actualResult->user);
+    }
+
+    public function testAuthenticatingSingleSchemeThatFailsReturnsFailingResult(): void
+    {
+        $request = $this->createMock(IRequest::class);
+        [$scheme, $schemeHandler] = $this->createSchemeAndSetUpResolver('foo');
+        // We're using a custom exception type to make sure that that's what is set in the auth result's failure
+        $expectedFailure = new RuntimeException('fail');
+        $schemeHandler->method('authenticate')
+            ->with($request, $scheme)
+            ->willReturn(AuthenticationResult::fail($expectedFailure, 'foo'));
+        $actualResult = $this->authenticator->authenticate($request, 'foo');
+        $this->assertFalse($actualResult->passed);
+        $this->assertSame($expectedFailure, $actualResult->failure);
+    }
+
+    public function testAuthenticatingSingleSchemeThatPassesReturnsPassingResult(): void
+    {
+        $request = $this->createMock(IRequest::class);
+        $user = $this->createMock(IPrincipal::class);
+        [$scheme, $schemeHandler] = $this->createSchemeAndSetUpResolver('foo');
+        $schemeHandler->method('authenticate')
+            ->with($request, $scheme)
+            ->willReturn(AuthenticationResult::pass($user, 'foo'));
+        $actualResult = $this->authenticator->authenticate($request, 'foo');
+        $this->assertTrue($actualResult->passed);
+        $this->assertSame($user, $actualResult->user);
+    }
+
+    public function testAuthenticatingWithEmptyListOfSchemeNamesThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('You must specify at least one scheme name or pass in null if using the default scheme');
+        $this->authenticator->authenticate($this->createMock(IRequest::class), []);
+    }
+
+    public function testChallengeForMultipleSchemesCallsAllSchemeHandlers(): void
+    {
+        $request = $this->createMock(IRequest::class);
+        $response = $this->createMock(IResponse::class);
+        [$scheme1, $scheme1Handler] = $this->createSchemeAndSetUpResolver('foo');
+        [$scheme2, $scheme2Handler] = $this->createSchemeAndSetUpResolver('bar');
+        $scheme1Handler->expects($this->once())
+            ->method('challenge')
+            ->with($request, $response, $scheme1);
+        $scheme2Handler->expects($this->once())
+            ->method('challenge')
+            ->with($request, $response, $scheme2);
+        $this->authenticator->challenge($request, $response, ['foo', 'bar']);
+    }
+
+    public function testChallengeForSingleSchemeCallsSchemeHandler(): void
     {
         $request = $this->createMock(IRequest::class);
         $response = $this->createMock(IResponse::class);
@@ -285,7 +317,22 @@ class AuthenticatorTest extends TestCase
         $this->authenticator->challenge($this->createMock(IRequest::class), $this->createMock(IResponse::class), 'foo');
     }
 
-    public function testForbidCallsSchemeHandler(): void
+    public function testForbidForMultipleSchemesCallsAllSchemeHandlers(): void
+    {
+        $request = $this->createMock(IRequest::class);
+        $response = $this->createMock(IResponse::class);
+        [$scheme1, $scheme1Handler] = $this->createSchemeAndSetUpResolver('foo');
+        [$scheme2, $scheme2Handler] = $this->createSchemeAndSetUpResolver('bar');
+        $scheme1Handler->expects($this->once())
+            ->method('forbid')
+            ->with($request, $response, $scheme1);
+        $scheme2Handler->expects($this->once())
+            ->method('forbid')
+            ->with($request, $response, $scheme2);
+        $this->authenticator->forbid($request, $response, ['foo', 'bar']);
+    }
+
+    public function testForbidForSingleSchemeCallsSchemeHandler(): void
     {
         $request = $this->createMock(IRequest::class);
         $response = $this->createMock(IResponse::class);
@@ -303,7 +350,28 @@ class AuthenticatorTest extends TestCase
         $this->authenticator->forbid($this->createMock(IRequest::class), $this->createMock(IResponse::class), 'foo');
     }
 
-    public function testLogInCallsSchemeHandler(): void
+    public function testLogInForMultipleSchemesCallsAllSchemeHandlers(): void
+    {
+        $request = $this->createMock(IRequest::class);
+        $response = $this->createMock(IResponse::class);
+        [$scheme1, $scheme1Handler] = $this->createLoginSchemeAndSetUpResolver('foo');
+        [$scheme2, $scheme2Handler] = $this->createLoginSchemeAndSetUpResolver('bar');
+        $identity = $this->createMock(IIdentity::class);
+        $identity->method('isAuthenticated')
+            ->willReturn(true);
+        $user = $this->createMock(IPrincipal::class);
+        $user->method('getPrimaryIdentity')
+            ->willReturn($identity);
+        $scheme1Handler->expects($this->once())
+            ->method('logIn')
+            ->with($user, $request, $response, $scheme1);
+        $scheme2Handler->expects($this->once())
+            ->method('logIn')
+            ->with($user, $request, $response, $scheme2);
+        $this->authenticator->logIn($user, $request, $response, ['foo', 'bar']);
+    }
+
+    public function testLogInForSingleSchemeCallsSchemeHandler(): void
     {
         $request = $this->createMock(IRequest::class);
         $response = $this->createMock(IResponse::class);
@@ -314,8 +382,6 @@ class AuthenticatorTest extends TestCase
         $user = $this->createMock(IPrincipal::class);
         $user->method('getPrimaryIdentity')
             ->willReturn($identity);
-        $this->userAccessor->shouldReceive('setUser')
-            ->with($user, $request);
         $schemeHandler->expects($this->once())
             ->method('logIn')
             ->with($user, $request, $response, $scheme);
@@ -365,12 +431,25 @@ class AuthenticatorTest extends TestCase
         $this->authenticator->logIn($user, $request, $response, 'foo');
     }
 
-    public function testLogOutCallsSchemeHandler(): void
+    public function testLogOutForMultipleSchemesCallsAllSchemeHandlers(): void
     {
         $request = $this->createMock(IRequest::class);
         $response = $this->createMock(IResponse::class);
-        $this->userAccessor->shouldReceive('setUser')
-            ->with(null, $request);
+        [$scheme1, $scheme1Handler] = $this->createLoginSchemeAndSetUpResolver('foo');
+        [$scheme2, $scheme2Handler] = $this->createLoginSchemeAndSetUpResolver('bar');
+        $scheme1Handler->expects($this->once())
+            ->method('logOut')
+            ->with($request, $response, $scheme1);
+        $scheme2Handler->expects($this->once())
+            ->method('logOut')
+            ->with($request, $response, $scheme2);
+        $this->authenticator->logOut($request, $response, ['foo', 'bar']);
+    }
+
+    public function testLogOutForSingleSchemeCallsSchemeHandler(): void
+    {
+        $request = $this->createMock(IRequest::class);
+        $response = $this->createMock(IResponse::class);
         [$scheme, $schemeHandler] = $this->createLoginSchemeAndSetUpResolver('foo');
         $schemeHandler->expects($this->once())
             ->method('logOut')
@@ -403,12 +482,17 @@ class AuthenticatorTest extends TestCase
      */
     private function createLoginSchemeAndSetUpResolver(string $schemeName): array
     {
+        // PHPUnit will not assign unique mock class names if you create multiple
+        // So, we'll use a mock builder to ensure that the generated class names are unique
+        $schemeHandlerClassName = "{$schemeName}_LoginSchemeHandler";
         /** @var ILoginAuthenticationSchemeHandler<AuthenticationSchemeOptions>&MockObject $schemeHandler */
-        $schemeHandler = $this->createMock(ILoginAuthenticationSchemeHandler::class);
+        $schemeHandler = $this->getMockBuilder(ILoginAuthenticationSchemeHandler::class)
+            ->setMockClassName($schemeHandlerClassName)
+            ->getMock();
         $scheme = new AuthenticationScheme($schemeName, $schemeHandler::class);
-        $this->authenticationHandlerResolver->method('resolve')
-            ->with($schemeHandler::class)
-            ->willReturn($schemeHandler);
+        $this->authenticationHandlerResolver->shouldReceive('resolve')
+            ->with($schemeHandlerClassName)
+            ->andReturn($schemeHandler);
         $this->schemes->registerScheme($scheme);
 
         return [$scheme, $schemeHandler];
@@ -422,12 +506,17 @@ class AuthenticatorTest extends TestCase
      */
     private function createSchemeAndSetUpResolver(string $schemeName): array
     {
+        // PHPUnit will not assign unique mock class names if you create multiple
+        // So, we'll use a mock builder to ensure that the generated class names are unique
+        $schemeHandlerClassName = "{$schemeName}_SchemeHandler";
         /** @var IAuthenticationSchemeHandler<AuthenticationSchemeOptions>&MockObject $schemeHandler */
-        $schemeHandler = $this->createMock(IAuthenticationSchemeHandler::class);
+        $schemeHandler = $this->getMockBuilder(IAuthenticationSchemeHandler::class)
+            ->setMockClassName($schemeHandlerClassName)
+            ->getMock();
         $scheme = new AuthenticationScheme($schemeName, $schemeHandler::class);
-        $this->authenticationHandlerResolver->method('resolve')
-            ->with($schemeHandler::class)
-            ->willReturn($schemeHandler);
+        $this->authenticationHandlerResolver->shouldReceive('resolve')
+            ->with($schemeHandlerClassName)
+            ->andReturn($schemeHandler);
         $this->schemes->registerScheme($scheme);
 
         return [$scheme, $schemeHandler];

--- a/src/Authentication/tests/AuthenticatorTest.php
+++ b/src/Authentication/tests/AuthenticatorTest.php
@@ -209,7 +209,7 @@ class AuthenticatorTest extends TestCase
         $this->assertFalse($actualResult->passed);
         $this->assertSame('All authentication schemes failed to authenticate', $actualResult->failure?->getMessage());
         $this->assertInstanceOf(AggregateAuthenticationException::class, $actualResult->failure);
-        $this->assertCount(2, $actualResult->failure?->innerExceptions);
+        $this->assertCount(2, $actualResult->failure?->innerExceptions ?? []);
     }
 
     public function testAuthenticatingMultipleSchemesThatMultiplePassReturnsPassingResultWithMergedUserIdentity(): void

--- a/src/Authentication/tests/AuthenticatorTest.php
+++ b/src/Authentication/tests/AuthenticatorTest.php
@@ -208,8 +208,11 @@ class AuthenticatorTest extends TestCase
         $actualResult = $this->authenticator->authenticate($request, ['foo', 'bar']);
         $this->assertFalse($actualResult->passed);
         $this->assertSame('All authentication schemes failed to authenticate', $actualResult->failure?->getMessage());
-        $this->assertInstanceOf(AggregateAuthenticationException::class, $actualResult->failure);
-        $this->assertCount(2, $actualResult->failure?->innerExceptions ?? []);
+        // I had to combine this check into one instance to make Psalm happy
+        $this->assertTrue(
+            $actualResult->failure instanceof AggregateAuthenticationException
+            && \count($actualResult->failure->innerExceptions) === 2
+        );
     }
 
     public function testAuthenticatingMultipleSchemesThatMultiplePassReturnsPassingResultWithMergedUserIdentity(): void

--- a/src/Authentication/tests/AuthenticatorTest.php
+++ b/src/Authentication/tests/AuthenticatorTest.php
@@ -14,13 +14,13 @@ namespace Aphiria\Authentication\Tests;
 
 use Aphiria\Authentication\AuthenticationResult;
 use Aphiria\Authentication\AuthenticationScheme;
+use Aphiria\Authentication\AuthenticationSchemeNotFoundException;
 use Aphiria\Authentication\AuthenticationSchemeOptions;
 use Aphiria\Authentication\AuthenticationSchemeRegistry;
 use Aphiria\Authentication\Authenticator;
 use Aphiria\Authentication\IAuthenticationSchemeHandlerResolver;
 use Aphiria\Authentication\IUserAccessor;
 use Aphiria\Authentication\NotAuthenticatedException;
-use Aphiria\Authentication\SchemeNotFoundException;
 use Aphiria\Authentication\Schemes\IAuthenticationSchemeHandler;
 use Aphiria\Authentication\Schemes\ILoginAuthenticationSchemeHandler;
 use Aphiria\Authentication\UnsupportedAuthenticationHandlerException;
@@ -232,14 +232,14 @@ class AuthenticatorTest extends TestCase
 
     public function testAuthenticateWithNoDefaultAuthenticationSchemeThrowsException(): void
     {
-        $this->expectException(SchemeNotFoundException::class);
+        $this->expectException(AuthenticationSchemeNotFoundException::class);
         $this->expectExceptionMessage('No default authentication scheme found');
         $this->authenticator->authenticate($this->createMock(IRequest::class));
     }
 
     public function testAuthenticateWithNonExistentSchemeThrowsException(): void
     {
-        $this->expectException(SchemeNotFoundException::class);
+        $this->expectException(AuthenticationSchemeNotFoundException::class);
         $this->expectExceptionMessage('No authentication scheme with name "foo" found');
         $this->authenticator->authenticate($this->createMock(IRequest::class), 'foo');
     }
@@ -280,7 +280,7 @@ class AuthenticatorTest extends TestCase
 
     public function testChallengeWithNonExistentSchemeThrowsException(): void
     {
-        $this->expectException(SchemeNotFoundException::class);
+        $this->expectException(AuthenticationSchemeNotFoundException::class);
         $this->expectExceptionMessage('No authentication scheme with name "foo" found');
         $this->authenticator->challenge($this->createMock(IRequest::class), $this->createMock(IResponse::class), 'foo');
     }
@@ -298,7 +298,7 @@ class AuthenticatorTest extends TestCase
 
     public function testForbidWithNonExistentSchemeThrowsException(): void
     {
-        $this->expectException(SchemeNotFoundException::class);
+        $this->expectException(AuthenticationSchemeNotFoundException::class);
         $this->expectExceptionMessage('No authentication scheme with name "foo" found');
         $this->authenticator->forbid($this->createMock(IRequest::class), $this->createMock(IResponse::class), 'foo');
     }
@@ -324,7 +324,7 @@ class AuthenticatorTest extends TestCase
 
     public function testLogInWithNonExistentSchemeThrowsException(): void
     {
-        $this->expectException(SchemeNotFoundException::class);
+        $this->expectException(AuthenticationSchemeNotFoundException::class);
         $this->expectExceptionMessage('No authentication scheme with name "foo" found');
         $identity = $this->createMock(IIdentity::class);
         $identity->method('isAuthenticated')
@@ -380,7 +380,7 @@ class AuthenticatorTest extends TestCase
 
     public function testLogOutWithNonExistentSchemeThrowsException(): void
     {
-        $this->expectException(SchemeNotFoundException::class);
+        $this->expectException(AuthenticationSchemeNotFoundException::class);
         $this->expectExceptionMessage('No authentication scheme with name "foo" found');
         $this->authenticator->logOut($this->createMock(IRequest::class), $this->createMock(IResponse::class), 'foo');
     }

--- a/src/Authentication/tests/AuthenticatorTest.php
+++ b/src/Authentication/tests/AuthenticatorTest.php
@@ -165,7 +165,7 @@ class AuthenticatorTest extends TestCase
     public function testAuthenticateDoesNotSetUserOnFailure(): void
     {
         $request = $this->createMock(IRequest::class);
-        $expectedResult = AuthenticationResult::fail('whoops');
+        $expectedResult = AuthenticationResult::fail('whoops', 'scheme');
         [$scheme, $schemeHandler] = $this->createSchemeAndSetUpResolver('foo');
         $schemeHandler->method('authenticate')
             ->with($request, $scheme)
@@ -184,7 +184,7 @@ class AuthenticatorTest extends TestCase
         $this->userAccessor->shouldReceive('setUser')
             ->with($user, $request);
         [$scheme, $schemeHandler] = $this->createSchemeAndSetUpResolver('foo');
-        $expectedResult = AuthenticationResult::pass($user);
+        $expectedResult = AuthenticationResult::pass($user, 'scheme');
         $schemeHandler->method('authenticate')
             ->with($request, $scheme)
             ->willReturn($expectedResult);
@@ -200,7 +200,7 @@ class AuthenticatorTest extends TestCase
             ->andReturn(null);
         $this->userAccessor->shouldReceive('setUser')
             ->with($user, $request);
-        $expectedResult = AuthenticationResult::pass($user);
+        $expectedResult = AuthenticationResult::pass($user, 'scheme');
         [$scheme, $schemeHandler] = $this->createSchemeAndSetUpResolver('foo');
         $schemeHandler->expects($this->once())
             ->method('authenticate')
@@ -220,7 +220,7 @@ class AuthenticatorTest extends TestCase
             ->andReturn(null);
         $this->userAccessor->shouldReceive('setUser')
             ->with($user, $request);
-        $expectedResult = AuthenticationResult::pass($user);
+        $expectedResult = AuthenticationResult::pass($user, 'scheme');
         [$scheme, $schemeHandler] = $this->createSchemeAndSetUpResolver('foo');
         $schemeHandler->expects($this->once())
             ->method('authenticate')
@@ -258,7 +258,7 @@ class AuthenticatorTest extends TestCase
         $this->userAccessor->shouldReceive('setUser')
             ->with($user1, $request);
         [$scheme, $schemeHandler] = $this->createSchemeAndSetUpResolver('foo');
-        $expectedResult = AuthenticationResult::pass($user2);
+        $expectedResult = AuthenticationResult::pass($user2, 'scheme');
         $schemeHandler->method('authenticate')
             ->with($request, $scheme)
             ->willReturn($expectedResult);

--- a/src/Authentication/tests/Middleware/AuthenticateTest.php
+++ b/src/Authentication/tests/Middleware/AuthenticateTest.php
@@ -62,9 +62,10 @@ class AuthenticateTest extends TestCase
         $next = $this->createMock(IRequestHandler::class);
 
         foreach ($schemeNames as $schemeName) {
+            // The auth scheme will always be set in the auth result in a real authenticator, so we fall back to a default scheme name in this test
             $this->authenticator->shouldReceive('authenticate')
                 ->with($request, $schemeName)
-                ->andReturn(AuthenticationResult::fail('foo'));
+                ->andReturn(AuthenticationResult::fail('foo', $schemeName ??  'schemeName'));
             $this->authenticator->shouldReceive('challenge')
                 ->withArgs(function (IRequest $actualRequest, IResponse $actualResponse, ?string $actualSchemeName) use ($request, $schemeName): bool {
                     return $actualRequest === $request
@@ -88,10 +89,10 @@ class AuthenticateTest extends TestCase
 
         $this->authenticator->shouldReceive('authenticate')
             ->with($request, 'foo')
-            ->andReturn(AuthenticationResult::fail('foo'));
+            ->andReturn(AuthenticationResult::fail('foo', 'scheme'));
         $this->authenticator->shouldReceive('authenticate')
             ->with($request, 'bar')
-            ->andReturn(AuthenticationResult::pass($this->createMock(IPrincipal::class)));
+            ->andReturn(AuthenticationResult::pass($this->createMock(IPrincipal::class), 'scheme'));
 
         $next->expects($this->once())
             ->method('handle')
@@ -113,7 +114,7 @@ class AuthenticateTest extends TestCase
         foreach ($schemeNames as $schemeName) {
             $this->authenticator->shouldReceive('authenticate')
                 ->with($request, $schemeName)
-                ->andReturn(AuthenticationResult::pass($this->createMock(IPrincipal::class)));
+                ->andReturn(AuthenticationResult::pass($this->createMock(IPrincipal::class), 'scheme'));
         }
 
         $next->expects($this->once())
@@ -131,10 +132,10 @@ class AuthenticateTest extends TestCase
 
         $this->authenticator->shouldReceive('authenticate')
             ->with($request, 'foo')
-            ->andReturn(AuthenticationResult::pass($this->createMock(IPrincipal::class)));
+            ->andReturn(AuthenticationResult::pass($this->createMock(IPrincipal::class), 'scheme'));
         $this->authenticator->shouldReceive('authenticate')
             ->with($request, 'bar')
-            ->andReturn(AuthenticationResult::fail('foo'));
+            ->andReturn(AuthenticationResult::fail('foo', 'scheme'));
 
         $next->expects($this->once())
             ->method('handle')

--- a/src/Authentication/tests/Middleware/AuthenticateTest.php
+++ b/src/Authentication/tests/Middleware/AuthenticateTest.php
@@ -64,9 +64,11 @@ class AuthenticateTest extends TestCase
         $request = $this->createMock(IRequest::class);
         $response = $this->createMock(IResponse::class);
         $next = $this->createMock(IRequestHandler::class);
+        // Authenticator will resolve null scheme names to the default scheme.  So, we'll create a dummy list of resolved scheme names that do not contain null.
+        $resolvedSchemeNames = \array_fill(0, \count($schemeNames), 'scheme');
         $this->authenticator->shouldReceive('authenticate')
             ->with($request, $schemeNames)
-            ->andReturn(AuthenticationResult::fail('foo', $schemeNames));
+            ->andReturn(AuthenticationResult::fail('foo', $resolvedSchemeNames));
         $this->authenticator->shouldReceive('challenge')
             ->withArgs(function (IRequest $actualRequest, IResponse $actualResponse, array|string $actualSchemeNames) use ($request, $schemeNames): bool {
                 // Similar to the above note, the real auth result will contain a non-null scheme name
@@ -90,9 +92,11 @@ class AuthenticateTest extends TestCase
         $request = $this->createMock(IRequest::class);
         $response = $this->createMock(IResponse::class);
         $next = $this->createMock(IRequestHandler::class);
+        // Authenticator will resolve null scheme names to the default scheme.  So, we'll create a dummy list of resolved scheme names that do not contain null.
+        $resolvedSchemeNames = \array_fill(0, \count($schemeNames), 'scheme');
         $this->authenticator->shouldReceive('authenticate')
             ->with($request, $schemeNames)
-            ->andReturn(AuthenticationResult::pass($this->createMock(IPrincipal::class), $schemeNames));
+            ->andReturn(AuthenticationResult::pass($this->createMock(IPrincipal::class), $resolvedSchemeNames));
         $next->expects($this->once())
             ->method('handle')
             ->willReturn($response);

--- a/src/Authentication/tests/Middleware/AuthenticateTest.php
+++ b/src/Authentication/tests/Middleware/AuthenticateTest.php
@@ -68,9 +68,10 @@ class AuthenticateTest extends TestCase
                 ->andReturn(AuthenticationResult::fail('foo', $schemeName ??  'schemeName'));
             $this->authenticator->shouldReceive('challenge')
                 ->withArgs(function (IRequest $actualRequest, IResponse $actualResponse, ?string $actualSchemeName) use ($request, $schemeName): bool {
+                    // Similar to the above note, the real auth result will contain a non-null scheme name
                     return $actualRequest === $request
                         && $actualResponse->getStatusCode() === HttpStatusCode::Unauthorized
-                        && $actualSchemeName === $schemeName;
+                        && $actualSchemeName === ($schemeName ?? 'schemeName');
                 });
         }
 

--- a/src/Authentication/tests/Middleware/AuthenticateTest.php
+++ b/src/Authentication/tests/Middleware/AuthenticateTest.php
@@ -70,11 +70,11 @@ class AuthenticateTest extends TestCase
             ->with($request, $schemeNames)
             ->andReturn(AuthenticationResult::fail('foo', $resolvedSchemeNames));
         $this->authenticator->shouldReceive('challenge')
-            ->withArgs(function (IRequest $actualRequest, IResponse $actualResponse, array|string $actualSchemeNames) use ($request, $schemeNames): bool {
+            ->withArgs(function (IRequest $actualRequest, IResponse $actualResponse, array|string $actualSchemeNames) use ($request, $resolvedSchemeNames): bool {
                 // Similar to the above note, the real auth result will contain a non-null scheme name
                 return $actualRequest === $request
                     && $actualResponse->getStatusCode() === HttpStatusCode::Unauthorized
-                    && $actualSchemeNames === $schemeNames;
+                    && $actualSchemeNames === $resolvedSchemeNames;
             });
         $next->expects($this->never())
             ->method('handle')

--- a/src/Authentication/tests/Mocks/MockAuthenticationResult.php
+++ b/src/Authentication/tests/Mocks/MockAuthenticationResult.php
@@ -21,9 +21,15 @@ use Exception;
  */
 readonly class MockAuthenticationResult extends AuthenticationResult
 {
+    /**
+     * @param bool $passed
+     * @param list<string>|string $schemeName
+     * @param IPrincipal|null $user
+     * @param Exception|null $failure
+     */
     public function __construct(
         bool $passed,
-        string $schemeName,
+        array|string $schemeName,
         ?IPrincipal $user = null,
         ?Exception $failure = null
     ) {

--- a/src/Authentication/tests/Mocks/MockAuthenticationResult.php
+++ b/src/Authentication/tests/Mocks/MockAuthenticationResult.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2023 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Authentication\Tests\Mocks;
+
+use Aphiria\Authentication\AuthenticationResult;
+use Aphiria\Security\IPrincipal;
+use Exception;
+
+/**
+ * Defines a mock authentication result that elevates the protected constructor in the base class for testing
+ */
+readonly class MockAuthenticationResult extends AuthenticationResult
+{
+    public function __construct(
+        bool $passed,
+        string $schemeName,
+        ?IPrincipal $user = null,
+        ?Exception $failure = null
+    ) {
+        parent::__construct($passed, $schemeName, $user, $failure);
+    }
+}

--- a/src/Authentication/tests/Schemes/BasicAuthenticationHandlerTest.php
+++ b/src/Authentication/tests/Schemes/BasicAuthenticationHandlerTest.php
@@ -139,7 +139,7 @@ class BasicAuthenticationHandlerTest extends TestCase
         $request->method('getHeaders')
             ->willReturn($headers);
         $headers->add('Authorization', $authorizationHeaderValue);
-        $this->schemeHandler->expectedResult = AuthenticationResult::pass($this->createMock(IPrincipal::class));
+        $this->schemeHandler->expectedResult = AuthenticationResult::pass($this->createMock(IPrincipal::class), 'foo');
         $scheme = new AuthenticationScheme('foo', $this->schemeHandler::class, new BasicAuthenticationOptions());
         $this->assertSame($this->schemeHandler->expectedResult, $this->schemeHandler->authenticate($request, $scheme));
         $this->assertSame('foo', $this->schemeHandler->actualUsername);

--- a/src/Authentication/tests/Schemes/BasicAuthenticationHandlerTest.php
+++ b/src/Authentication/tests/Schemes/BasicAuthenticationHandlerTest.php
@@ -64,7 +64,7 @@ class BasicAuthenticationHandlerTest extends TestCase
                 IRequest $request,
                 AuthenticationScheme $scheme
             ): AuthenticationResult {
-                return AuthenticationResult::fail('foo');
+                return AuthenticationResult::fail('foo', $scheme->name);
             }
         };
 

--- a/src/Authentication/tests/Schemes/CookieAuthenticationHandlerTest.php
+++ b/src/Authentication/tests/Schemes/CookieAuthenticationHandlerTest.php
@@ -70,7 +70,7 @@ class CookieAuthenticationHandlerTest extends TestCase
             ->willReturn($headers);
         $scheme = new AuthenticationScheme('foo', $this->schemeHandler::class, new CookieAuthenticationOptions('cookie'));
         /** @psalm-suppress UndefinedPropertyAssignment This property does actually exist on the anonymous class */
-        $this->schemeHandler->expectedAuthenticationResult = AuthenticationResult::pass($this->createMock(IPrincipal::class));
+        $this->schemeHandler->expectedAuthenticationResult = AuthenticationResult::pass($this->createMock(IPrincipal::class), $scheme->name);
         $this->assertSame(
             $this->schemeHandler->expectedAuthenticationResult,
             $this->schemeHandler->authenticate($request, $scheme)

--- a/src/Authorization/src/Attributes/AuthorizeRoles.php
+++ b/src/Authorization/src/Attributes/AuthorizeRoles.php
@@ -26,13 +26,12 @@ final class AuthorizeRoles extends Middleware
 {
     /**
      * @param list<string>|string $roles The role or list of roles that will be OR'd together for authorization
-     * @param list<string>|string|null $authenticationSchemeNames The authentication scheme or schemes to use, or null if using the default one
+     * @param list<string|null>|string|null $authenticationSchemeNames The authentication scheme or schemes to use, or null if using the default one
      */
     public function __construct(
         array|string $roles,
         array|string $authenticationSchemeNames = null
     ) {
-        $authenticationSchemeNames = \is_string($authenticationSchemeNames) ? [$authenticationSchemeNames] : $authenticationSchemeNames;
         $policy = new AuthorizationPolicy('roles', new RolesRequirement($roles), $authenticationSchemeNames);
 
         parent::__construct(Authorize::class, ['policy' => $policy]);

--- a/src/Authorization/src/Authority.php
+++ b/src/Authorization/src/Authority.php
@@ -67,9 +67,9 @@ class Authority implements IAuthority
         }
 
         if ($authorizationContext->allRequirementsPassed()) {
-            return AuthorizationResult::pass();
+            return AuthorizationResult::pass($policy->name);
         }
 
-        return AuthorizationResult::fail($authorizationContext->pendingRequirements->toArray());
+        return AuthorizationResult::fail($policy->name, $authorizationContext->pendingRequirements->toArray());
     }
 }

--- a/src/Authorization/src/AuthorizationPolicy.php
+++ b/src/Authorization/src/AuthorizationPolicy.php
@@ -19,7 +19,7 @@ use InvalidArgumentException;
  */
 readonly class AuthorizationPolicy
 {
-    /** @var list<string>|null The list of authentication schemes the requirements are evaluated against, or null if using the default scheme */
+    /** @var list<string|null>|null The list of authentication schemes the requirements are evaluated against, or null if using the default scheme */
     public ?array $authenticationSchemeNames;
     /** @var non-empty-list<object> The list of requirements */
     public array $requirements;
@@ -27,7 +27,7 @@ readonly class AuthorizationPolicy
     /**
      * @param string $name The name of the policy
      * @param non-empty-list<object>|object $requirements The requirement or list of requirements
-     * @param list<string>|string|null $authenticationSchemeNames The authentication scheme name or list of scheme names the requirements are evaluated against, or null if using the default scheme
+     * @param list<string|null>|string|null $authenticationSchemeNames The authentication scheme name or list of scheme names the requirements are evaluated against, or null if using the default scheme
      * @throws InvalidArgumentException Thrown if the requirements were empty
      */
     public function __construct(

--- a/src/Authorization/src/AuthorizationResult.php
+++ b/src/Authorization/src/AuthorizationResult.php
@@ -21,10 +21,12 @@ readonly class AuthorizationResult
 {
     /**
      * @param bool $passed Whether or not the authorization was successful
+     * @param string $policyName The name of the policy used
      * @param list<object> $failedRequirements The list of requirements that failed
      */
-    public function __construct(
+    protected function __construct(
         public bool $passed,
+        public string $policyName,
         public array $failedRequirements = []
     ) {
     }
@@ -32,21 +34,23 @@ readonly class AuthorizationResult
     /**
      * Creates a failed authorization result
      *
+     * @param string $policyName The name of the policy used
      * @param list<object> $failedRequirements The list of requirements that failed, or nothing if we're explicitly failing
      * @return static A failed authorization result
      */
-    public static function fail(array $failedRequirements = []): static
+    public static function fail(string $policyName, array $failedRequirements = []): static
     {
-        return new static(false, $failedRequirements);
+        return new static(false, $policyName, $failedRequirements);
     }
 
     /**
      * Creates a passing authorization result
      *
+     * @param string $policyName The name of the policy used
      * @return static A passing authorization result
      */
-    public static function pass(): static
+    public static function pass(string $policyName): static
     {
-        return new static(true);
+        return new static(true, $policyName);
     }
 }

--- a/src/Authorization/src/Middleware/Authorize.php
+++ b/src/Authorization/src/Middleware/Authorize.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 
 namespace Aphiria\Authorization\Middleware;
 
+use Aphiria\Authentication\AuthenticationSchemeNotFoundException;
 use Aphiria\Authentication\IAuthenticator;
 use Aphiria\Authentication\IUserAccessor;
 use Aphiria\Authentication\RequestPropertyUserAccessor;
-use Aphiria\Authentication\SchemeNotFoundException;
 use Aphiria\Authorization\AuthorizationPolicy;
 use Aphiria\Authorization\AuthorizationPolicyRegistry;
 use Aphiria\Authorization\AuthorizationResult;
@@ -97,7 +97,7 @@ class Authorize extends ParameterizedMiddleware
      * @param AuthorizationPolicy $policy The policy that was evaluated against
      * @param AuthorizationResult $authorizationResult The failed authorization result
      * @return IResponse The response
-     * @throws SchemeNotFoundException Thrown if the scheme could not be found
+     * @throws AuthenticationSchemeNotFoundException Thrown if the scheme could not be found
      */
     protected function handleFailedAuthorizationResult(IRequest $request, AuthorizationPolicy $policy, AuthorizationResult $authorizationResult): IResponse
     {
@@ -118,7 +118,7 @@ class Authorize extends ParameterizedMiddleware
      * @param IRequest $request The current request
      * @param AuthorizationPolicy $policy The policy that was evaluated against
      * @return IResponse The response
-     * @throws SchemeNotFoundException Thrown if the scheme could not be found
+     * @throws AuthenticationSchemeNotFoundException Thrown if the scheme could not be found
      */
     protected function handleUnauthenticatedUser(IRequest $request, AuthorizationPolicy $policy): IResponse
     {

--- a/src/Authorization/tests/Attributes/AuthorizeRolesTest.php
+++ b/src/Authorization/tests/Attributes/AuthorizeRolesTest.php
@@ -21,10 +21,10 @@ use PHPUnit\Framework\TestCase;
 class AuthorizeRolesTest extends TestCase
 {
     /**
-     * @param list<string>|string|null $authenticationSchemeNames The authentication scheme name or list of scheme names, or null if using the default scheme name
+     * @param list<string|null>|string|null $authenticationSchemeNames The authentication scheme name or list of scheme names, or null if using the default scheme name
      */
-    #[TestWith(['foo', 'bar'])]
-    #[TestWith(['foo'])]
+    #[TestWith([['foo', 'bar']])]
+    #[TestWith([['foo']])]
     #[TestWith([null])]
     public function testAuthenticationSchemeNamesParameterIsAutomaticallySet(array|string|null $authenticationSchemeNames): void
     {

--- a/src/Authorization/tests/AuthorizationResultTest.php
+++ b/src/Authorization/tests/AuthorizationResultTest.php
@@ -19,22 +19,27 @@ class AuthorizationResultTest extends TestCase
 {
     public function testFailSetsFailedRequirementsAndPassedToFalse(): void
     {
-        $result = AuthorizationResult::fail([$this]);
+        $result = AuthorizationResult::fail('policy', [$this]);
         $this->assertFalse($result->passed);
         $this->assertSame([$this], $result->failedRequirements);
+    }
+
+    public function testFailSetsPolicyName(): void
+    {
+        $result = AuthorizationResult::fail('policy', [$this]);
+        $this->assertSame('policy', $result->policyName);
     }
 
     public function testPassSetsPassedToTrue(): void
     {
-        $result = AuthorizationResult::pass();
+        $result = AuthorizationResult::pass('policy');
         $this->assertTrue($result->passed);
         $this->assertEmpty($result->failedRequirements);
     }
 
-    public function testPropertiesSetInConstructor(): void
+    public function testPassSetsPolicyName(): void
     {
-        $result = new AuthorizationResult(false, [$this]);
-        $this->assertFalse($result->passed);
-        $this->assertSame([$this], $result->failedRequirements);
+        $result = AuthorizationResult::pass('policy');
+        $this->assertSame('policy', $result->policyName);
     }
 }

--- a/src/Authorization/tests/Middleware/AuthorizeTest.php
+++ b/src/Authorization/tests/Middleware/AuthorizeTest.php
@@ -178,7 +178,7 @@ class AuthorizeTest extends TestCase
         $this->authority->expects($this->once())
             ->method('authorize')
             ->with($user, $policy)
-            ->willReturn(AuthorizationResult::pass());
+            ->willReturn(AuthorizationResult::pass($policy->name));
         $this->middleware->setParameters(['policy' => $policy]);
         $next = $this->createMock(IRequestHandler::class);
         $response = $this->createMock(IResponse::class);
@@ -201,7 +201,7 @@ class AuthorizeTest extends TestCase
         $this->authority->expects($this->once())
             ->method('authorize')
             ->with($user, $policy)
-            ->willReturn(AuthorizationResult::pass());
+            ->willReturn(AuthorizationResult::pass($policy->name));
         $this->middleware->setParameters(['policyName' => $policy->name]);
         $next = $this->createMock(IRequestHandler::class);
         $response = $this->createMock(IResponse::class);
@@ -235,7 +235,7 @@ class AuthorizeTest extends TestCase
         $this->authority->expects($this->once())
             ->method('authorize')
             ->with($user1, $policy)
-            ->willReturn(AuthorizationResult::pass());
+            ->willReturn(AuthorizationResult::pass($policy->name));
         $response = $this->createMock(IResponse::class);
         $next = $this->createMock(IRequestHandler::class);
         $next->expects($this->once())
@@ -281,7 +281,7 @@ class AuthorizeTest extends TestCase
         $this->authority->expects($this->once())
             ->method('authorize')
             ->with($user, $policy)
-            ->willReturn(AuthorizationResult::pass());
+            ->willReturn(AuthorizationResult::pass($policy->name));
         $response = $this->createMock(IResponse::class);
         $next = $this->createMock(IRequestHandler::class);
         $next->expects($this->once())
@@ -303,7 +303,7 @@ class AuthorizeTest extends TestCase
         $this->authority->expects($this->once())
             ->method('authorize')
             ->with($user, $policy)
-            ->willReturn(AuthorizationResult::fail([$this]));
+            ->willReturn(AuthorizationResult::fail($policy->name, [$this]));
         $this->authenticator->expects($this->once())
             ->method('forbid')
             ->with($request, $this->callback(fn (IResponse $response): bool => $response->getStatusCode() === HttpStatusCode::Forbidden), 'scheme');
@@ -323,7 +323,7 @@ class AuthorizeTest extends TestCase
         $this->authority->expects($this->once())
             ->method('authorize')
             ->with($user, $policy)
-            ->willReturn(AuthorizationResult::fail([$this]));
+            ->willReturn(AuthorizationResult::fail($policy->name, [$this]));
         $this->authenticator->expects($this->once())
             ->method('forbid')
             ->with($request, $this->callback(fn (IResponse $response): bool => $response->getStatusCode() === HttpStatusCode::Forbidden), 'scheme');

--- a/src/Authorization/tests/Middleware/AuthorizeTest.php
+++ b/src/Authorization/tests/Middleware/AuthorizeTest.php
@@ -223,10 +223,10 @@ class AuthorizeTest extends TestCase
         $user2 = new User([new Identity([], 'authScheme2')]);
         $authenticator->shouldReceive('authenticate')
             ->with($request, 'authScheme1')
-            ->andReturn(AuthenticationResult::pass($user1));
+            ->andReturn(AuthenticationResult::pass($user1, 'authScheme1'));
         $authenticator->shouldReceive('authenticate')
             ->with($request, 'authScheme2')
-            ->andReturn(AuthenticationResult::pass($user2));
+            ->andReturn(AuthenticationResult::pass($user2, 'authScheme2'));
         $this->userAccessor->shouldReceive('getUser')
             ->with($request)
             ->andReturn(null, $user1);
@@ -275,7 +275,7 @@ class AuthorizeTest extends TestCase
         $this->authenticator->expects($this->once())
             ->method('authenticate')
             ->with($request, null)
-            ->willReturn(AuthenticationResult::pass($user));
+            ->willReturn(AuthenticationResult::pass($user, 'scheme'));
         $policy = new AuthorizationPolicy('policy', [$this]);
         $this->middleware->setParameters(['policy' => $policy]);
         $this->authority->expects($this->once())

--- a/src/Framework/src/Authentication/Binders/AuthenticationBinder.php
+++ b/src/Framework/src/Authentication/Binders/AuthenticationBinder.php
@@ -38,7 +38,7 @@ class AuthenticationBinder extends Binder
         $container->bindInstance(IAuthenticationSchemeHandlerResolver::class, $schemeHandlerResolver);
         $userAccessor = $this->getUserAccessor($container);
         $container->bindInstance(IUserAccessor::class, $userAccessor);
-        $authenticator = new Authenticator($schemes, $schemeHandlerResolver, $userAccessor);
+        $authenticator = new Authenticator($schemes, $schemeHandlerResolver);
         $container->bindInstance(IAuthenticator::class, $authenticator);
     }
 


### PR DESCRIPTION
Closed #265 #266 

- [x] Should `IAuthenticator` methods take in a `string` and/or `string[]` auth scheme names?  I would loop through each and authenticate/challenge/forbid/log in/log out for each scheme
  - This could basically solve the problem of needing another shared class that can loop through multiple schemes and do the same thing, eg `PolicyEvaluator` in ASP.NET Core