### PR TITLE
feat(preload): Preloading support #34

### DIFF
--- a/src/Framework/src/Application/AphiriaComponents.php
+++ b/src/Framework/src/Application/AphiriaComponents.php
@@ -35,6 +35,8 @@ use Aphiria\Framework\Authentication\Components\AuthenticationComponent;
 use Aphiria\Framework\Authorization\Components\AuthorizationComponent;
 use Aphiria\Framework\Console\Commands\FlushFrameworkCachesCommand;
 use Aphiria\Framework\Console\Commands\FlushFrameworkCachesCommandHandler;
+use Aphiria\Framework\Console\Commands\PreloadCommand;
+use Aphiria\Framework\Console\Commands\PreloadCommandHandler;
 use Aphiria\Framework\Console\Commands\ServeCommand;
 use Aphiria\Framework\Console\Commands\ServeCommandHandler;
 use Aphiria\Framework\Console\Components\CommandComponent;
@@ -393,6 +395,7 @@ trait AphiriaComponents
             ->withCommands(static function (CommandRegistry $commands) use ($commandNamesToExclude) {
                 $commandBindings = [
                     new CommandBinding(new FlushFrameworkCachesCommand(), FlushFrameworkCachesCommandHandler::class),
+                    new CommandBinding(new PreloadCommand(), PreloadCommandHandler::class),
                     new CommandBinding(new ServeCommand(), ServeCommandHandler::class),
                     new CommandBinding(new RouteListCommand(), RouteListCommandHandler::class)
                 ];

--- a/src/Framework/src/Application/AphiriaComponents.php
+++ b/src/Framework/src/Application/AphiriaComponents.php
@@ -4,7 +4,7 @@
  * Aphiria
  *
  * @link      https://www.aphiria.com
- * @copyright Copyright (C) 2025 David Young
+ * @copyright Copyright (C) 2026 David Young
  * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
  */
 
@@ -89,7 +89,7 @@ trait AphiriaComponents
     protected function withAuthenticationScheme(
         IApplicationBuilder $appBuilder,
         AuthenticationScheme $scheme,
-        bool $isDefault = false
+        bool $isDefault = false,
     ): static {
         // Note: We are violating DRY here just so that we don't have confusing methods for enabling this component
         if (!$appBuilder->hasComponent(AuthenticationComponent::class)) {
@@ -155,7 +155,7 @@ trait AphiriaComponents
     protected function withAuthorizationRequirementHandler(
         IApplicationBuilder $appBuilder,
         string $requirementType,
-        IAuthorizationRequirementHandler $requirementHandler
+        IAuthorizationRequirementHandler $requirementHandler,
     ): static {
         // Note: We are violating DRY here just so that we don't have confusing methods for enabling this component
         if (!$appBuilder->hasComponent(AuthorizationComponent::class)) {
@@ -167,7 +167,7 @@ trait AphiriaComponents
             if (!Container::$globalInstance->hasBinding(AuthorizationRequirementHandlerRegistry::class)) {
                 Container::$globalInstance->bindInstance(
                     AuthorizationRequirementHandlerRegistry::class,
-                    new AuthorizationRequirementHandlerRegistry()
+                    new AuthorizationRequirementHandlerRegistry(),
                 );
             }
 
@@ -199,9 +199,9 @@ trait AphiriaComponents
 
             $appBuilder->withComponent(
                 new BinderComponent(
-                    Container::$globalInstance
+                    Container::$globalInstance,
                 ),
-                0
+                0,
             );
         }
 
@@ -230,9 +230,9 @@ trait AphiriaComponents
 
             $appBuilder->withComponent(
                 new BinderComponent(
-                    Container::$globalInstance
+                    Container::$globalInstance,
                 ),
-                0
+                0,
             );
         }
 
@@ -347,7 +347,7 @@ trait AphiriaComponents
     protected function withConsoleExceptionOutputWriter(
         IApplicationBuilder $appBuilder,
         string $exceptionType,
-        Closure $callback
+        Closure $callback,
     ): static {
         // Note: We are violating DRY here just so that we don't have confusing methods for enabling this component
         if (!$appBuilder->hasComponent(ExceptionHandlerComponent::class)) {
@@ -397,7 +397,7 @@ trait AphiriaComponents
                     new CommandBinding(new FlushFrameworkCachesCommand(), FlushFrameworkCachesCommandHandler::class),
                     new CommandBinding(new PreloadCommand(), PreloadCommandHandler::class),
                     new CommandBinding(new ServeCommand(), ServeCommandHandler::class),
-                    new CommandBinding(new RouteListCommand(), RouteListCommandHandler::class)
+                    new CommandBinding(new RouteListCommand(), RouteListCommandHandler::class),
                 ];
 
                 foreach ($commandBindings as $commandBinding) {
@@ -425,7 +425,7 @@ trait AphiriaComponents
     protected function withGlobalMiddleware(
         IApplicationBuilder $appBuilder,
         MiddlewareBinding|array $middlewareBindings,
-        ?int $priority = null
+        ?int $priority = null,
     ): static {
         if (!$appBuilder->hasComponent(MiddlewareComponent::class)) {
             if (!isset(Container::$globalInstance)) {
@@ -459,7 +459,7 @@ trait AphiriaComponents
     protected function withLogLevelFactory(
         IApplicationBuilder $appBuilder,
         string $exceptionType,
-        Closure $logLevelFactory
+        Closure $logLevelFactory,
     ): static {
         //Note: We are violating DRY here just so that we don't have confusing methods for enabling this component
         if (!$appBuilder->hasComponent(ExceptionHandlerComponent::class)) {
@@ -547,7 +547,7 @@ trait AphiriaComponents
         string|Closure|null $detail = null,
         HttpStatusCode|int|Closure|null $status = HttpStatusCode::InternalServerError,
         string|Closure|null $instance = null,
-        array|Closure|null $extensions = null
+        array|Closure|null $extensions = null,
     ): static {
         // Note: We are violating DRY here just so that we don't have confusing methods for enabling this component
         if (!$appBuilder->hasComponent(ExceptionHandlerComponent::class)) {

--- a/src/Framework/src/Console/Commands/Preload/IFileDiscovery.php
+++ b/src/Framework/src/Console/Commands/Preload/IFileDiscovery.php
@@ -4,7 +4,7 @@
  * Aphiria
  *
  * @link      https://www.aphiria.com
- * @copyright Copyright (C) 2025 David Young
+ * @copyright Copyright (C) 2026 David Young
  * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
  */
 

--- a/src/Framework/src/Console/Commands/Preload/IFileDiscovery.php
+++ b/src/Framework/src/Console/Commands/Preload/IFileDiscovery.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2025 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Framework\Console\Commands\Preload;
+
+/**
+ * Defines the interface for file discovery strategies used in preload script generation
+ */
+interface IFileDiscovery
+{
+    /**
+     * Discovers files that should be included in the preload script
+     *
+     * @param list<string> $excludePatterns Patterns to exclude from results
+     * @param int $minHits Minimum number of OPcache hits required to include a file
+     * @return list<string> The list of file paths to preload
+     * @throws PreloadException Thrown if file discovery fails
+     */
+    public function discoverFiles(array $excludePatterns = [], int $minHits = 1): array;
+}

--- a/src/Framework/src/Console/Commands/Preload/IPreloadScriptGenerator.php
+++ b/src/Framework/src/Console/Commands/Preload/IPreloadScriptGenerator.php
@@ -4,7 +4,7 @@
  * Aphiria
  *
  * @link      https://www.aphiria.com
- * @copyright Copyright (C) 2025 David Young
+ * @copyright Copyright (C) 2026 David Young
  * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
  */
 

--- a/src/Framework/src/Console/Commands/Preload/IPreloadScriptGenerator.php
+++ b/src/Framework/src/Console/Commands/Preload/IPreloadScriptGenerator.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2025 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Framework\Console\Commands\Preload;
+
+/**
+ * Defines the interface for preload script generators
+ */
+interface IPreloadScriptGenerator
+{
+    /**
+     * Generates a preload script containing the specified files
+     *
+     * @param list<string> $files The file paths to include in the preload script
+     * @param string $outputPath The path where the preload script should be written
+     * @throws PreloadException Thrown if script generation fails
+     */
+    public function generate(array $files, string $outputPath): void;
+}

--- a/src/Framework/src/Console/Commands/Preload/OpcacheFileDiscovery.php
+++ b/src/Framework/src/Console/Commands/Preload/OpcacheFileDiscovery.php
@@ -4,7 +4,7 @@
  * Aphiria
  *
  * @link      https://www.aphiria.com
- * @copyright Copyright (C) 2025 David Young
+ * @copyright Copyright (C) 2026 David Young
  * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
  */
 

--- a/src/Framework/src/Console/Commands/Preload/OpcacheFileDiscovery.php
+++ b/src/Framework/src/Console/Commands/Preload/OpcacheFileDiscovery.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2025 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Framework\Console\Commands\Preload;
+
+/**
+ * Defines the OPcache-based file discovery strategy
+ */
+final class OpcacheFileDiscovery implements IFileDiscovery
+{
+    /**
+     * @inheritdoc
+     */
+    #[\Override]
+    public function discoverFiles(array $excludePatterns = [], int $minHits = 1): array
+    {
+        if (!\function_exists('opcache_get_status')) {
+            throw new PreloadException('OPcache extension is not available');
+        }
+
+        $status = \opcache_get_status(true);
+
+        if ($status === false) {
+            throw new PreloadException('Could not get OPcache status - OPcache may be disabled');
+        }
+
+        if (!isset($status['scripts']) || !\is_array($status['scripts'])) {
+            throw new PreloadException('No scripts found in OPcache');
+        }
+
+        /** @var list<string> $files */
+        $files = [];
+
+        /** @var array{hits?: int, full_path?: string} $script */
+        foreach ($status['scripts'] as $script) {
+            if (!isset($script['hits'], $script['full_path'])) {
+                continue;
+            }
+
+            if ($script['hits'] < $minHits) {
+                continue;
+            }
+
+            $files[] = $script['full_path'];
+        }
+
+        return $this->filterFiles($files, $excludePatterns);
+    }
+
+    /**
+     * Filters files based on exclude patterns and removes test files
+     *
+     * @param list<string> $files The files to filter
+     * @param list<string> $excludePatterns The patterns to exclude
+     * @return list<string> The filtered files
+     */
+    private function filterFiles(array $files, array $excludePatterns): array
+    {
+        // Default exclusions for test files
+        $defaultExclusions = [
+            '/tests/',
+            '/Tests/',
+            '/test/',
+            '/Test/',
+            'Test.php',
+            'Tests.php',
+            '/vendor/phpunit/',
+            '/vendor/bin/',
+        ];
+
+        $allExclusions = \array_merge($defaultExclusions, $excludePatterns);
+        $filtered = [];
+
+        foreach ($files as $file) {
+            $exclude = false;
+
+            foreach ($allExclusions as $pattern) {
+                if (\str_contains($file, $pattern)) {
+                    $exclude = true;
+                    break;
+                }
+            }
+
+            if (!$exclude) {
+                $filtered[] = $file;
+            }
+        }
+
+        // Sort files for consistent output
+        \sort($filtered);
+
+        return $filtered;
+    }
+}

--- a/src/Framework/src/Console/Commands/Preload/PreloadException.php
+++ b/src/Framework/src/Console/Commands/Preload/PreloadException.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2025 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Framework\Console\Commands\Preload;
+
+use Exception;
+
+/**
+ * Defines the exception thrown during preload operations
+ */
+final class PreloadException extends Exception
+{
+}

--- a/src/Framework/src/Console/Commands/Preload/PreloadException.php
+++ b/src/Framework/src/Console/Commands/Preload/PreloadException.php
@@ -4,7 +4,7 @@
  * Aphiria
  *
  * @link      https://www.aphiria.com
- * @copyright Copyright (C) 2025 David Young
+ * @copyright Copyright (C) 2026 David Young
  * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
  */
 
@@ -17,6 +17,4 @@ use Exception;
 /**
  * Defines the exception thrown during preload operations
  */
-final class PreloadException extends Exception
-{
-}
+final class PreloadException extends Exception {}

--- a/src/Framework/src/Console/Commands/Preload/PreloadScriptGenerator.php
+++ b/src/Framework/src/Console/Commands/Preload/PreloadScriptGenerator.php
@@ -4,7 +4,7 @@
  * Aphiria
  *
  * @link      https://www.aphiria.com
- * @copyright Copyright (C) 2025 David Young
+ * @copyright Copyright (C) 2026 David Young
  * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
  */
 

--- a/src/Framework/src/Console/Commands/Preload/PreloadScriptGenerator.php
+++ b/src/Framework/src/Console/Commands/Preload/PreloadScriptGenerator.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2025 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Framework\Console\Commands\Preload;
+
+/**
+ * Defines the preload script generator
+ */
+final class PreloadScriptGenerator implements IPreloadScriptGenerator
+{
+    /**
+     * @inheritdoc
+     */
+    #[\Override]
+    public function generate(array $files, string $outputPath): void
+    {
+        if (empty($files)) {
+            throw new PreloadException('No files to preload');
+        }
+
+        $date = \date('Y-m-d H:i:s');
+        $fileCount = \count($files);
+
+        $script = <<<PHP
+<?php
+
+/**
+ * Aphiria Preload Script
+ *
+ * Generated: $date
+ * Files: $fileCount
+ *
+ * To use this script, add the following to your php.ini:
+ * opcache.preload=$outputPath
+ * opcache.preload_user=www-data
+ *
+ * @link https://www.php.net/manual/en/opcache.preloading.php
+ */
+
+declare(strict_types=1);
+
+
+PHP;
+
+        foreach ($files as $file) {
+            $escapedFile = \addslashes($file);
+            $script .= "if (\\file_exists('$escapedFile')) {\n";
+            $script .= "    \\opcache_compile_file('$escapedFile');\n";
+            $script .= "}\n";
+        }
+
+        $result = \file_put_contents($outputPath, $script);
+
+        if ($result === false) {
+            throw new PreloadException("Failed to write preload script to '$outputPath'");
+        }
+    }
+}

--- a/src/Framework/src/Console/Commands/PreloadCommand.php
+++ b/src/Framework/src/Console/Commands/PreloadCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2025 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Framework\Console\Commands;
+
+use Aphiria\Console\Commands\Command;
+use Aphiria\Console\Input\Argument;
+use Aphiria\Console\Input\ArgumentType;
+use Aphiria\Console\Input\Option;
+use Aphiria\Console\Input\OptionType;
+
+/**
+ * Defines the command that generates a PHP preload script from OPcache
+ */
+final class PreloadCommand extends Command
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'app:preload',
+            [
+                new Argument(
+                    'urls',
+                    [ArgumentType::Optional, ArgumentType::IsArray],
+                    'URLs to warm up before generating the preload script'
+                )
+            ],
+            [
+                new Option(
+                    'output',
+                    OptionType::RequiredValue,
+                    'o',
+                    'Output path for the preload script',
+                    'preload.php'
+                ),
+                new Option(
+                    'exclude',
+                    [OptionType::IsArray, OptionType::OptionalValue],
+                    'e',
+                    'Patterns to exclude from the preload script'
+                ),
+                new Option(
+                    'min-hits',
+                    OptionType::RequiredValue,
+                    null,
+                    'Minimum OPcache hits required to include a file',
+                    '1'
+                ),
+                new Option(
+                    'dry-run',
+                    OptionType::NoValue,
+                    null,
+                    'Show files that would be included without generating the script'
+                )
+            ],
+            'Generates a PHP preload script from OPcache'
+        );
+    }
+}

--- a/src/Framework/src/Console/Commands/PreloadCommand.php
+++ b/src/Framework/src/Console/Commands/PreloadCommand.php
@@ -4,7 +4,7 @@
  * Aphiria
  *
  * @link      https://www.aphiria.com
- * @copyright Copyright (C) 2025 David Young
+ * @copyright Copyright (C) 2026 David Young
  * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
  */
 
@@ -31,8 +31,8 @@ final class PreloadCommand extends Command
                 new Argument(
                     'urls',
                     [ArgumentType::Optional, ArgumentType::IsArray],
-                    'URLs to warm up before generating the preload script'
-                )
+                    'URLs to warm up before generating the preload script',
+                ),
             ],
             [
                 new Option(
@@ -40,29 +40,29 @@ final class PreloadCommand extends Command
                     OptionType::RequiredValue,
                     'o',
                     'Output path for the preload script',
-                    'preload.php'
+                    'preload.php',
                 ),
                 new Option(
                     'exclude',
                     [OptionType::IsArray, OptionType::OptionalValue],
                     'e',
-                    'Patterns to exclude from the preload script'
+                    'Patterns to exclude from the preload script',
                 ),
                 new Option(
                     'min-hits',
                     OptionType::RequiredValue,
                     null,
                     'Minimum OPcache hits required to include a file',
-                    '1'
+                    '1',
                 ),
                 new Option(
                     'dry-run',
                     OptionType::NoValue,
                     null,
-                    'Show files that would be included without generating the script'
-                )
+                    'Show files that would be included without generating the script',
+                ),
             ],
-            'Generates a PHP preload script from OPcache'
+            'Generates a PHP preload script from OPcache',
         );
     }
 }

--- a/src/Framework/src/Console/Commands/PreloadCommandHandler.php
+++ b/src/Framework/src/Console/Commands/PreloadCommandHandler.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2025 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Framework\Console\Commands;
+
+use Aphiria\Console\Commands\ICommandHandler;
+use Aphiria\Console\Input\Input;
+use Aphiria\Console\Output\IOutput;
+use Aphiria\Console\StatusCode;
+use Aphiria\Framework\Console\Commands\Preload\IFileDiscovery;
+use Aphiria\Framework\Console\Commands\Preload\IPreloadScriptGenerator;
+use Aphiria\Framework\Console\Commands\Preload\PreloadException;
+
+/**
+ * Defines the console command handler that generates a preload script from OPcache
+ */
+final class PreloadCommandHandler implements ICommandHandler
+{
+    /**
+     * @param IFileDiscovery $fileDiscovery The file discovery strategy
+     * @param IPreloadScriptGenerator $generator The preload script generator
+     */
+    public function __construct(
+        private readonly IFileDiscovery $fileDiscovery,
+        private readonly IPreloadScriptGenerator $generator
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    #[\Override]
+    public function handle(Input $input, IOutput $output): StatusCode
+    {
+        // Optionally warm URLs first
+        /** @var list<string> $urls */
+        $urls = $input->arguments['urls'] ?? [];
+
+        foreach ($urls as $url) {
+            $output->writeln("<info>Warming: $url</info>");
+            @\file_get_contents($url);
+        }
+
+        // Get options
+        /** @var list<string> $excludePatterns */
+        $excludePatterns = $input->options['exclude'] ?? [];
+        $minHits = (int)($input->options['min-hits'] ?? 1);
+        $outputPath = (string)($input->options['output'] ?? 'preload.php');
+        $isDryRun = \array_key_exists('dry-run', $input->options);
+
+        try {
+            $files = $this->fileDiscovery->discoverFiles($excludePatterns, $minHits);
+        } catch (PreloadException $e) {
+            $output->writeln("<error>{$e->getMessage()}</error>");
+
+            return StatusCode::Error;
+        }
+
+        if (empty($files)) {
+            $output->writeln('<comment>No files found in OPcache matching the criteria</comment>');
+
+            return StatusCode::Ok;
+        }
+
+        $output->writeln('<info>Found ' . \count($files) . ' files in OPcache</info>');
+
+        if ($isDryRun) {
+            $output->writeln('');
+            $output->writeln('<comment>Files that would be included:</comment>');
+
+            foreach ($files as $file) {
+                $output->writeln("  $file");
+            }
+
+            return StatusCode::Ok;
+        }
+
+        try {
+            $this->generator->generate($files, $outputPath);
+        } catch (PreloadException $e) {
+            $output->writeln("<error>{$e->getMessage()}</error>");
+
+            return StatusCode::Error;
+        }
+
+        $output->writeln("<success>Generated preload script: $outputPath</success>");
+        $output->writeln('');
+        $output->writeln('<comment>To use this script, add the following to your php.ini:</comment>');
+        $output->writeln("  opcache.preload=$outputPath");
+        $output->writeln('  opcache.preload_user=www-data');
+
+        return StatusCode::Ok;
+    }
+}

--- a/src/Framework/src/Console/Commands/PreloadCommandHandler.php
+++ b/src/Framework/src/Console/Commands/PreloadCommandHandler.php
@@ -4,7 +4,7 @@
  * Aphiria
  *
  * @link      https://www.aphiria.com
- * @copyright Copyright (C) 2025 David Young
+ * @copyright Copyright (C) 2026 David Young
  * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
  */
 
@@ -31,9 +31,8 @@ final class PreloadCommandHandler implements ICommandHandler
      */
     public function __construct(
         private readonly IFileDiscovery $fileDiscovery,
-        private readonly IPreloadScriptGenerator $generator
-    ) {
-    }
+        private readonly IPreloadScriptGenerator $generator,
+    ) {}
 
     /**
      * @inheritdoc
@@ -53,8 +52,8 @@ final class PreloadCommandHandler implements ICommandHandler
         // Get options
         /** @var list<string> $excludePatterns */
         $excludePatterns = $input->options['exclude'] ?? [];
-        $minHits = (int)($input->options['min-hits'] ?? 1);
-        $outputPath = (string)($input->options['output'] ?? 'preload.php');
+        $minHits = (int) ($input->options['min-hits'] ?? 1);
+        $outputPath = (string) ($input->options['output'] ?? 'preload.php');
         $isDryRun = \array_key_exists('dry-run', $input->options);
 
         try {

--- a/src/Framework/tests/Console/Commands/Preload/OpcacheFileDiscoveryTest.php
+++ b/src/Framework/tests/Console/Commands/Preload/OpcacheFileDiscoveryTest.php
@@ -4,7 +4,7 @@
  * Aphiria
  *
  * @link      https://www.aphiria.com
- * @copyright Copyright (C) 2025 David Young
+ * @copyright Copyright (C) 2026 David Young
  * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
  */
 
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Aphiria\Framework\Tests\Console\Commands\Preload;
 
 use Aphiria\Framework\Console\Commands\Preload\OpcacheFileDiscovery;
-use Aphiria\Framework\Console\Commands\Preload\PreloadException;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 
@@ -27,10 +26,8 @@ class OpcacheFileDiscoveryTest extends TestCase
     }
 
     #[RequiresPhpExtension('Zend OPcache')]
-    public function testDiscoverFilesReturnsFilesFromOpcache(): void
+    public function testDiscoverFilesAppliesCustomExcludePatterns(): void
     {
-        // This test requires OPcache to be enabled
-        // It serves as a basic smoke test when OPcache is available
         if (!\function_exists('opcache_get_status')) {
             $this->markTestSkipped('OPcache extension is not available');
         }
@@ -41,9 +38,13 @@ class OpcacheFileDiscoveryTest extends TestCase
             $this->markTestSkipped('OPcache is disabled');
         }
 
-        // Just verify no exception is thrown and an array is returned
-        $files = $this->discovery->discoverFiles();
-        $this->assertIsArray($files);
+        $excludePatterns = ['/vendor/'];
+        $files = $this->discovery->discoverFiles($excludePatterns);
+
+        // Verify excluded patterns are not included
+        foreach ($files as $file) {
+            $this->assertStringNotContainsString('/vendor/', $file);
+        }
     }
 
     #[RequiresPhpExtension('Zend OPcache')]
@@ -71,8 +72,10 @@ class OpcacheFileDiscoveryTest extends TestCase
     }
 
     #[RequiresPhpExtension('Zend OPcache')]
-    public function testDiscoverFilesAppliesCustomExcludePatterns(): void
+    public function testDiscoverFilesReturnsFilesFromOpcache(): void
     {
+        // This test requires OPcache to be enabled
+        // It serves as a basic smoke test when OPcache is available
         if (!\function_exists('opcache_get_status')) {
             $this->markTestSkipped('OPcache extension is not available');
         }
@@ -83,13 +86,9 @@ class OpcacheFileDiscoveryTest extends TestCase
             $this->markTestSkipped('OPcache is disabled');
         }
 
-        $excludePatterns = ['/vendor/'];
-        $files = $this->discovery->discoverFiles($excludePatterns);
-
-        // Verify excluded patterns are not included
-        foreach ($files as $file) {
-            $this->assertStringNotContainsString('/vendor/', $file);
-        }
+        // Just verify no exception is thrown and an array is returned
+        $files = $this->discovery->discoverFiles();
+        $this->assertIsArray($files);
     }
 
     #[RequiresPhpExtension('Zend OPcache')]

