### PR TITLE
Added the ability to customize request parameter deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added the ability to use `#[Header]`, `#[QueryString]`, and `#[RouteVariable]` to route action parameters to clarify where they should be resolved from ([#320](https://github.com/aphiria/aphiria/pull/320))
 - Added the ability to use `#[Header]`, `#[QueryString]`, and `#[RouteVariable]` to define where to get values from when generating route URIs ([#320](https://github.com/aphiria/aphiria/pull/320))
 - Added the ability to generate HTTP requests for routes with `RouteRequestFactory` ([#322](https://github.com/aphiria/aphiria/pull/322))
+- Added the ability to customize deserialization of request parameters ([#323](https://github.com/aphiria/aphiria/pull/323))
 
 ### Fixed
 

--- a/src/Api/src/Controllers/ControllerParameterResolver.php
+++ b/src/Api/src/Controllers/ControllerParameterResolver.php
@@ -35,8 +35,9 @@ final class ControllerParameterResolver implements IControllerParameterResolver
      * @param UriParser $uriParser The URI parser to use
      */
     public function __construct(
-        private readonly IBodyDeserializer $bodyDeserializer = new NegotiatedBodyDeserializer(),
-        private readonly UriParser $uriParser = new UriParser()
+        private readonly IBodyDeserializer             $bodyDeserializer = new NegotiatedBodyDeserializer(),
+        private readonly IRequestParameterDeserializer $routeActionParameterDeserializer = new RequestParameterDeserializer(),
+        private readonly UriParser                     $uriParser = new UriParser()
     ) {
     }
 
@@ -53,7 +54,7 @@ final class ControllerParameterResolver implements IControllerParameterResolver
 
         // Try to resolve an object parameter
         if ($reflectionParameterType instanceof ReflectionNamedType && !$reflectionParameterType->isBuiltin()) {
-            return $this->resolveObjectParameter(
+            return $this->resolveRequestBody(
                 $reflectionParameter,
                 $reflectionParameterType,
                 $request
@@ -64,7 +65,7 @@ final class ControllerParameterResolver implements IControllerParameterResolver
         if (\count($routeVariableAttributes = $reflectionParameter->getAttributes(RouteVariable::class)) === 1) {
             $parameterName = $routeVariableAttributes[0]->newInstance()->name ?? $reflectionParameter->getName();
 
-            return $this->resolveScalarParameter(
+            return $this->resolveRequestParameters(
                 fn (): bool => isset($routeVariables[$parameterName]),
                 fn (): mixed => $routeVariables[$parameterName],
                 $reflectionParameter
@@ -75,7 +76,7 @@ final class ControllerParameterResolver implements IControllerParameterResolver
         if (\count($queryStringAttributes = $reflectionParameter->getAttributes(QueryString::class)) === 1) {
             $parameterName = $queryStringAttributes[0]->newInstance()->name ?? $reflectionParameter->getName();
 
-            return $this->resolveScalarParameter(
+            return $this->resolveRequestParameters(
                 fn (): bool => isset($queryStringVars[$parameterName]),
                 fn (): mixed => $queryStringVars[$parameterName],
                 $reflectionParameter
@@ -86,7 +87,7 @@ final class ControllerParameterResolver implements IControllerParameterResolver
         if (\count($headerAttributes = $reflectionParameter->getAttributes(Header::class)) === 1) {
             $parameterName = $headerAttributes[0]->newInstance()->name ?? $reflectionParameter->getName();
 
-            return $this->resolveScalarParameter(
+            return $this->resolveRequestParameters(
                 fn (): bool => isset($request->headers[$parameterName]),
                 fn (): mixed => $request->headers->getFirst($parameterName),
                 $reflectionParameter
@@ -95,7 +96,7 @@ final class ControllerParameterResolver implements IControllerParameterResolver
 
         // No attributes for where to resolve the value from, so check the route
         if (isset($routeVariables[$reflectionParameter->getName()])) {
-            return $this->resolveScalarParameter(
+            return $this->resolveRequestParameters(
                 fn (): bool => isset($routeVariables[$reflectionParameter->getName()]),
                 fn (): mixed => $routeVariables[$reflectionParameter->getName()],
                 $reflectionParameter
@@ -104,7 +105,7 @@ final class ControllerParameterResolver implements IControllerParameterResolver
 
         // No attributes for where to resolve the value from, so now check the query string
         if (isset($queryStringVars[$reflectionParameter->getName()])) {
-            return $this->resolveScalarParameter(
+            return $this->resolveRequestParameters(
                 fn (): bool => isset($queryStringVars[$reflectionParameter->getName()]),
                 fn (): mixed => $queryStringVars[$reflectionParameter->getName()],
                 $reflectionParameter
@@ -112,7 +113,7 @@ final class ControllerParameterResolver implements IControllerParameterResolver
         }
 
         // We could not resolve this parameter, so try doing it with default values
-        return $this->resolveScalarParameter(
+        return $this->resolveRequestParameters(
             fn (): bool => false,
             fn (): null => null,
             $reflectionParameter
@@ -120,19 +121,19 @@ final class ControllerParameterResolver implements IControllerParameterResolver
     }
 
     /**
-     * Resolves an object parameter using content negotiator
+     * Resolves the request body using content negotiator
      *
      * @param ReflectionParameter $reflectionParameter The parameter to resolve
      * @param ReflectionNamedType $type The type to resolve to
      * @param IRequest $request The current request
-     * @return object|null The resolved parameter
+     * @return object|null The resolved request body
      * @throws FailedRequestContentNegotiationException Thrown if the request content negotiation failed
      * @throws RequestBodyDeserializationException Thrown if there was an error deserializing the request body
      * @throws MissingControllerParameterValueException Thrown if there was no valid value for the parameter
      * @psalm-suppress InvalidReturnType The media type formatter will resolve to the parameter type, which will be an object
      * @psalm-suppress InvalidReturnStatement Ditto
      */
-    private function resolveObjectParameter(
+    private function resolveRequestBody(
         ReflectionParameter $reflectionParameter,
         ReflectionNamedType $type,
         IRequest $request
@@ -169,43 +170,35 @@ final class ControllerParameterResolver implements IControllerParameterResolver
     }
 
     /**
-     * Resolves scalar parameters
+     * Resolves request parameters
      *
      * @param Closure(): bool $issetClosure The closure that returns whether or not the value can be resolved from a source
      * @param Closure(): mixed $getClosure The closure that returns the value from a source
      * @param ReflectionParameter $reflectionParameter The parameter to resolve
-     * @return mixed The resolved parameter value
-     * @throws FailedScalarParameterConversionException Thrown if the scalar parameter could not be converted
+     * @return mixed The resolved request parameter value
+     * @throws FailedRequestParameterConversionException Thrown if the request parameter could not be converted
      * @throws MissingControllerParameterValueException Thrown if there was no valid value for the parameter
      */
-    private function resolveScalarParameter(
+    private function resolveRequestParameters(
         Closure $issetClosure,
         Closure $getClosure,
         ReflectionParameter $reflectionParameter
     ): mixed {
         if ($issetClosure()) {
             $rawValue = $getClosure();
-            $typeName = $reflectionParameter->getType() instanceof ReflectionNamedType
+            $type = $reflectionParameter->getType() instanceof ReflectionNamedType
                 ? $reflectionParameter->getType()->getName()
                 : null;
 
-            switch ($typeName) {
-                case 'int':
-                    return (int)$rawValue;
-                case 'float':
-                    return (float)$rawValue;
-                case 'string':
-                    return (string)$rawValue;
-                case 'bool':
-                    return (bool)$rawValue;
-                case null:
-                    // Do not attempt to convert it
-                    return $rawValue;
-                case 'array':
-                    throw new FailedScalarParameterConversionException('Cannot automatically resolve array types - you must either read the body or the query string inside the controller method');
-                default:
-                    throw new FailedScalarParameterConversionException("Failed to convert value to $typeName");
+            if ($type === 'array') {
+                throw new FailedRequestParameterConversionException('Cannot automatically resolve array types - you must either read the body or the query string inside the controller method');
             }
+
+            if ($type === null) {
+                return $rawValue;
+            }
+
+            return $this->routeActionParameterDeserializer->deserializeRouteActionParameter($type, $rawValue);
         }
 
         if ($reflectionParameter->isDefaultValueAvailable()) {

--- a/src/Api/src/Controllers/FailedRequestParameterConversionException.php
+++ b/src/Api/src/Controllers/FailedRequestParameterConversionException.php
@@ -15,9 +15,9 @@ namespace Aphiria\Api\Controllers;
 use Exception;
 
 /**
- * Defines the exception that's thrown when a scalar parameter fails to be converted
+ * Defines the exception that's thrown when a request parameter fails to be converted
  */
-final class FailedScalarParameterConversionException extends Exception
+final class FailedRequestParameterConversionException extends Exception
 {
     // Don't do anything
 }

--- a/src/Api/src/Controllers/IControllerParameterResolver.php
+++ b/src/Api/src/Controllers/IControllerParameterResolver.php
@@ -30,7 +30,7 @@ interface IControllerParameterResolver
      * @throws FailedRequestContentNegotiationException Thrown if the request content negotiation failed
      * @throws MissingControllerParameterValueException Thrown if there was no valid value for the parameter
      * @throws RequestBodyDeserializationException Thrown if the request body could not be deserialized
-     * @throws FailedScalarParameterConversionException Thrown if a scalar parameter could not be converted
+     * @throws FailedRequestParameterConversionException Thrown if a request parameter could not be converted
      */
     public function resolveParameter(
         ReflectionParameter $reflectionParameter,

--- a/src/Api/src/Controllers/IRequestParameterDeserializer.php
+++ b/src/Api/src/Controllers/IRequestParameterDeserializer.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2025 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Api\Controllers;
+
+/**
+ * Defines the interface for route action parameter deserializers to implement
+ */
+interface IRequestParameterDeserializer
+{
+    /**
+     * Deserializes a route action parameter
+     *
+     * @param string $type The type to deserialize to
+     * @param mixed $value The serialized value to deserialize
+     * @return mixed The deserialized route action parameter
+     * @throws FailedRequestParameterConversionException Thrown if the value could not be deserialized
+     */
+    public function deserializeRouteActionParameter(string $type, mixed $value): mixed;
+}

--- a/src/Api/src/Controllers/RequestParameterDeserializer.php
+++ b/src/Api/src/Controllers/RequestParameterDeserializer.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2025 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+namespace Aphiria\Api\Controllers;
+
+use Closure;
+
+class RequestParameterDeserializer implements IRequestParameterDeserializer
+{
+    /**
+     * @var array<string, Closure(mixed): mixed> The map of types to their deserializers
+     */
+    private array $typesToDeserializers = [];
+
+    /**
+     * @param array<string, Closure(mixed): mixed> $typesToDeserializers The map of types to their deserializers
+     */
+    public function __construct(?array $typesToDeserializers = null)
+    {
+        $this->typesToDeserializers = $typesToDeserializers ?? [
+            'bool' => fn (mixed $value): bool => (bool)$value,
+            'float' => fn (mixed $value): float => (float)$value,
+            'int' => fn (mixed $value): int => (int)$value,
+            'string' => fn (mixed $value): string => (string)$value
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function deserializeRouteActionParameter(string $type, mixed $value): mixed
+    {
+        if (!isset($this->typesToDeserializers[$type])) {
+            throw new FailedRequestParameterConversionException("No deserializer registered for type $type");
+        }
+
+        return $this->typesToDeserializers[$type]($value);
+    }
+
+    /**
+     * Registers a deserializer
+     *
+     * @param string $type The type that will be deserialized
+     * @param Closure(mixed): mixed $deserializer The deserializer
+     */
+    public function registerDeserializer(string $type, Closure $deserializer): void
+    {
+        $this->typesToDeserializers[$type] = $deserializer;
+    }
+}

--- a/src/Api/src/Controllers/RequestParameterDeserializer.php
+++ b/src/Api/src/Controllers/RequestParameterDeserializer.php
@@ -27,7 +27,12 @@ class RequestParameterDeserializer implements IRequestParameterDeserializer
     public function __construct(?array $typesToDeserializers = null)
     {
         $this->typesToDeserializers = $typesToDeserializers ?? [
-            'bool' => fn (mixed $value): bool => (bool)$value,
+            'bool' => function (mixed $value): bool {
+                return match ($value) {
+                    true, '1', 1, 'true', 'yes', 'y' => true,
+                    default => false,
+                };
+            },
             'float' => fn (mixed $value): float => (float)$value,
             'int' => fn (mixed $value): int => (int)$value,
             'string' => fn (mixed $value): string => (string)$value

--- a/src/Api/src/Controllers/RouteActionInvoker.php
+++ b/src/Api/src/Controllers/RouteActionInvoker.php
@@ -96,7 +96,7 @@ class RouteActionInvoker implements IRouteActionInvoker
                     $request->properties->add(self::PARSED_BODY_PROPERTY_NAME, $resolvedParameter);
                 }
             }
-        } catch (MissingControllerParameterValueException | FailedScalarParameterConversionException $ex) {
+        } catch (MissingControllerParameterValueException | FailedRequestParameterConversionException $ex) {
             throw new HttpException(
                 HttpStatusCode::BadRequest,
                 'Failed to invoke controller',

--- a/src/Api/tests/Controllers/ControllerParameterResolverTest.php
+++ b/src/Api/tests/Controllers/ControllerParameterResolverTest.php
@@ -15,7 +15,7 @@ namespace Aphiria\Api\Tests\Controllers;
 use Aphiria\Api\Controllers\Controller;
 use Aphiria\Api\Controllers\ControllerParameterResolver;
 use Aphiria\Api\Controllers\FailedRequestContentNegotiationException;
-use Aphiria\Api\Controllers\FailedScalarParameterConversionException;
+use Aphiria\Api\Controllers\FailedRequestParameterConversionException;
 use Aphiria\Api\Controllers\MissingControllerParameterValueException;
 use Aphiria\Api\Controllers\RequestBodyDeserializationException;
 use Aphiria\Api\Tests\Controllers\Mocks\User;
@@ -47,7 +47,7 @@ class ControllerParameterResolverTest extends TestCase
         $this->resolver = new ControllerParameterResolver($this->bodyDeserializer);
     }
 
-    public static function scalarParameterWithQueryStringValuesDataProvider(): array
+    public static function requestParameterWithQueryStringValuesDataProvider(): array
     {
         $controller = new class () extends Controller {
             public function boolParameterWithName(#[QueryString('bar')] bool $foo): IResponse
@@ -132,7 +132,7 @@ class ControllerParameterResolverTest extends TestCase
         ];
     }
 
-    public static function scalarParameterWithHeaderValuesDataProvider(): array
+    public static function requestParameterWithHeaderValuesDataProvider(): array
     {
         $controller = new class () extends Controller {
             public function boolParameterWithName(#[Header('bar')] bool $foo): IResponse
@@ -217,7 +217,7 @@ class ControllerParameterResolverTest extends TestCase
         ];
     }
 
-    public static function scalarParameterWithRouteVariableValuesDataProvider(): array
+    public static function requestParameterWithRouteVariableValuesDataProvider(): array
     {
         $controller = new class () extends Controller {
             public function boolParameterWithName(#[RouteVariable('bar')] bool $foo): IResponse
@@ -379,7 +379,7 @@ class ControllerParameterResolverTest extends TestCase
 
     public function testResolvingArrayParameterWithMatchingQueryStringVariableThrowsException(): void
     {
-        $this->expectException(FailedScalarParameterConversionException::class);
+        $this->expectException(FailedRequestParameterConversionException::class);
         $controller = new class () extends Controller
         {
             public function arrayParameter(array $foo): IResponse
@@ -396,7 +396,7 @@ class ControllerParameterResolverTest extends TestCase
 
     public function testResolvingArrayParameterWithMatchingRouteVariableThrowsException(): void
     {
-        $this->expectException(FailedScalarParameterConversionException::class);
+        $this->expectException(FailedRequestParameterConversionException::class);
         $controller = new class () extends Controller
         {
             public function arrayParameter(array $foo): IResponse
@@ -523,17 +523,17 @@ class ControllerParameterResolverTest extends TestCase
         $this->assertNull($resolvedParameter);
     }
 
-    public function testResolvingNullableScalarParameterWithNoMatchingValuePassesNull(): void
+    public function testResolvingNullableRequestParameterWithNoMatchingValuePassesNull(): void
     {
         $controller = new class () extends Controller
         {
-            public function nullableScalarParameter(?int $foo): IResponse
+            public function nullableRequestParameter(?int $foo): IResponse
             {
                 return new Response(body: new StringBody($foo === null ? 'null' : 'notnull'));
             }
         };
         $resolvedParameter = $this->resolver->resolveParameter(
-            new ReflectionParameter([$controller, 'nullableScalarParameter'], 'foo'),
+            new ReflectionParameter([$controller, 'nullableRequestParameter'], 'foo'),
             $this->createRequestWithoutBody('http://foo.com'),
             []
         );
@@ -587,17 +587,17 @@ class ControllerParameterResolverTest extends TestCase
      * @param string $methodName The method name
      * @param string $parameterName The parameter name
      * @param string $rawValue The raw value
-     * @param mixed $scalarValue Ths scalar value
+     * @param mixed $requestParameterValue Ths request parameter value
      * @param string|null $parameterNameFromAttribute The parameter name used in the attribute
      */
-    #[DataProvider('scalarParameterWithQueryStringValuesDataProvider')]
-    public function testResolvingScalarParametersWithQueryStringAttributeUsesQueryString(
+    #[DataProvider('requestParameterWithQueryStringValuesDataProvider')]
+    public function testResolvingRequestParametersWithQueryStringAttributeUsesQueryString(
         Controller $controller,
-        string $methodName,
-        string $parameterName,
-        string $rawValue,
-        mixed $scalarValue,
-        ?string $parameterNameFromAttribute = null
+        string     $methodName,
+        string     $parameterName,
+        string     $rawValue,
+        mixed      $requestParameterValue,
+        ?string    $parameterNameFromAttribute = null
     ): void {
         $resolvedParameter = $this->resolver->resolveParameter(
             new ReflectionParameter([$controller, $methodName], $parameterName),
@@ -605,7 +605,7 @@ class ControllerParameterResolverTest extends TestCase
             // Add this parameter to the route variables just to ensure it's not being used
             [$parameterName => 'doNotUse']
         );
-        $this->assertSame($scalarValue, $resolvedParameter);
+        $this->assertSame($requestParameterValue, $resolvedParameter);
     }
 
     /**
@@ -613,17 +613,17 @@ class ControllerParameterResolverTest extends TestCase
      * @param string $methodName The method name
      * @param string $parameterName The parameter name
      * @param string $rawValue The raw value
-     * @param mixed $scalarValue Ths scalar value
+     * @param mixed $requestParameterValue Ths request parameter value
      * @param string|null $parameterNameFromAttribute The parameter name used in the attribute
      */
-    #[DataProvider('scalarParameterWithRouteVariableValuesDataProvider')]
-    public function testResolvingScalarParametersWithRouteVariableAttributeUsesRouteVariable(
+    #[DataProvider('requestParameterWithRouteVariableValuesDataProvider')]
+    public function testResolvingRequestParametersWithRouteVariableAttributeUsesRouteVariable(
         Controller $controller,
-        string $methodName,
-        string $parameterName,
-        string $rawValue,
-        mixed $scalarValue,
-        ?string $parameterNameFromAttribute = null
+        string     $methodName,
+        string     $parameterName,
+        string     $rawValue,
+        mixed      $requestParameterValue,
+        ?string    $parameterNameFromAttribute = null
     ): void {
         $request = $this->createRequestWithoutBody('http://foo.com');
         $request->headers->add($parameterNameFromAttribute ?? $parameterName, $rawValue);
@@ -634,7 +634,7 @@ class ControllerParameterResolverTest extends TestCase
             // Add this parameter to the route variables just to ensure it's not being used
             [$parameterNameFromAttribute ?? $parameterName => $rawValue]
         );
-        $this->assertSame($scalarValue, $resolvedParameter);
+        $this->assertSame($requestParameterValue, $resolvedParameter);
     }
 
     /**
@@ -642,17 +642,17 @@ class ControllerParameterResolverTest extends TestCase
      * @param string $methodName The method name
      * @param string $parameterName The parameter name
      * @param string $rawValue The raw value
-     * @param mixed $scalarValue Ths scalar value
+     * @param mixed $requestParameterValue Ths request parameter value
      * @param string|null $parameterNameFromAttribute The parameter name used in the attribute
      */
-    #[DataProvider('scalarParameterWithHeaderValuesDataProvider')]
-    public function testResolvingScalarParametersWithHeaderAttributeUsesHeader(
+    #[DataProvider('requestParameterWithHeaderValuesDataProvider')]
+    public function testResolvingRequestParametersWithHeaderAttributeUsesHeader(
         Controller $controller,
-        string $methodName,
-        string $parameterName,
-        string $rawValue,
-        mixed $scalarValue,
-        ?string $parameterNameFromAttribute = null
+        string     $methodName,
+        string     $parameterName,
+        string     $rawValue,
+        mixed      $requestParameterValue,
+        ?string    $parameterNameFromAttribute = null
     ): void {
         $request = $this->createRequestWithoutBody('http://foo.com');
         $request->headers->add($parameterNameFromAttribute ?? $parameterName, $rawValue);
@@ -663,10 +663,10 @@ class ControllerParameterResolverTest extends TestCase
             // Add this parameter to the route variables just to ensure it's not being used
             [$parameterName => 'doNotUse']
         );
-        $this->assertSame($scalarValue, $resolvedParameter);
+        $this->assertSame($requestParameterValue, $resolvedParameter);
     }
 
-    public function testResolvingScalarParameterWillPullValueFromQueryStringIfNotAvailableInRoute(): void
+    public function testResolvingRequestParameterWillPullValueFromQueryStringIfNotAvailableInRoute(): void
     {
         $controller = new class () extends Controller {
             public function foo(string $foo): IResponse
@@ -682,7 +682,7 @@ class ControllerParameterResolverTest extends TestCase
         $this->assertSame('bar', $resolvedParameter);
     }
 
-    public function testResolvingScalarParameterWillPullValueFromRouteIfItIsAvailableEvenIfItIsAlsoAvailableInQueryString(): void
+    public function testResolvingRequestParameterWillPullValueFromRouteIfItIsAvailableEvenIfItIsAlsoAvailableInQueryString(): void
     {
         $controller = new class () extends Controller {
             public function foo(string $foo): IResponse
@@ -698,9 +698,9 @@ class ControllerParameterResolverTest extends TestCase
         $this->assertSame('baz', $resolvedParameter);
     }
 
-    public function testResolvingScalarParameterWithUnsupportedTypeThrowsException(): void
+    public function testResolvingRequestParameterWithUnsupportedTypeThrowsException(): void
     {
-        $this->expectException(FailedScalarParameterConversionException::class);
+        $this->expectException(FailedRequestParameterConversionException::class);
         $this->expectExceptionMessage('Failed to convert value to ');
         $controller = new class () extends Controller
         {

--- a/src/Api/tests/Controllers/ControllerParameterResolverTest.php
+++ b/src/Api/tests/Controllers/ControllerParameterResolverTest.php
@@ -701,7 +701,7 @@ class ControllerParameterResolverTest extends TestCase
     public function testResolvingRequestParameterWithUnsupportedTypeThrowsException(): void
     {
         $this->expectException(FailedRequestParameterConversionException::class);
-        $this->expectExceptionMessage('Failed to convert value to ');
+        $this->expectExceptionMessage('No deserializer registered for type callable');
         $controller = new class () extends Controller
         {
             public function callableParameter(callable $foo): IResponse

--- a/src/Api/tests/Controllers/RequestParameterDeserializerTest.php
+++ b/src/Api/tests/Controllers/RequestParameterDeserializerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2025 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Api\Tests\Controllers;
+
+use Aphiria\Api\Controllers\RequestParameterDeserializer;
+use DateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class RequestParameterDeserializerTest extends TestCase
+{
+    public static function boolProvider(): array
+    {
+        return [
+            [true, true],
+            [false, false],
+            ['1', true],
+            ['0', false],
+            [1, true],
+            [0, false],
+            ['true', true],
+            ['false', false],
+            ['yes', true],
+            ['no', false],
+            ['y', true],
+            ['n', false]
+        ];
+    }
+
+    /**
+     * @param mixed $rawValue The raw value
+     * @param bool $expectedDeserializedValue The expected deserialized value
+     */
+    #[DataProvider('boolProvider')]
+    public function testBoolsDeserializeByDefault(mixed $rawValue, bool $expectedDeserializedValue): void
+    {
+        $deserializer = new RequestParameterDeserializer();
+        $this->assertSame($expectedDeserializedValue, $deserializer->deserializeRouteActionParameter('bool', $rawValue));
+    }
+
+    public function testFloatsDeserializeByDefault(): void
+    {
+        $deserializer = new RequestParameterDeserializer();
+        $this->assertSame(1.0, $deserializer->deserializeRouteActionParameter('float', 1.0));
+        $this->assertSame(1.0, $deserializer->deserializeRouteActionParameter('float', '1.0'));
+    }
+
+    public function testIntsDeserializeByDefault(): void
+    {
+        $deserializer = new RequestParameterDeserializer();
+        $this->assertSame(1, $deserializer->deserializeRouteActionParameter('int', 1));
+        $this->assertSame(1, $deserializer->deserializeRouteActionParameter('int', '1'));
+    }
+
+    public function testRegisteringDeserializerForTypeWithBuiltInDeserializerOverwritesIt(): void
+    {
+        $deserializer = new RequestParameterDeserializer();
+        $deserializer->registerDeserializer('int', fn (mixed $value): int => (int)$value + 1);
+        $this->assertSame(2, $deserializer->deserializeRouteActionParameter('int', 1));
+    }
+
+    public function testRegisteringDeserializerForTypeWithoutBuiltInDeserializerCanDeserializeValues(): void
+    {
+        $deserializer = new RequestParameterDeserializer();
+        $deserializer->registerDeserializer(DateTime::class, fn (mixed $value): DateTime => DateTime::createFromFormat('Y-m-d', $value));
+        $deserializedDateTime = $deserializer->deserializeRouteActionParameter(DateTime::class, '2025-01-03');
+        $this->assertSame('2025', $deserializedDateTime->format('Y'));
+        $this->assertSame('01', $deserializedDateTime->format('m'));
+        $this->assertSame('03', $deserializedDateTime->format('d'));
+    }
+
+    public function testStringsDeserializeByDefault(): void
+    {
+        $deserializer = new RequestParameterDeserializer();
+        $this->assertSame('1', $deserializer->deserializeRouteActionParameter('string', 1));
+        $this->assertSame('1', $deserializer->deserializeRouteActionParameter('string', '1'));
+    }
+}

--- a/src/Api/tests/Controllers/RouteActionInvokerTest.php
+++ b/src/Api/tests/Controllers/RouteActionInvokerTest.php
@@ -14,7 +14,7 @@ namespace Aphiria\Api\Tests\Controllers;
 
 use Aphiria\Api\Controllers\Controller;
 use Aphiria\Api\Controllers\FailedRequestContentNegotiationException;
-use Aphiria\Api\Controllers\FailedScalarParameterConversionException;
+use Aphiria\Api\Controllers\FailedRequestParameterConversionException;
 use Aphiria\Api\Controllers\IControllerParameterResolver;
 use Aphiria\Api\Controllers\MissingControllerParameterValueException;
 use Aphiria\Api\Controllers\RequestBodyDeserializationException;
@@ -81,13 +81,13 @@ class RouteActionInvokerTest extends TestCase
         }
     }
 
-    public function testFailedScalarParameterConversionExceptionIsRethrownAsHttpException(): void
+    public function testFailedRequestParameterConversionExceptionIsRethrownAsHttpException(): void
     {
         try {
             $this->parameterResolver->expects($this->once())
                 ->method('resolveParameter')
                 ->with($this->anything(), $this->anything())
-                ->willThrowException(new FailedScalarParameterConversionException());
+                ->willThrowException(new FailedRequestParameterConversionException());
             $this->invoker->invokeRouteAction(
                 Closure::fromCallable([$this->controller, 'stringParameter']),
                 $this->createMock(IRequest::class),

--- a/src/Api/tests/Validation/RequestBodyValidatorTest.php
+++ b/src/Api/tests/Validation/RequestBodyValidatorTest.php
@@ -113,7 +113,7 @@ class RequestBodyValidatorTest extends TestCase
         }
     }
 
-    public function testValidatingScalarValueDoesNotThrowException(): void
+    public function testValidatingRequestParameterValueDoesNotThrowException(): void
     {
         $this->requestBodyValidator->validate($this->request, 1);
         // Dummy assertion

--- a/src/Framework/src/Api/Binders/ControllerBinder.php
+++ b/src/Framework/src/Api/Binders/ControllerBinder.php
@@ -18,6 +18,8 @@ use Aphiria\Api\Controllers\IRouteActionInvoker;
 use Aphiria\Api\Controllers\RequestParameterDeserializer;
 use Aphiria\Api\Controllers\RouteActionInvoker;
 use Aphiria\Api\Validation\RequestBodyValidator;
+use Aphiria\Application\Configuration\GlobalConfiguration;
+use Aphiria\Application\Configuration\MissingConfigurationValueException;
 use Aphiria\ContentNegotiation\IBodyDeserializer;
 use Aphiria\ContentNegotiation\IContentNegotiator;
 use Aphiria\DependencyInjection\Binders\Binder;
@@ -25,6 +27,9 @@ use Aphiria\DependencyInjection\IContainer;
 use Aphiria\Net\Http\IResponseFactory;
 use Aphiria\Validation\ErrorMessages\IErrorMessageInterpolator;
 use Aphiria\Validation\IValidator;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
 
 /**
  * Defines the binder for controllers
@@ -33,6 +38,7 @@ final class ControllerBinder extends Binder
 {
     /**
      * @inheritdoc
+     * @throws MissingConfigurationValueException Thrown if the date format config value does not exist
      */
     public function bind(IContainer $container): void
     {
@@ -56,9 +62,21 @@ final class ControllerBinder extends Binder
      *
      * @param IContainer $container The DI container
      * @return IRequestParameterDeserializer The request parameter deserializer
+     * @throws MissingConfigurationValueException Thrown if the date format config value does not exist
      */
     protected function getRequestParameterDeserializer(IContainer $container): IRequestParameterDeserializer
     {
-        return new RequestParameterDeserializer();
+        $deserializer = new RequestParameterDeserializer();
+        $dateFormat = GlobalConfiguration::getString('aphiria.serialization.dateFormat');
+        $deserializer->registerDeserializer(
+            DateTime::class,
+            fn (mixed $value): DateTime => DateTime::createFromFormat($dateFormat, (string)$value),
+        );
+        $deserializer->registerDeserializer(
+            DateTimeImmutable::class,
+            fn (mixed $value): DateTimeImmutable => DateTimeImmutable::createFromFormat($dateFormat, (string)$value),
+        );
+
+        return $deserializer;
     }
 }

--- a/src/Framework/src/Api/Binders/ControllerBinder.php
+++ b/src/Framework/src/Api/Binders/ControllerBinder.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 namespace Aphiria\Framework\Api\Binders;
 
 use Aphiria\Api\Controllers\ControllerParameterResolver;
+use Aphiria\Api\Controllers\IRequestParameterDeserializer;
 use Aphiria\Api\Controllers\IRouteActionInvoker;
+use Aphiria\Api\Controllers\RequestParameterDeserializer;
 use Aphiria\Api\Controllers\RouteActionInvoker;
 use Aphiria\Api\Validation\RequestBodyValidator;
 use Aphiria\ContentNegotiation\IBodyDeserializer;
@@ -46,5 +48,17 @@ final class ControllerBinder extends Binder
             $controllerParameterResolver
         );
         $container->bindInstance(IRouteActionInvoker::class, $routeActionInvoker);
+        $container->bindInstance(IRequestParameterDeserializer::class, $this->getRequestParameterDeserializer($container));
+    }
+
+    /**
+     * Gets the request parameter deserializer
+     *
+     * @param IContainer $container The DI container
+     * @return IRequestParameterDeserializer The request parameter deserializer
+     */
+    protected function getRequestParameterDeserializer(IContainer $container): IRequestParameterDeserializer
+    {
+        return new RequestParameterDeserializer();
     }
 }

--- a/src/Framework/src/Serialization/Binders/SymfonySerializerBinder.php
+++ b/src/Framework/src/Serialization/Binders/SymfonySerializerBinder.php
@@ -79,7 +79,7 @@ final class SymfonySerializerBinder extends Binder
             switch ($normalizerName) {
                 case DateTimeNormalizer::class:
                     $normalizers[] = new DateTimeNormalizer([
-                        DateTimeNormalizer::FORMAT_KEY => GlobalConfiguration::getString('aphiria.serialization.dateFormat')
+                        DateTimeNormalizer::FORMAT_KEY => GlobalConfiguration::getString('aphiria.serialization.dateTimeFormat')
                     ]);
                     break;
                 case ObjectNormalizer::class:

--- a/src/Framework/tests/Api/Binders/ControllerBinderTest.php
+++ b/src/Framework/tests/Api/Binders/ControllerBinderTest.php
@@ -12,8 +12,11 @@ declare(strict_types=1);
 
 namespace Aphiria\Framework\Tests\Api\Binders;
 
+use Aphiria\Api\Controllers\IRequestParameterDeserializer;
 use Aphiria\Api\Controllers\IRouteActionInvoker;
 use Aphiria\Api\Controllers\RouteActionInvoker;
+use Aphiria\Application\Configuration\GlobalConfiguration;
+use Aphiria\Application\Configuration\HashTableConfiguration;
 use Aphiria\ContentNegotiation\IBodyDeserializer;
 use Aphiria\ContentNegotiation\IContentNegotiator;
 use Aphiria\DependencyInjection\IContainer;
@@ -21,33 +24,53 @@ use Aphiria\Framework\Api\Binders\ControllerBinder;
 use Aphiria\Net\Http\IResponseFactory;
 use Aphiria\Validation\ErrorMessages\IErrorMessageInterpolator;
 use Aphiria\Validation\IValidator;
-use PHPUnit\Framework\MockObject\MockObject;
+use Mockery;
+use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 
 class ControllerBinderTest extends TestCase
 {
     private ControllerBinder $binder;
-    private IContainer&MockObject $container;
+    private IContainer&MockInterface $container;
 
     protected function setUp(): void
     {
-        $this->container = $this->createMock(IContainer::class);
+        $this->container = Mockery::spy(IContainer::class);
         $this->binder = new ControllerBinder();
 
         // Set up some universal mocks
-        $this->container->method('resolve')
-            ->willReturnMap([
-                [IValidator::class, $this->createMock(IValidator::class)],
-                [IErrorMessageInterpolator::class, $this->createMock(IErrorMessageInterpolator::class)],
-                [IContentNegotiator::class, $this->createMock(IContentNegotiator::class)],
-                [IBodyDeserializer::class, $this->createMock(IBodyDeserializer::class)],
-                [IResponseFactory::class, $this->createMock(IResponseFactory::class)]
-            ]);
+        $this->container->shouldReceive('resolve')
+            ->with(IValidator::class)
+            ->andReturn($this->createMock(IValidator::class));
+        $this->container->shouldReceive('resolve')
+            ->with(IErrorMessageInterpolator::class)
+            ->andReturn($this->createMock(IErrorMessageInterpolator::class));
+        $this->container->shouldReceive('resolve')
+            ->with(IContentNegotiator::class)
+            ->andReturn($this->createMock(IContentNegotiator::class));
+        $this->container->shouldReceive('resolve')
+            ->with(IBodyDeserializer::class)
+            ->andReturn($this->createMock(IBodyDeserializer::class));
+        $this->container->shouldReceive('resolve')
+            ->with(IResponseFactory::class)
+            ->andReturn($this->createMock(IResponseFactory::class));
+
+        // Set up the date format config
+        GlobalConfiguration::addConfigurationSource(new HashTableConfiguration(['aphiria' => ['serialization' => ['dateFormat' => 'Y-m-d']]]));
+    }
+
+    public function testRequestParameterDeserializerIsBound(): void
+    {
+        $this->container->shouldReceive('bindInstance')
+            ->with(IRequestParameterDeserializer::class, $this->isInstanceOf(IRequestParameterDeserializer::class));
+        $this->binder->bind($this->container);
+        // Dummy assertion
+        $this->assertTrue(true);
     }
 
     public function testRouteActionInvokerIsBound(): void
     {
-        $this->container->method('bindInstance')
+        $this->container->shouldReceive('bindInstance')
             ->with(IRouteActionInvoker::class, $this->isInstanceOf(RouteActionInvoker::class));
         $this->binder->bind($this->container);
         // Dummy assertion

--- a/src/Framework/tests/Serialization/Binders/SymfonySerializerBinderTest.php
+++ b/src/Framework/tests/Serialization/Binders/SymfonySerializerBinderTest.php
@@ -241,7 +241,7 @@ class SymfonySerializerBinderTest extends TestCase
         return [
             'aphiria' => [
                 'serialization' => [
-                    'dateFormat' => 'Ymd',
+                    'dateTimeFormat' => 'Ymd',
                     'encoders' => [],
                     'nameConverter' => null,
                     'normalizers' => [],


### PR DESCRIPTION
Closes #319 

- [x] Add unit tests for `RequestParameterDeserializer`
- [x] Add unit test for `ControllerBinder`
- [x] Add default deserializer for `DateTime` and `DateTimeImmutable`
- [x] Update docs with examples, update use of "scalar" parameters to be "request parameters"