--- a/src/Framework/tests/Console/Commands/Preload/OpcacheFileDiscoveryTest.php
+++ b/src/Framework/tests/Console/Commands/Preload/OpcacheFileDiscoveryTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2025 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Framework\Tests\Console\Commands\Preload;
+
+use Aphiria\Framework\Console\Commands\Preload\OpcacheFileDiscovery;
+use Aphiria\Framework\Console\Commands\Preload\PreloadException;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+
+class OpcacheFileDiscoveryTest extends TestCase
+{
+    private OpcacheFileDiscovery $discovery;
+
+    protected function setUp(): void
+    {
+        $this->discovery = new OpcacheFileDiscovery();
+    }
+
+    #[RequiresPhpExtension('Zend OPcache')]
+    public function testDiscoverFilesReturnsFilesFromOpcache(): void
+    {
+        // This test requires OPcache to be enabled
+        // It serves as a basic smoke test when OPcache is available
+        if (!\function_exists('opcache_get_status')) {
+            $this->markTestSkipped('OPcache extension is not available');
+        }
+
+        $status = \opcache_get_status(true);
+
+        if ($status === false) {
+            $this->markTestSkipped('OPcache is disabled');
+        }
+
+        // Just verify no exception is thrown and an array is returned
+        $files = $this->discovery->discoverFiles();
+        $this->assertIsArray($files);
+    }
+
+    #[RequiresPhpExtension('Zend OPcache')]
+    public function testDiscoverFilesFiltersTestFiles(): void
+    {
+        if (!\function_exists('opcache_get_status')) {
+            $this->markTestSkipped('OPcache extension is not available');
+        }
+
+        $status = \opcache_get_status(true);
+
+        if ($status === false) {
+            $this->markTestSkipped('OPcache is disabled');
+        }
+
+        $files = $this->discovery->discoverFiles();
+
+        // Verify no test files are included
+        foreach ($files as $file) {
+            $this->assertStringNotContainsString('/tests/', $file);
+            $this->assertStringNotContainsString('/Tests/', $file);
+            $this->assertStringNotContainsString('Test.php', $file);
+            $this->assertStringNotContainsString('/vendor/phpunit/', $file);
+        }
+    }
+
+    #[RequiresPhpExtension('Zend OPcache')]
+    public function testDiscoverFilesAppliesCustomExcludePatterns(): void
+    {
+        if (!\function_exists('opcache_get_status')) {
+            $this->markTestSkipped('OPcache extension is not available');
+        }
+
+        $status = \opcache_get_status(true);
+
+        if ($status === false) {
+            $this->markTestSkipped('OPcache is disabled');
+        }
+
+        $excludePatterns = ['/vendor/'];
+        $files = $this->discovery->discoverFiles($excludePatterns);
+
+        // Verify excluded patterns are not included
+        foreach ($files as $file) {
+            $this->assertStringNotContainsString('/vendor/', $file);
+        }
+    }
+
+    #[RequiresPhpExtension('Zend OPcache')]
+    public function testDiscoverFilesReturnsResultsSortedAlphabetically(): void
+    {
+        if (!\function_exists('opcache_get_status')) {
+            $this->markTestSkipped('OPcache extension is not available');
+        }
+
+        $status = \opcache_get_status(true);
+
+        if ($status === false) {
+            $this->markTestSkipped('OPcache is disabled');
+        }
+
+        $files = $this->discovery->discoverFiles();
+
+        if (\count($files) > 1) {
+            $sortedFiles = $files;
+            \sort($sortedFiles);
+            $this->assertSame($sortedFiles, $files);
+        }
+    }
+}

--- a/src/Framework/tests/Console/Commands/Preload/PreloadExceptionTest.php
+++ b/src/Framework/tests/Console/Commands/Preload/PreloadExceptionTest.php
@@ -4,7 +4,7 @@
  * Aphiria
  *
  * @link      https://www.aphiria.com
- * @copyright Copyright (C) 2025 David Young
+ * @copyright Copyright (C) 2026 David Young
  * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
  */
 

--- a/src/Framework/tests/Console/Commands/Preload/PreloadExceptionTest.php
+++ b/src/Framework/tests/Console/Commands/Preload/PreloadExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2025 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Framework\Tests\Console\Commands\Preload;
+
+use Aphiria\Framework\Console\Commands\Preload\PreloadException;
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+class PreloadExceptionTest extends TestCase
+{
+    public function testPreloadExceptionExtendsException(): void
+    {
+        $exception = new PreloadException('Test message');
+        $this->assertInstanceOf(Exception::class, $exception);
+        $this->assertSame('Test message', $exception->getMessage());
+    }
+}

--- a/src/Framework/tests/Console/Commands/Preload/PreloadScriptGeneratorTest.php
+++ b/src/Framework/tests/Console/Commands/Preload/PreloadScriptGeneratorTest.php
@@ -4,7 +4,7 @@
  * Aphiria
  *
  * @link      https://www.aphiria.com
- * @copyright Copyright (C) 2025 David Young
+ * @copyright Copyright (C) 2026 David Young
  * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
  */
 
@@ -58,60 +58,6 @@ class PreloadScriptGeneratorTest extends TestCase
         $this->assertStringContainsString('opcache_compile_file', $content);
     }
 
-    public function testGenerateIncludesFileExistsCheck(): void
-    {
-        $files = ['/path/to/file.php'];
-        $outputPath = $this->tempDir . '/preload.php';
-
-        $this->generator->generate($files, $outputPath);
-
-        $content = \file_get_contents($outputPath);
-        $this->assertStringContainsString('file_exists', $content);
-    }
-
-    public function testGenerateIncludesFileCount(): void
-    {
-        $files = ['/path/to/file1.php', '/path/to/file2.php', '/path/to/file3.php'];
-        $outputPath = $this->tempDir . '/preload.php';
-
-        $this->generator->generate($files, $outputPath);
-
-        $content = \file_get_contents($outputPath);
-        $this->assertStringContainsString('Files: 3', $content);
-    }
-
-    public function testGenerateThrowsExceptionWithEmptyFiles(): void
-    {
-        $this->expectException(PreloadException::class);
-        $this->expectExceptionMessage('No files to preload');
-
-        $this->generator->generate([], $this->tempDir . '/preload.php');
-    }
-
-    public function testGenerateEscapesFilePaths(): void
-    {
-        $files = ["/path/to/file's.php"];
-        $outputPath = $this->tempDir . '/preload.php';
-
-        $this->generator->generate($files, $outputPath);
-
-        $content = \file_get_contents($outputPath);
-        // Check that the single quote is escaped
-        $this->assertStringContainsString("\\'", $content);
-    }
-
-    public function testGenerateIncludesPhpIniInstructions(): void
-    {
-        $files = ['/path/to/file.php'];
-        $outputPath = $this->tempDir . '/preload.php';
-
-        $this->generator->generate($files, $outputPath);
-
-        $content = \file_get_contents($outputPath);
-        $this->assertStringContainsString('opcache.preload=', $content);
-        $this->assertStringContainsString('opcache.preload_user=www-data', $content);
-    }
-
     public function testGenerateCreatesValidPhpSyntax(): void
     {
         $files = ['/path/to/file.php'];
@@ -126,6 +72,52 @@ class PreloadScriptGeneratorTest extends TestCase
         $this->assertSame(0, $returnCode, 'Generated PHP file has syntax errors: ' . \implode("\n", $output));
     }
 
+    public function testGenerateEscapesFilePaths(): void
+    {
+        $files = ["/path/to/file's.php"];
+        $outputPath = $this->tempDir . '/preload.php';
+
+        $this->generator->generate($files, $outputPath);
+
+        $content = \file_get_contents($outputPath);
+        // Check that the single quote is escaped
+        $this->assertStringContainsString("\\'", $content);
+    }
+
+    public function testGenerateIncludesFileCount(): void
+    {
+        $files = ['/path/to/file1.php', '/path/to/file2.php', '/path/to/file3.php'];
+        $outputPath = $this->tempDir . '/preload.php';
+
+        $this->generator->generate($files, $outputPath);
+
+        $content = \file_get_contents($outputPath);
+        $this->assertStringContainsString('Files: 3', $content);
+    }
+
+    public function testGenerateIncludesFileExistsCheck(): void
+    {
+        $files = ['/path/to/file.php'];
+        $outputPath = $this->tempDir . '/preload.php';
+
+        $this->generator->generate($files, $outputPath);
+
+        $content = \file_get_contents($outputPath);
+        $this->assertStringContainsString('file_exists', $content);
+    }
+
+    public function testGenerateIncludesPhpIniInstructions(): void
+    {
+        $files = ['/path/to/file.php'];
+        $outputPath = $this->tempDir . '/preload.php';
+
+        $this->generator->generate($files, $outputPath);
+
+        $content = \file_get_contents($outputPath);
+        $this->assertStringContainsString('opcache.preload=', $content);
+        $this->assertStringContainsString('opcache.preload_user=www-data', $content);
+    }
+
     public function testGenerateThrowsExceptionWhenCannotWriteFile(): void
     {
         $this->expectException(PreloadException::class);
@@ -136,5 +128,13 @@ class PreloadScriptGeneratorTest extends TestCase
         $outputPath = '/nonexistent/directory/preload.php';
 
         $this->generator->generate($files, $outputPath);
+    }
+
+    public function testGenerateThrowsExceptionWithEmptyFiles(): void
+    {
+        $this->expectException(PreloadException::class);
+        $this->expectExceptionMessage('No files to preload');
+
+        $this->generator->generate([], $this->tempDir . '/preload.php');
     }
 }

--- a/src/Framework/tests/Console/Commands/Preload/PreloadScriptGeneratorTest.php
+++ b/src/Framework/tests/Console/Commands/Preload/PreloadScriptGeneratorTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2025 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Framework\Tests\Console\Commands\Preload;
+
+use Aphiria\Framework\Console\Commands\Preload\PreloadException;
+use Aphiria\Framework\Console\Commands\Preload\PreloadScriptGenerator;
+use PHPUnit\Framework\TestCase;
+
+class PreloadScriptGeneratorTest extends TestCase
+{
+    private PreloadScriptGenerator $generator;
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->generator = new PreloadScriptGenerator();
+        $this->tempDir = \sys_get_temp_dir() . '/preload_test_' . \uniqid();
+        \mkdir($this->tempDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up temp files
+        $files = \glob($this->tempDir . '/*');
+
+        if ($files !== false) {
+            foreach ($files as $file) {
+                \unlink($file);
+            }
+        }
+
+        \rmdir($this->tempDir);
+    }
+
+    public function testGenerateCreatesPreloadScript(): void
+    {
+        $files = ['/path/to/file1.php', '/path/to/file2.php'];
+        $outputPath = $this->tempDir . '/preload.php';
+
+        $this->generator->generate($files, $outputPath);
+
+        $this->assertFileExists($outputPath);
+        $content = \file_get_contents($outputPath);
+        $this->assertStringContainsString('<?php', $content);
+        $this->assertStringContainsString('Aphiria Preload Script', $content);
+        $this->assertStringContainsString('/path/to/file1.php', $content);
+        $this->assertStringContainsString('/path/to/file2.php', $content);
+        $this->assertStringContainsString('opcache_compile_file', $content);
+    }
+
+    public function testGenerateIncludesFileExistsCheck(): void
+    {
+        $files = ['/path/to/file.php'];
+        $outputPath = $this->tempDir . '/preload.php';
+
+        $this->generator->generate($files, $outputPath);
+
+        $content = \file_get_contents($outputPath);
+        $this->assertStringContainsString('file_exists', $content);
+    }
+
+    public function testGenerateIncludesFileCount(): void
+    {
+        $files = ['/path/to/file1.php', '/path/to/file2.php', '/path/to/file3.php'];
+        $outputPath = $this->tempDir . '/preload.php';
+
+        $this->generator->generate($files, $outputPath);
+
+        $content = \file_get_contents($outputPath);
+        $this->assertStringContainsString('Files: 3', $content);
+    }
+
+    public function testGenerateThrowsExceptionWithEmptyFiles(): void
+    {
+        $this->expectException(PreloadException::class);
+        $this->expectExceptionMessage('No files to preload');
+
+        $this->generator->generate([], $this->tempDir . '/preload.php');
+    }
+
+    public function testGenerateEscapesFilePaths(): void
+    {
+        $files = ["/path/to/file's.php"];
+        $outputPath = $this->tempDir . '/preload.php';
+
+        $this->generator->generate($files, $outputPath);
+
+        $content = \file_get_contents($outputPath);
+        // Check that the single quote is escaped
+        $this->assertStringContainsString("\\'", $content);
+    }
+
+    public function testGenerateIncludesPhpIniInstructions(): void
+    {
+        $files = ['/path/to/file.php'];
+        $outputPath = $this->tempDir . '/preload.php';
+
+        $this->generator->generate($files, $outputPath);
+
+        $content = \file_get_contents($outputPath);
+        $this->assertStringContainsString('opcache.preload=', $content);
+        $this->assertStringContainsString('opcache.preload_user=www-data', $content);
+    }
+
+    public function testGenerateCreatesValidPhpSyntax(): void
+    {
+        $files = ['/path/to/file.php'];
+        $outputPath = $this->tempDir . '/preload.php';
+
+        $this->generator->generate($files, $outputPath);
+
+        //  has valid PHP syntax?
+        $output = [];
+        $returnCode = 0;
+        \exec('php -l ' . \escapeshellarg($outputPath) . ' 2>&1', $output, $returnCode);
+        $this->assertSame(0, $returnCode, 'Generated PHP file has syntax errors: ' . \implode("\n", $output));
+    }
+
+    public function testGenerateThrowsExceptionWhenCannotWriteFile(): void
+    {
+        $this->expectException(PreloadException::class);
+        $this->expectExceptionMessage('Failed to write preload script');
+
+        $files = ['/path/to/file.php'];
+        // Use a path that doesn't exist
+        $outputPath = '/nonexistent/directory/preload.php';
+
+        $this->generator->generate($files, $outputPath);
+    }
+}

--- a/src/Framework/tests/Console/Commands/PreloadCommandHandlerTest.php
+++ b/src/Framework/tests/Console/Commands/PreloadCommandHandlerTest.php
@@ -4,7 +4,7 @@
  * Aphiria
  *
  * @link      https://www.aphiria.com
- * @copyright Copyright (C) 2025 David Young
+ * @copyright Copyright (C) 2026 David Young
  * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
  */
 
@@ -28,8 +28,8 @@ class PreloadCommandHandlerTest extends TestCase
 {
     private IFileDiscovery&MockObject $fileDiscovery;
     private IPreloadScriptGenerator&MockObject $generator;
-    private IOutput&MockObject $output;
     private PreloadCommandHandler $handler;
+    private IOutput&MockObject $output;
 
     protected function setUp(): void
     {
@@ -74,6 +74,35 @@ class PreloadCommandHandlerTest extends TestCase
         $this->assertSame(StatusCode::Ok, $result);
     }
 
+    public function testHandleWithCustomOutputPath(): void
+    {
+        $this->fileDiscovery
+            ->method('discoverFiles')
+            ->willReturn(['/path/to/file.php']);
+
+        $this->generator
+            ->expects($this->once())
+            ->method('generate')
+            ->with(['/path/to/file.php'], '/custom/path/preload.php');
+
+        $input = new Input('app:preload', [], ['output' => '/custom/path/preload.php']);
+        $result = $this->handler->handle($input, $this->output);
+
+        $this->assertSame(StatusCode::Ok, $result);
+    }
+
+    public function testHandleWithDiscoveryExceptionReturnsError(): void
+    {
+        $this->fileDiscovery
+            ->method('discoverFiles')
+            ->willThrowException(new PreloadException('OPcache is not available'));
+
+        $input = new Input('app:preload', [], []);
+        $result = $this->handler->handle($input, $this->output);
+
+        $this->assertSame(StatusCode::Error, $result);
+    }
+
     public function testHandleWithDryRunDoesNotGenerateScript(): void
     {
         $files = ['/path/to/file1.php', '/path/to/file2.php'];
@@ -112,6 +141,22 @@ class PreloadCommandHandlerTest extends TestCase
         $this->assertSame(StatusCode::Ok, $result);
     }
 
+    public function testHandleWithGeneratorExceptionReturnsError(): void
+    {
+        $this->fileDiscovery
+            ->method('discoverFiles')
+            ->willReturn(['/path/to/file.php']);
+
+        $this->generator
+            ->method('generate')
+            ->willThrowException(new PreloadException('Failed to write preload script'));
+
+        $input = new Input('app:preload', [], []);
+        $result = $this->handler->handle($input, $this->output);
+
+        $this->assertSame(StatusCode::Error, $result);
+    }
+
     public function testHandleWithMinHitsPassesToDiscovery(): void
     {
         $this->fileDiscovery
@@ -124,23 +169,6 @@ class PreloadCommandHandlerTest extends TestCase
             ->method('generate');
 
         $input = new Input('app:preload', [], ['min-hits' => '5']);
-        $result = $this->handler->handle($input, $this->output);
-
-        $this->assertSame(StatusCode::Ok, $result);
-    }
-
-    public function testHandleWithCustomOutputPath(): void
-    {
-        $this->fileDiscovery
-            ->method('discoverFiles')
-            ->willReturn(['/path/to/file.php']);
-
-        $this->generator
-            ->expects($this->once())
-            ->method('generate')
-            ->with(['/path/to/file.php'], '/custom/path/preload.php');
-
-        $input = new Input('app:preload', [], ['output' => '/custom/path/preload.php']);
         $result = $this->handler->handle($input, $this->output);
 
         $this->assertSame(StatusCode::Ok, $result);
@@ -160,33 +188,5 @@ class PreloadCommandHandlerTest extends TestCase
         $result = $this->handler->handle($input, $this->output);
 
         $this->assertSame(StatusCode::Ok, $result);
-    }
-
-    public function testHandleWithDiscoveryExceptionReturnsError(): void
-    {
-        $this->fileDiscovery
-            ->method('discoverFiles')
-            ->willThrowException(new PreloadException('OPcache is not available'));
-
-        $input = new Input('app:preload', [], []);
-        $result = $this->handler->handle($input, $this->output);
-
-        $this->assertSame(StatusCode::Error, $result);
-    }
-
-    public function testHandleWithGeneratorExceptionReturnsError(): void
-    {
-        $this->fileDiscovery
-            ->method('discoverFiles')
-            ->willReturn(['/path/to/file.php']);
-
-        $this->generator
-            ->method('generate')
-            ->willThrowException(new PreloadException('Failed to write preload script'));
-
-        $input = new Input('app:preload', [], []);
-        $result = $this->handler->handle($input, $this->output);
-
-        $this->assertSame(StatusCode::Error, $result);
     }
 }

--- a/src/Framework/tests/Console/Commands/PreloadCommandHandlerTest.php
+++ b/src/Framework/tests/Console/Commands/PreloadCommandHandlerTest.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2025 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Framework\Tests\Console\Commands;
+
+use Aphiria\Console\Drivers\IDriver;
+use Aphiria\Console\Input\Input;
+use Aphiria\Console\Output\IOutput;
+use Aphiria\Console\StatusCode;
+use Aphiria\Framework\Console\Commands\Preload\IFileDiscovery;
+use Aphiria\Framework\Console\Commands\Preload\IPreloadScriptGenerator;
+use Aphiria\Framework\Console\Commands\Preload\PreloadException;
+use Aphiria\Framework\Console\Commands\PreloadCommandHandler;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
+use PHPUnit\Framework\TestCase;
+
+class PreloadCommandHandlerTest extends TestCase
+{
+    private IFileDiscovery&MockObject $fileDiscovery;
+    private IPreloadScriptGenerator&MockObject $generator;
+    private IOutput&MockObject $output;
+    private PreloadCommandHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->fileDiscovery = $this->createMock(IFileDiscovery::class);
+        $this->generator = $this->createMock(IPreloadScriptGenerator::class);
+        $this->output = $this->createMock(IOutput::class);
+
+        $driver = new class () implements IDriver {
+            public int $cliWidth = 80;
+            public int $cliHeight = 24;
+
+            public function readHiddenInput(IOutput $output): ?string
+            {
+                return null;
+            }
+        };
+        $this->output
+            ->method(PropertyHook::get('driver'))
+            ->willReturn($driver);
+
+        $this->handler = new PreloadCommandHandler($this->fileDiscovery, $this->generator);
+    }
+
+    public function testHandleGeneratesPreloadScript(): void
+    {
+        $files = ['/path/to/file1.php', '/path/to/file2.php'];
+
+        $this->fileDiscovery
+            ->expects($this->once())
+            ->method('discoverFiles')
+            ->with([], 1)
+            ->willReturn($files);
+
+        $this->generator
+            ->expects($this->once())
+            ->method('generate')
+            ->with($files, 'preload.php');
+
+        $input = new Input('app:preload', [], ['output' => 'preload.php', 'min-hits' => '1']);
+        $result = $this->handler->handle($input, $this->output);
+
+        $this->assertSame(StatusCode::Ok, $result);
+    }
+
+    public function testHandleWithDryRunDoesNotGenerateScript(): void
+    {
+        $files = ['/path/to/file1.php', '/path/to/file2.php'];
+
+        $this->fileDiscovery
+            ->expects($this->once())
+            ->method('discoverFiles')
+            ->willReturn($files);
+
+        $this->generator
+            ->expects($this->never())
+            ->method('generate');
+
+        $input = new Input('app:preload', [], ['dry-run' => true]);
+        $result = $this->handler->handle($input, $this->output);
+
+        $this->assertSame(StatusCode::Ok, $result);
+    }
+
+    public function testHandleWithExcludePatternsPassesThemToDiscovery(): void
+    {
+        $excludePatterns = ['/vendor/', '/src/Legacy/'];
+
+        $this->fileDiscovery
+            ->expects($this->once())
+            ->method('discoverFiles')
+            ->with($excludePatterns, 1)
+            ->willReturn(['/path/to/file.php']);
+
+        $this->generator
+            ->method('generate');
+
+        $input = new Input('app:preload', [], ['exclude' => $excludePatterns, 'min-hits' => '1']);
+        $result = $this->handler->handle($input, $this->output);
+
+        $this->assertSame(StatusCode::Ok, $result);
+    }
+
+    public function testHandleWithMinHitsPassesToDiscovery(): void
+    {
+        $this->fileDiscovery
+            ->expects($this->once())
+            ->method('discoverFiles')
+            ->with([], 5)
+            ->willReturn(['/path/to/file.php']);
+
+        $this->generator
+            ->method('generate');
+
+        $input = new Input('app:preload', [], ['min-hits' => '5']);
+        $result = $this->handler->handle($input, $this->output);
+
+        $this->assertSame(StatusCode::Ok, $result);
+    }
+
+    public function testHandleWithCustomOutputPath(): void
+    {
+        $this->fileDiscovery
+            ->method('discoverFiles')
+            ->willReturn(['/path/to/file.php']);
+
+        $this->generator
+            ->expects($this->once())
+            ->method('generate')
+            ->with(['/path/to/file.php'], '/custom/path/preload.php');
+
+        $input = new Input('app:preload', [], ['output' => '/custom/path/preload.php']);
+        $result = $this->handler->handle($input, $this->output);
+
+        $this->assertSame(StatusCode::Ok, $result);
+    }
+
+    public function testHandleWithNoFilesReturnsOk(): void
+    {
+        $this->fileDiscovery
+            ->method('discoverFiles')
+            ->willReturn([]);
+
+        $this->generator
+            ->expects($this->never())
+            ->method('generate');
+
+        $input = new Input('app:preload', [], []);
+        $result = $this->handler->handle($input, $this->output);
+
+        $this->assertSame(StatusCode::Ok, $result);
+    }
+
+    public function testHandleWithDiscoveryExceptionReturnsError(): void
+    {
+        $this->fileDiscovery
+            ->method('discoverFiles')
+            ->willThrowException(new PreloadException('OPcache is not available'));
+
+        $input = new Input('app:preload', [], []);
+        $result = $this->handler->handle($input, $this->output);
+
+        $this->assertSame(StatusCode::Error, $result);
+    }
+
+    public function testHandleWithGeneratorExceptionReturnsError(): void
+    {
+        $this->fileDiscovery
+            ->method('discoverFiles')
+            ->willReturn(['/path/to/file.php']);
+
+        $this->generator
+            ->method('generate')
+            ->willThrowException(new PreloadException('Failed to write preload script'));
+
+        $input = new Input('app:preload', [], []);
+        $result = $this->handler->handle($input, $this->output);
+
+        $this->assertSame(StatusCode::Error, $result);
+    }
+}

--- a/src/Framework/tests/Console/Commands/PreloadCommandTest.php
+++ b/src/Framework/tests/Console/Commands/PreloadCommandTest.php
@@ -4,7 +4,7 @@
  * Aphiria
  *
  * @link      https://www.aphiria.com
- * @copyright Copyright (C) 2025 David Young
+ * @copyright Copyright (C) 2026 David Young
  * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
  */
 
@@ -12,8 +12,6 @@ declare(strict_types=1);
 
 namespace Aphiria\Framework\Tests\Console\Commands;
 
-use Aphiria\Console\Input\ArgumentType;
-use Aphiria\Console\Input\OptionType;
 use Aphiria\Framework\Console\Commands\PreloadCommand;
 use PHPUnit\Framework\TestCase;
 
@@ -36,22 +34,11 @@ class PreloadCommandTest extends TestCase
         $this->assertSame('Generates a PHP preload script from OPcache', $this->command->description);
     }
 
-    public function testUrlsArgumentIsOptionalArray(): void
+    public function testDryRunOptionIsFlag(): void
     {
-        $this->assertCount(1, $this->command->arguments);
-        $urlsArgument = $this->command->arguments[0];
-        $this->assertSame('urls', $urlsArgument->name);
-        $this->assertTrue($urlsArgument->isOptional);
-        $this->assertTrue($urlsArgument->isArray);
-    }
-
-    public function testOutputOptionHasCorrectConfiguration(): void
-    {
-        $outputOption = $this->findOption('output');
-        $this->assertNotNull($outputOption);
-        $this->assertSame('o', $outputOption->shortName);
-        $this->assertTrue($outputOption->valueIsRequired);
-        $this->assertSame('preload.php', $outputOption->defaultValue);
+        $dryRunOption = $this->findOption('dry-run');
+        $this->assertNotNull($dryRunOption);
+        $this->assertFalse($dryRunOption->valueIsPermitted);
     }
 
     public function testExcludeOptionIsArray(): void
@@ -71,11 +58,22 @@ class PreloadCommandTest extends TestCase
         $this->assertSame('1', $minHitsOption->defaultValue);
     }
 
-    public function testDryRunOptionIsFlag(): void
+    public function testOutputOptionHasCorrectConfiguration(): void
     {
-        $dryRunOption = $this->findOption('dry-run');
-        $this->assertNotNull($dryRunOption);
-        $this->assertFalse($dryRunOption->valueIsPermitted);
+        $outputOption = $this->findOption('output');
+        $this->assertNotNull($outputOption);
+        $this->assertSame('o', $outputOption->shortName);
+        $this->assertTrue($outputOption->valueIsRequired);
+        $this->assertSame('preload.php', $outputOption->defaultValue);
+    }
+
+    public function testUrlsArgumentIsOptionalArray(): void
+    {
+        $this->assertCount(1, $this->command->arguments);
+        $urlsArgument = $this->command->arguments[0];
+        $this->assertSame('urls', $urlsArgument->name);
+        $this->assertTrue($urlsArgument->isOptional);
+        $this->assertTrue($urlsArgument->isArray);
     }
 
     /**

--- a/src/Framework/tests/Console/Commands/PreloadCommandTest.php
+++ b/src/Framework/tests/Console/Commands/PreloadCommandTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2025 David Young
+ * @license   https://github.com/aphiria/aphiria/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Aphiria\Framework\Tests\Console\Commands;
+
+use Aphiria\Console\Input\ArgumentType;
+use Aphiria\Console\Input\OptionType;
+use Aphiria\Framework\Console\Commands\PreloadCommand;
+use PHPUnit\Framework\TestCase;
+
+class PreloadCommandTest extends TestCase
+{
+    private PreloadCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->command = new PreloadCommand();
+    }
+
+    public function testCommandNameIsCorrect(): void
+    {
+        $this->assertSame('app:preload', $this->command->name);
+    }
+
+    public function testDescriptionIsCorrect(): void
+    {
+        $this->assertSame('Generates a PHP preload script from OPcache', $this->command->description);
+    }
+
+    public function testUrlsArgumentIsOptionalArray(): void
+    {
+        $this->assertCount(1, $this->command->arguments);
+        $urlsArgument = $this->command->arguments[0];
+        $this->assertSame('urls', $urlsArgument->name);
+        $this->assertTrue($urlsArgument->isOptional);
+        $this->assertTrue($urlsArgument->isArray);
+    }
+
+    public function testOutputOptionHasCorrectConfiguration(): void
+    {
+        $outputOption = $this->findOption('output');
+        $this->assertNotNull($outputOption);
+        $this->assertSame('o', $outputOption->shortName);
+        $this->assertTrue($outputOption->valueIsRequired);
+        $this->assertSame('preload.php', $outputOption->defaultValue);
+    }
+
+    public function testExcludeOptionIsArray(): void
+    {
+        $excludeOption = $this->findOption('exclude');
+        $this->assertNotNull($excludeOption);
+        $this->assertSame('e', $excludeOption->shortName);
+        $this->assertTrue($excludeOption->valueIsArray);
+    }
+
+    public function testMinHitsOptionHasCorrectConfiguration(): void
+    {
+        $minHitsOption = $this->findOption('min-hits');
+        $this->assertNotNull($minHitsOption);
+        $this->assertNull($minHitsOption->shortName);
+        $this->assertTrue($minHitsOption->valueIsRequired);
+        $this->assertSame('1', $minHitsOption->defaultValue);
+    }
+
+    public function testDryRunOptionIsFlag(): void
+    {
+        $dryRunOption = $this->findOption('dry-run');
+        $this->assertNotNull($dryRunOption);
+        $this->assertFalse($dryRunOption->valueIsPermitted);
+    }
+
+    /**
+     * Finds an option by name
+     */
+    private function findOption(string $name): ?\Aphiria\Console\Input\Option
+    {
+        foreach ($this->command->options as $option) {
+            if ($option->name === $name) {
+                return $option;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
This PR adds preload support w opcache

```
# from current OPcache state
php aphiria app:preload

# Warm URLs first, then generate
php aphiria app:preload http://localhost/api/users http://localhost/api/products

# Exclude vendor, only app code
php aphiria app:preload --exclude='/vendor/'

# Only files hit 5> times
php aphiria app:preload --min-hits=5

# Preview
php aphiria app:preload --dry-run

# Custom output path
php aphiria app:preload -o /path/to/preload.php
```